### PR TITLE
explicitly use Channel from play.api.libs.iteratee.Concurrent

### DIFF
--- a/modules/socket/src/main/WithSocket.scala
+++ b/modules/socket/src/main/WithSocket.scala
@@ -1,14 +1,13 @@
 package lila.socket
 
 import ornicar.scalalib.Zero
-import play.api.libs.iteratee.Concurrent.Channel
 import play.api.libs.iteratee.{ Iteratee, Enumerator }
 import play.api.libs.json._
 
 
 trait WithSocket {
 
-  type JsChannel = Channel[JsValue]
+  type JsChannel = play.api.libs.iteratee.Concurrent.Channel[JsValue]
   type JsEnumerator = Enumerator[JsValue]
   type JsIteratee = Iteratee[JsValue, _]
   type JsSocketHandler = (JsIteratee, JsEnumerator)


### PR DESCRIPTION
There is a name conflict going on:

```
[info] Loading project definition from /home/niklas/Projekte/lila/project
[info] Set current project to lila (in build file:/home/niklas/Projekte/lila/)
[info] Compiling 3 Scala sources to /home/niklas/Projekte/lila/modules/chess/target/scala-2.11/classes...
[info] Compiling 12 Scala sources to /home/niklas/Projekte/lila/modules/chess/target/scala-2.11/classes...
[info] Compiling 2 Scala sources to /home/niklas/Projekte/lila/modules/socket/target/scala-2.11/classes...
[info] Compiling 1 Scala source to /home/niklas/Projekte/lila/modules/opening/target/scala-2.11/classes...
[info] Compiling 2 Scala sources to /home/niklas/Projekte/lila/modules/puzzle/target/scala-2.11/classes...
[info] Compiling 2 Scala sources to /home/niklas/Projekte/lila/modules/game/target/scala-2.11/classes...
[warn] /home/niklas/Projekte/lila/modules/socket/src/main/WithSocket.scala:4: imported `Channel' is permanently hidden by definition of class Channel in package socket
[warn] import play.api.libs.iteratee.Concurrent.Channel
[warn]                                          ^
[error] /home/niklas/Projekte/lila/modules/socket/src/main/WithSocket.scala:10: lila.socket.Channel does not take type parameters
[error]   type JsChannel = Channel[JsValue]
[error]                    ^
[warn] one warning found
[error] one error found
[warn] /home/niklas/Projekte/lila/modules/opening/src/main/Generated.scala:55: method ValidationFlatMapDeprecated in object Validation is deprecated: flatMap does not accumulate errors, use `scalaz.\/` or `import scalaz.Validation.FlatMap._` instead
[warn]         (UciMove(moveStr) toValid s"Invalid UCI move $moveStr" flatMap {
[warn]                           ^
[warn] /home/niklas/Projekte/lila/modules/puzzle/src/main/Generated.scala:39: method ValidationFlatMapDeprecated in object Validation is deprecated: flatMap does not accumulate errors, use `scalaz.\/` or `import scalaz.Validation.FlatMap._` instead
[warn]         (UciMove(moveStr) toValid s"Invalid UCI move $moveStr" flatMap {
[warn]                           ^
[warn] one warning found
[warn] one warning found
[info] Compiling 2 Scala sources to /home/niklas/Projekte/lila/modules/ai/target/scala-2.11/classes...
[error] (socket/compile:compileIncremental) Compilation failed
[error] Total time: 28 s, completed 12.09.2015 03:11:23
```

Not sure if this is the most elegant solution.

I see no recent related changes. Not sure what caused it to come up now.