### PR TITLE
Prevent duplicate desktop notifications

### DIFF
--- a/public/javascripts/big.js
+++ b/public/javascripts/big.js
@@ -487,11 +487,6 @@ lichess.desktopNotification = function(msg) {
           if ($notif.length) clearTimeout($notif.data('timeout'));
           else {
             $('#challenge_notifications').append(data.html);
-            var latestNotificationChallengeId = lichess.storage.get("latestNotificationChallengeId");
-            if (latestNotificationChallengeId !== data.id) {
-              lichess.desktopNotification("You got challenged!");
-              lichess.storage.set("latestNotificationChallengeId", data.id);
-            }
             $notif = $('#' + htmlId);
             $notif.find('> a').click(function() {
               lichess.hasToReload = true; // allow quit by accept challenge (simul)
@@ -509,6 +504,7 @@ lichess.desktopNotification = function(msg) {
                 $('#top .challenge_notifications').addClass('shown');
                 $.sound.newChallenge();
               }
+              lichess.desktopNotification("You got challenged!");
               lichess.storage.set('challenge-' + data.id, 1);
             }
             refreshButton();

--- a/public/javascripts/big.js
+++ b/public/javascripts/big.js
@@ -451,7 +451,12 @@ lichess.desktopNotification = function(msg) {
         $('#nb_messages').text(e || "0").parent().parent().toggle(e > 0);
         if (e) {
           $.sound.newPM();
-          lichess.desktopNotification("New inbox message!");
+          var inboxDesktopNotification = lichess.storage.get("inboxDesktopNotification") || "0";
+          var s = e.toString();
+          if (inboxDesktopNotification !== s) {
+            lichess.desktopNotification("New inbox message!");
+            lichess.storage.set("inboxDesktopNotification", s);
+          }
         }
       },
       redirect: function(o) {
@@ -482,7 +487,11 @@ lichess.desktopNotification = function(msg) {
           if ($notif.length) clearTimeout($notif.data('timeout'));
           else {
             $('#challenge_notifications').append(data.html);
-            lichess.desktopNotification("You got challenged!");
+            var latestNotificationChallengeId = lichess.storage.get("latestNotificationChallengeId");
+            if (latestNotificationChallengeId !== data.id) {
+              lichess.desktopNotification("You got challenged!");
+              lichess.storage.set("latestNotificationChallengeId", data.id);
+            }
             $notif = $('#' + htmlId);
             $notif.find('> a').click(function() {
               lichess.hasToReload = true; // allow quit by accept challenge (simul)
@@ -688,6 +697,7 @@ lichess.desktopNotification = function(msg) {
       $('body').on('lichess.content_loaded', updatePowertips);
 
       $('#message_notifications_tag').on('click', function() {
+        lichess.storage.remove("inboxDesktopNotification");
         $.ajax({
           url: $(this).data('href'),
           cache: false,


### PR DESCRIPTION
How it works:
- For challenge desktop notifications, the code stores the desktop notification for the latest challenge ID to localStorage. When a new challenge comes in, it checks whether the ID of this challenge is the same as in localStorage. Yes? Then the notification is a duplicate and shouldn't be shown.
- For inbox notifications, the code stores the number of unread inbox messages in localStorage after it shows a desktop notification. And before it shows a notification, it checks whether the new amount of unread messages equals the amount in localStorage. Yes? Then the notification would be a duplicate and should not be shown. When you click on the Inbox icon in the top bar, the number in localStorage gets reset.

Fixes #854.