### PR TITLE
All relations going out from a player are deleted when that player cl…

### DIFF
--- a/app/controllers/Account.scala
+++ b/app/controllers/Account.scala
@@ -8,11 +8,13 @@ import lila.db.api.$find
 import lila.security.Permission
 import lila.user.tube.userTube
 import lila.user.{ User => UserModel, UserRepo }
+import lila.relation.RelationApi
 import views._
 
 object Account extends LilaController {
 
   private def env = Env.user
+  private def relationEnv = Env.relation
   private def forms = lila.user.DataForm
 
   def profile = Auth { implicit ctx =>
@@ -110,6 +112,7 @@ object Account extends LilaController {
           case false => BadRequest(html.account.close(me, Env.security.forms.closeAccount)).fuccess
           case true =>
             (UserRepo disable me.id) >>
+              relationEnv.api.unfollowAll(me.id) >>
               Env.team.api.quitAll(me.id) >>
               (Env.security disconnect me.id) inject {
                 Redirect(routes.User show me.username) withCookies LilaCookie.newSession

--- a/modules/relation/src/main/RelationApi.scala
+++ b/modules/relation/src/main/RelationApi.scala
@@ -88,6 +88,8 @@ final class RelationApi(
       case _            => funit
     }
 
+  def unfollowAll(u1: ID): Funit = RelationRepo.unfollowAll(u1)
+
   def unblock(u1: ID, u2: ID): Funit =
     if (u1 == u2) funit
     else relation(u1, u2) flatMap {

--- a/modules/relation/src/main/RelationRepo.scala
+++ b/modules/relation/src/main/RelationRepo.scala
@@ -35,6 +35,8 @@ private[relation] object RelationRepo {
   def block(u1: ID, u2: ID): Funit = save(u1, u2, Block)
   def unblock(u1: ID, u2: ID): Funit = remove(u1, u2)
 
+  def unfollowAll(u1: ID): Funit = $remove(Json.obj("u1" -> u1))
+
   private def save(u1: ID, u2: ID, relation: Relation): Funit = $save(
     makeId(u1, u2),
     Json.obj("u1" -> u1, "u2" -> u2, "r" -> relation)


### PR DESCRIPTION
…oses their accounts. Relations other players have to this player are kept. Tested that only follows in one direction are removed. Also tested that team removal on account closing still works - #690 

Relations that already exist for closed accounts should be removed as a one-time job after this commit has been deployed.

