### PR TITLE
show disabled game controls instead of removing

### DIFF
--- a/ui/round/src/view/button.js
+++ b/ui/round/src/view/button.js
@@ -1,4 +1,5 @@
 var chessground = require('chessground');
+var classSet = chessground.util.classSet;
 var game = require('game').game;
 var status = require('game').status;
 var partial = chessground.util.partial;
@@ -6,14 +7,16 @@ var throttle = require('lodash/function/throttle');
 var m = require('mithril');
 
 module.exports = {
-  standard: function(ctrl, condition, icon, hint, socketMsg) {
-    return condition(ctrl.data) ? m('button', {
-      class: 'button hint--bottom ' + socketMsg,
+  standard: function(ctrl, condition, icon, hint, socketMsg, onclick) {
+    // disabled if condition callback is provied and is falsy
+    var enabled = !condition || condition(ctrl.data);
+    return m('button', {
+      class: 'button hint--bottom ' + socketMsg + classSet({' disabled': !enabled}),
       'data-hint': ctrl.trans(hint),
-      onclick: partial(ctrl.socket.send, socketMsg, null)
+      onclick: enabled ? onclick || partial(ctrl.socket.send, socketMsg, null) : null
     }, m('span', {
       'data-icon': icon
-    })) : null
+    }));
   },
   forceResign: function(ctrl) {
     if (!ctrl.data.opponent.ai && ctrl.data.clock && ctrl.data.opponent.isGone && game.resignable(ctrl.data))

--- a/ui/round/src/view/table.js
+++ b/ui/round/src/view/table.js
@@ -85,12 +85,8 @@ function renderTablePlay(ctrl) {
   return [
     renderReplay(ctrl),
     m('div.control.icons', [
-      button.standard(ctrl, game.abortable, 'L', 'abortGame', 'abort'),
-      game.takebackable(ctrl.data) ? m('button', {
-        class: 'button hint--bottom takeback-yes',
-        'data-hint': ctrl.trans('proposeATakeback'),
-        onclick: partial(ctrl.takebackYes)
-      }, m('span[data-icon=i]')) : null,
+      game.abortable(ctrl.data) ? button.standard(ctrl, null, 'L', 'abortGame', 'abort') : 
+        button.standard(ctrl, game.takebackable, 'i', 'proposeATakeback', 'takeback-yes', partial(ctrl.takebackYes)),
       button.standard(ctrl, game.drawable, '2', 'offerDraw', 'draw-yes'),
       button.standard(ctrl, game.resignable, 'b', 'resign', 'resign')
     ]),


### PR DESCRIPTION
It helps with remebering which button is which when you always can
see them and they aren't moving around depending on gamestate.
http://i.imgur.com/AiEN7JV.png (left = before, right = this commit)

Also changed button.standard to allow overiding onclick's default