### PR TITLE
Fixes the Tournament FAQ: 30 seconds -> 15 seconds

### DIFF
--- a/app/views/tournament/faq.scala.html
+++ b/app/views/tournament/faq.scala.html
@@ -93,7 +93,7 @@
   Games in progress must be finished, however they don't count for the tournament.
 
   <h2>Other important rules.</h2>
-  You are required to make your first move within 30 seconds of your turn. Failing to make
+  You are required to make your first move within 15 seconds of your turn. Failing to make
   a move in this time will forfeit the game to your opponent.
   <br />
   Drawing the game within the first 10 moves of play will earn neither player any points.


### PR DESCRIPTION
The lichess forum post linked from #515 points out to "fix a mistake - 30 seconds to 15 seconds in the tournaments description (Other important rules.)" This commit does that.