### PR TITLE
Add a "Online"/"Offline" tooltip on user page

### DIFF
--- a/app/views/user/show.scala.html
+++ b/app/views/user/show.scala.html
@@ -97,7 +97,7 @@ openGraph = Map(
     case _ => {}
     }
     }
-    <h1 class="lichess_title"><span@if(isOnline(u.id)) { class="connected" } data-icon="r"></span> @u.titleUsername</h1>
+    <h1 class="lichess_title"><span@if(isOnline(u.id)) { class="connected" title="Online" } else { title="Offline" } data-icon="r"></span> @u.titleUsername</h1>
     @if(u.disabled) {
     <span class="staff">CLOSED</span>
     }


### PR DESCRIPTION
When I just joined Lichess, I was a bit confused by the color of the icon next to the username. Later I found out it indicates whether someone is online or not. To reduce confusion, this commit adds a tooltip that says "Online" if the user is online, else, "Offline".