### PR TITLE
Move trophies a bit to the left to fix #516

### DIFF
--- a/public/stylesheets/user-show.css
+++ b/public/stylesheets/user-show.css
@@ -20,7 +20,7 @@ div.user_show div.content_box_top > .trophy {
   margin-top: -46px;
 }
 div.user_show div.content_box_top > .trophy:first-child {
-  margin-right: 50px;
+  margin-right: 40px;
 }
 div.user_show .honorific {
   display: inline-block;


### PR DESCRIPTION
By moving the trophies 10px to the left, they don't break the menu bar below them. See #516 for a screenshot.