### PR TITLE
only autoscroll chat when at bottom, fixes #503

### DIFF
--- a/public/javascripts/big.js
+++ b/public/javascripts/big.js
@@ -1422,9 +1422,12 @@ lichess.storage = {
     },
     _appendHtml: function(html) {
       if (!html) return;
-      this.$msgs.append(html);
+      this.$msgs.each(function(i, el) {
+        var autoScroll = (el.scrollTop == 0 || (el.scrollTop > (el.scrollHeight - el.clientHeight - 50)));
+        $(el).append(html);
+        if (autoScroll) el.scrollTop = 999999;
+      });
       $('body').trigger('lichess.content_loaded');
-      this.$msgs.scrollTop(999999);
     }
   });
 


### PR DESCRIPTION
autoscrolls within 1 message from bottom and also when completely at top

tested in firefox and chromium