### PR TITLE
disable context menu on board

### DIFF
--- a/ui/round/src/view/main.js
+++ b/ui/round/src/view/main.js
@@ -62,7 +62,10 @@ function visualBoard(ctrl) {
           return wheel(ctrl, e);
         });
       },
-      onclick: ctrl.data.player.spectator ? toggleDontTouch : null
+      onclick: ctrl.data.player.spectator ? toggleDontTouch : null,
+      oncontextmenu: function(e) {
+        e.preventDefault();
+      }
     }, chessground.view(ctrl.chessground)),
     renderPromotion(ctrl),
     renderVariantReminder(ctrl)


### PR DESCRIPTION
Most browsers bind right mouse to context menu, which is not that useful
when you are playing but may cause misclicks. Not disabled on analysis or training.