### PR TITLE
allow user tournaments to reuse bottom free lanes

### DIFF
--- a/public/stylesheets/tournament.css
+++ b/public/stylesheets/tournament.css
@@ -452,6 +452,7 @@ ol.scheduled_tournaments li.marathon {
 }
 #tournament_schedule .timeheader.hour {
   font-weight: bold;
+  border-left-style: solid;
 }
 #tournament_schedule .timeheader.now {
   top: 1.7em;

--- a/ui/tournamentSchedule/src/view.js
+++ b/ui/tournamentSchedule/src/view.js
@@ -63,6 +63,27 @@ function splitOverlaping(lanes) {
   return ret;
 }
 
+// Tries to compress lanes by moving tours
+// upwards until it hits another tournament.
+// Should not bubble past existing ones.
+function bubbleUp(lanes, tours) {
+  var returnLanes = lanes.concat([]);
+  tours.forEach(function(tour) {
+    var i = returnLanes.length - 1;
+    while (i >= 0) {
+      if (!fitLane(returnLanes[i], tour))
+        break;
+      i--;
+    }
+    if (i + 1 >= returnLanes.length) {
+      returnLanes.push([tour]);
+    } else {
+      returnLanes[i + 1].push(tour);
+    }
+  });
+  return returnLanes;
+}
+
 function renderTournament(ctrl, tour) {
   var width = tour.minutes * scale;
   var left = leftPos(tour.startsAt);
@@ -156,7 +177,7 @@ module.exports = function(ctrl) {
 
   // group system tournaments into dedicated lanes for PerfType
   var tourLanes = splitOverlaping(
-    group(ctrl.data.systemTours, speedGrouper).concat([ctrl.data.userTours]));
+    bubbleUp(group(ctrl.data.systemTours, speedGrouper), ctrl.data.userTours));
 
   return m('div.schedule.dragscroll', {
     config: function(el, isUpdate) {


### PR DESCRIPTION
It bubbles them up until it hits an official
![2015-06-21-225234_668x363_scrot](https://cloud.githubusercontent.com/assets/81471/8273324/d6201ab4-1868-11e5-98d1-76bda004259d.png)

I don't want them mixed with the
officials but this reuses the bottom lanes better when there is lots of
future official tourney lanes. Also hour-mark has solid lines.