### PR TITLE
Move times: fix pluralization mistake

### DIFF
--- a/public/javascripts/chart2.js
+++ b/public/javascripts/chart2.js
@@ -230,7 +230,7 @@ $(function() {
         tooltip: {
           formatter: function() {
             var seconds = Math.abs(this.point.y);
-            var unit = seconds > 1 ? 'seconds' : 'second';
+            var unit = seconds != 1 ? 'seconds' : 'second';
             return this.point.name + '<br /><strong>' + seconds + '</strong> ' + unit;
           }
         },


### PR DESCRIPTION
The Move Times chart said "0 second" instead of "0 seconds".