### PR TITLE
use syzygy tablebases from ai.syzygy_path

### DIFF
--- a/modules/ai/src/main/Config.scala
+++ b/modules/ai/src/main/Config.scala
@@ -9,6 +9,7 @@ private[ai] case class Config(
     hashSize: Int,
     nbThreads: Int,
     nbInstances: Int,
+    syzygyPath: String,
     playMaxMoveTime: FiniteDuration,
     analyseMoveTime: FiniteDuration,
     playTimeout: FiniteDuration,
@@ -37,7 +38,8 @@ private[ai] case class Config(
   def init = List(
     setoption("Hash", hashSize),
     setoption("Threads", nbThreads),
-    setoption("Ponder", false))
+    setoption("Ponder", false),
+    setoption("SyzygyPath", syzygyPath))
 
   def prepare(req: Req) = (req match {
     case r: PlayReq => setoption("Skill Level", skill(r.level))
@@ -46,7 +48,8 @@ private[ai] case class Config(
     setoption("UCI_Chess960", req.variant == Chess960),
     setoption("UCI_KingOfTheHill", req.variant == KingOfTheHill),
     setoption("UCI_3Check", req.variant == ThreeCheck),
-    setoption("UCI_Horde", req.variant == Horde))
+    setoption("UCI_Horde", req.variant == Horde),
+    setoption("SyzygyProbeLimit", if (req.variant == Standard || req.variant == Chess960) 6 else 0))
 
   def go(req: Req): List[String] = req match {
     case r: PlayReq => List(

--- a/modules/ai/src/main/Env.scala
+++ b/modules/ai/src/main/Env.scala
@@ -30,6 +30,7 @@ final class Env(
     hashSize = c getInt "hash_size",
     nbThreads = c getInt "threads",
     nbInstances = c getInt "instances",
+    syzygyPath = if (c hasPath "syzygy_path") c getString "syzygy_path" else "<empty>",
     playMaxMoveTime = c duration "play.movetime",
     analyseMoveTime = c duration "analyse.movetime",
     playTimeout = c duration "play.timeout",


### PR DESCRIPTION
So this adds tablebase support for standard chess and Chess960, by adding a new optional config option `ai.syzygy_path`.

Tablebases sizes are:
Up to 4 pieces: 5 MB
Up to 5 pieces: 1 GB
Up to 6 pieces: 158 GB

Sources for download are:
Torrent: http://oics.olympuschess.com/tracker/index.php
eMule: http://kirill-kryukov.com/chess/tablebases-online/
HTTP: http://tablebase.sesse.net/syzygy/

5 piece tables would already be a good improvement.

Using tablebases shouldn't add a whole lot of disk I/O, but if it is too much, it can still be finetuned. **How would we best go about testing this?**

Non-obvious non-issues:
* Lower skill levels still do not play perfect endgames.