### PR TITLE
Increase specificity of #sound_state:hover' in dark.css to give sound icon color change on hover in transparent theme to be consistent with other icons

### DIFF
--- a/public/stylesheets/dark.css
+++ b/public/stylesheets/dark.css
@@ -176,7 +176,7 @@ body.dark #message_notifications div.notification:hover {
   color: #b0b0b0;
 }
 body.dark #top a.toggle:hover,
-body.dark #sound_state:hover {
+body.dark #top #sound_state:hover {
   color: #c0c0c0;
 }
 body.dark div.user_show .trophy.icon3d,


### PR DESCRIPTION
Previously overridden as `body.transp #top #sound_state` > `body.dark #sound_state:hover`