### PR TITLE
expose user data for a given IP - protected by passkey

### DIFF
--- a/app/controllers/Mod.scala
+++ b/app/controllers/Mod.scala
@@ -8,6 +8,7 @@ import views._
 import org.joda.time.DateTime
 import play.api.mvc._
 import play.api.mvc.Results._
+import play.api.libs.json.Json
 
 import lila.evaluation.{ PlayerAssessment }
 
@@ -112,6 +113,13 @@ object Mod extends LilaController {
   def ipIntel(ip: String) = Secure(_.IpBan) { ctx =>
     me =>
       ipIntelCache(ip).map { Ok(_) }
+  }
+
+  def whois(ip: String) = Open { implicit ctx =>
+    Env.security.whois(ip, ~get("key")) map {
+      case Left(msg)   => BadRequest(Json.obj("error" -> msg))
+      case Right(data) => Ok(data)
+    }
   }
 
   def redirect(username: String, mod: Boolean = true) = Redirect(routes.User.show(username).url + mod.??("?mod"))

--- a/conf/routes
+++ b/conf/routes
@@ -257,6 +257,7 @@ GET   /mod/log                         controllers.Mod.log
 POST  /mod/:username/refreshUserAssess controllers.Mod.refreshUserAssess(username: String)
 POST  /mod/:username/email             controllers.Mod.setEmail(username: String)
 GET   /mod/ip-intel                    controllers.Mod.ipIntel(ip: String)
+GET   /mod/whois/:ip                   controllers.Mod.whois(ip: String)
 
 # Wiki
 GET   /wiki                            controllers.Wiki.home

--- a/modules/security/src/main/Api.scala
+++ b/modules/security/src/main/Api.scala
@@ -78,6 +78,14 @@ private[security] final class Api(firewall: Firewall, tor: Tor) {
             _.flatMap(_.getAs[String]("user"))
           }
       }
+
+  def userIdsByIp(ip: String): Fu[List[String]] =
+    tube.storeColl.find(
+      BSONDocument("ip" -> ip),
+      BSONDocument("user" -> true)
+    ).cursor[BSONDocument]().collect[List]().map {
+        _.flatMap(_.getAs[String]("user"))
+      }.map(_.distinct)
 }
 
 object Api {

--- a/modules/security/src/main/Env.scala
+++ b/modules/security/src/main/Env.scala
@@ -14,6 +14,7 @@ final class Env(
     config: Config,
     captcher: akka.actor.ActorSelection,
     messenger: akka.actor.ActorSelection,
+    userJson: lila.user.JsonView,
     system: ActorSystem,
     scheduler: lila.common.Scheduler,
     db: lila.db.Env) {
@@ -45,6 +46,7 @@ final class Env(
     val DisposableEmailRefreshDelay = config duration "disposable_email.refresh_delay"
     val RecaptchaPrivateKey = config getString "recaptcha.private_key"
     val RecaptchaEndpoint = config getString "recaptcha.endpoint"
+    val WhoisKey = config getString "whois.key"
   }
   import settings._
 
@@ -74,6 +76,12 @@ final class Env(
   lazy val userSpy = UserSpy(firewall, geoIP) _
 
   lazy val disconnect = Store disconnect _
+
+  lazy val whois = new Whois(
+    key = WhoisKey,
+    api = api,
+    tor = tor,
+    userJson = userJson)
 
   lazy val emailConfirm = new EmailConfirm(
     apiUrl = EmailConfirmMailgunApiUrl,
@@ -115,5 +123,6 @@ object Env {
     system = lila.common.PlayApp.system,
     scheduler = lila.common.PlayApp.scheduler,
     captcher = lila.hub.Env.current.actor.captcher,
-    messenger = lila.hub.Env.current.actor.messenger)
+    messenger = lila.hub.Env.current.actor.messenger,
+    userJson = lila.user.Env.current.jsonView)
 }

--- a/modules/security/src/main/Whois.scala
+++ b/modules/security/src/main/Whois.scala
@@ -8,7 +8,7 @@ final class Whois(key: String, api: Api, tor: Tor, userJson: lila.user.JsonView)
 
   def apply(ip: String, reqKey: String): Fu[Either[String, JsObject]] =
     if (reqKey != key) fuccess(Left("Invalid key"))
-    else api.userIdsSharingIp(ip) flatMap lila.user.UserRepo.byIds map { users =>
+    else api.userIdsByIp(ip) flatMap lila.user.UserRepo.byIds map { users =>
       Right(Json.obj(
         "ip" -> ip,
         "tor" -> tor.isExitNode(ip),

--- a/modules/security/src/main/Whois.scala
+++ b/modules/security/src/main/Whois.scala
@@ -1,0 +1,23 @@
+package lila.security
+
+import org.joda.time.DateTime
+
+import play.api.libs.json._
+
+final class Whois(key: String, api: Api, tor: Tor, userJson: lila.user.JsonView) {
+
+  def apply(ip: String, reqKey: String): Fu[Either[String, JsObject]] =
+    if (reqKey != key) fuccess(Left("Invalid key"))
+    else api.userIdsSharingIp(ip) flatMap lila.user.UserRepo.byIds map { users =>
+      Right(Json.obj(
+        "ip" -> ip,
+        "tor" -> tor.isExitNode(ip),
+        "users" -> users.map { u =>
+          userJson(u, true) ++ Json.obj(
+            "nbGames" -> u.count.game,
+            "closed" -> !u.enabled,
+            "troll" -> u.troll,
+            "ipBan" -> u.ipBan)
+        }))
+    }
+}


### PR DESCRIPTION
``` sh
curl 'http://en.lichess.org/mod/whois/127.0.0.1?key=secretkey'
```

``` javascript
{
    "ip": "127.0.0.1",
    "tor": false,
    "users": [
        {
            "id": "arstnhutlh",
            "username": "arstnhutlh",
            "booster": false,
            "closed": false,
            "createdAt": 1435236364897,
            "engine": false,
            "ipBan": false,
            "nbGames": 261,
            "online": false,
            "profile": {
              "bio": "Self description of the player",
               // more public info about the player
            },
            "seenAt": 1435236364897,
            "troll": false,
            "perfs": {
                "blitz": {
                    "games": 30,
                    "prog": 22,
                    "rating": 1811,
                    "rd": 103
                },
                "bullet": {
                    "games": 231,
                    "prog": -14,
                    "rating": 1975,
                    "rd": 79
                },
                // more perfs for this user
        },
        // more users for this IP
}
```
