### PR TITLE
make FromPosition variant analysable

### DIFF
--- a/modules/game/src/main/Game.scala
+++ b/modules/game/src/main/Game.scala
@@ -313,12 +313,7 @@ case class Game(
 
   def replayable = imported || finished
 
-  def analysable = replayable && playedTurns > 4 && {
-    // thematic tournament use the "from position" variant
-    Game.analysableVariants(variant) || {
-      variant == chess.variant.FromPosition && tournamentId.isDefined
-    }
-  }
+  def analysable = replayable && playedTurns > 4 && Game.analysableVariants(variant)
 
   def ratingVariant =
     if (isTournament && variant == chess.variant.FromPosition) chess.variant.Standard
@@ -448,7 +443,8 @@ object Game {
     chess.variant.Standard,
     chess.variant.Chess960,
     chess.variant.KingOfTheHill,
-    chess.variant.ThreeCheck)
+    chess.variant.ThreeCheck,
+    chess.variant.FromPosition)
 
   val unanalysableVariants: Set[Variant] = Variant.all.toSet -- analysableVariants
 


### PR DESCRIPTION
The original reason to make it not analysable were Stockfish crashes with illegal or impossible positions.

I tested the following scenarios with https://github.com/ddugovic/Stockfish:

* Impossible castling rights (filtered out before they reach Stockfish)
* Excess pawns
* Excess pieces
* Opposite side check

The result is: If the game starts when "playing vs a friend", then analysis works fine. Additionally you can not play excess pawn and piece positions vs the machine, although it could handle those just fine.

Of course there could still be edge cases with specifically crafted positions, that I would not have found in my tests. (Looks unlikely to me.)