### PR TITLE
Add maxlength attribute to chat input

### DIFF
--- a/app/views/base/chatDom.scala.html
+++ b/app/views/base/chatDom.scala.html
@@ -17,7 +17,7 @@
     <div class="messages_container active">
       <ol class="messages content scroll-shadow-soft"></ol>
       <form action="#">
-        <input class="lichess_say" value="" placeholder="@trans.talkInChat()" />
+        <input class="lichess_say" value="" placeholder="@trans.talkInChat()" maxlength="140" />
         <a class="send" data-icon="z"></a>
       </form>
     </div>


### PR DESCRIPTION
When posting a chat message, you get an error if it's longer than 140 characters. When giving it a maxlength, users can see when they reached the maximum length.