### PR TITLE
fixes replay getting stuck

### DIFF
--- a/ui/round/src/replay/ctrl.js
+++ b/ui/round/src/replay/ctrl.js
@@ -61,6 +61,7 @@ module.exports = function(root) {
   }.bind(this);
 
   var disable = function() {
+    this.ply = 0;
     this.vm.late = false;
     root.chessground.set({
       movable: {
@@ -82,9 +83,9 @@ module.exports = function(root) {
     if (this.ply == ply || ply < 1 || ply > root.data.game.moves.length) return;
     this.active = ply != root.data.game.moves.length;
     this.ply = ply;
+    showFen();
     if (this.active) enable();
     else disable();
-    showFen();
   }.bind(this);
 
   this.onReload = function(cfg) {


### PR DESCRIPTION
To reproduce: click Prev then Next replay buttons, do a move or wait for
opponents move, now the prev button/(or that move in movelist) is stuck
because it thinks it is still displaying that move (from the Next
click).