### PR TITLE
reduce page load, 8s to 240ms when 1k powertips

### DIFF
--- a/public/javascripts/big.js
+++ b/public/javascripts/big.js
@@ -620,25 +620,23 @@ lichess.storage = {
 
     function userPowertips() {
       var header = document.getElementById('site_header');
-      $('.ulpt').removeClass('ulpt').each(function() {
-        $(this).powerTip({
-          fadeInTime: 100,
-          fadeOutTime: 100,
-          placement: $(this).data('placement') || ($.contains(header, this) ? 'e' : 'w'),
-          mouseOnToPopup: true,
-          closeDelay: 200
-        }).on({
-          powerTipPreRender: function() {
-            $.ajax({
-              url: ($(this).attr('href') || $(this).data('href')).replace(/\?.+$/, '') + '/mini',
-              success: function(html) {
-                $('#powerTip').html(html);
-                $('body').trigger('lichess.content_loaded');
-              }
-            });
-          }
-        }).data('powertip', ' ');
-      });
+      $('.ulpt').removeClass('ulpt').powerTip({
+        fadeInTime: 100,
+        fadeOutTime: 100,
+        placement: $(this).data('placement') || ($.contains(header, this) ? 'e' : 'w'),
+        mouseOnToPopup: true,
+        closeDelay: 200
+      }).on({
+        powerTipPreRender: function() {
+          $.ajax({
+            url: ($(this).attr('href') || $(this).data('href')).replace(/\?.+$/, '') + '/mini',
+            success: function(html) {
+              $('#powerTip').html(html);
+              $('body').trigger('lichess.content_loaded');
+            }
+          });
+        }
+      }).data('powertip', ' ');
     }
     setTimeout(userPowertips, 600);
     $('body').on('lichess.content_loaded', userPowertips);


### PR DESCRIPTION
Tested on lichess.org/player/online
Powertip supports multiple targets in the same call. End of each call
they are saved to a collection that gets uniqueSorted with slow comparison,
this sorts one time instead of 1000 on that page.

Only code-change is indentation and removal of

    623: .each(function() {
    624:    $(this)
    641: });