### PR TITLE
Fixes localization of string "decline" in big.js

### DIFF
--- a/public/javascripts/big.js
+++ b/public/javascripts/big.js
@@ -481,7 +481,7 @@ lichess.storage = {
           }
           $('.lichess_overboard.joining.' + data.id).each(function() {
             if (!$(this).find('a.decline').length) $(this).find('form').append(
-              declineListener($(data.html).find('a.decline').text($.trans('decline')), function() {
+              declineListener($(data.html).find('a.decline').text($.trans('Decline')), function() {
                 location.href = "/";
               })
             );


### PR DESCRIPTION
Key is `"Decline"`, not `"decline"` in `lichess_translations`.

See dialogue on joining a challenge:

![](https://i.imgur.com/n86u3RO.png)