### PR TITLE
Minor search form cosmetic improvements

### DIFF
--- a/app/views/game/search.scala.html
+++ b/app/views/game/search.scala.html
@@ -20,11 +20,11 @@ moreCss = moreCss) {
     <table>
       <tr>
         <th>
-          <label>@trans.players()</label>
+          <label>@trans.players() <span class="help" title="The name(s) of the player(s) you wish to search">(?)</span></label>
         </th>
         <td class="usernames">
           <div class="half">@base.input(form("players")("a"))</div>
-          <div class="half">vs @base.input(form("players")("b"))</div>
+          <div class="half">@base.input(form("players")("b"))</div>
         </td>
       </tr>
       <tr class="winner none">
@@ -39,17 +39,16 @@ moreCss = moreCss) {
       </tr>
       <tr>
         <th>
-          <label>Rating</label>
+          <label>@trans.rating() <span class="help" title="The average rating of both players">(?)</span></label>
         </th>
         <td>
           <div class="half">From @base.select(form("ratingMin"), Query.averageRatings, "".some)</div>
           <div class="half">To @base.select(form("ratingMax"), Query.averageRatings, "".some)</div>
         </td>
-        <th class="help">Average of both players Rating</th>
       </tr>
       <tr>
         <th>
-          <label for="@form("hasAi").id">Opponent</label>
+          <label for="@form("hasAi").id">@trans.opponent() <span class="help" title="Whether the player's opponent was a human or a computer">(?)</span></label>
         </th>
         <td class="single opponent">
           @base.select(form("hasAi"), Query.hasAis, "".some)
@@ -134,7 +133,7 @@ moreCss = moreCss) {
       </tr>
       <tr>
         <th>
-          <label>Analysed</label>
+          <label>Analysis <span class="help" title="Whether computer analysis is available or not">(?)</span></label>
         </th>
         <td class="single">
           @{ base.checkbox(form("analysed"), Query.analyseds._2, 1) }

--- a/modules/gameSearch/src/main/Query.scala
+++ b/modules/gameSearch/src/main/Query.scala
@@ -105,7 +105,7 @@ object Query {
 
   val aiLevels = (1 to 8) map { l => l -> ("Stockfish level " + l) }
 
-  val analyseds = 1 -> "Analysis available"
+  val analyseds = 1
 
   val dates = List("0d" -> "Now") ++
     options(List(1, 2, 6), "h", "%d hour{s} ago") ++

--- a/public/stylesheets/search.css
+++ b/public/stylesheets/search.css
@@ -44,8 +44,8 @@ form.search div.level {
   display: inline;
 }
 
-form.search th.help {
-  padding-left: 10px;
+form.search span.help {
+  text-decoration: underline #747474;
 }
 
 div.search_status {


### PR DESCRIPTION
- Added explanatory mouseover tooltips (can be added for all)
- Removed annoying off-center 'vs'
- Added localization for some labels whose translations already exist (I can add support for all other missing translations if wanted)

Before:
![lichess-search-form](https://cloud.githubusercontent.com/assets/6705285/8554077/894ee962-24df-11e5-8399-b3c22644c656.jpg)

After:
![lichess-search-form-2](https://cloud.githubusercontent.com/assets/6705285/8554086/93a1f18e-24df-11e5-8eeb-b1c8ee316ea1.jpg)

What do you think?