### PR TITLE
fix analysis action menu for unsaved/fen games

### DIFF
--- a/ui/analyse/src/data.js
+++ b/ui/analyse/src/data.js
@@ -5,5 +5,7 @@ module.exports = function(old, cfg) {
   if (cfg.game.moves) data.game.moves = data.game.moves.split(' ');
   else data.game.moves = [];
 
+  if (!cfg.game.moveTimes) data.game.moveTimes = [];
+
   return data;
 };


### PR DESCRIPTION
moveTimes was null on http://en.l.org/analysis or when pressing analyse on board editor and analysing from a fen string