### PR TITLE
rename Nightly tournaments to Oriental

### DIFF
--- a/modules/tournament/src/main/Schedule.scala
+++ b/modules/tournament/src/main/Schedule.scala
@@ -35,15 +35,15 @@ object Schedule {
   object Freq {
     case object Hourly extends Freq
     case object Daily extends Freq
-    case object Nightly extends Freq // deprecated - use Oriental instead
-    case object Oriental extends Freq
+    case object Nightly extends Freq // deprecated - use Eastern instead
+    case object Eastern extends Freq
     case object Weekly extends Freq
     case object Monthly extends Freq
     case object Marathon extends Freq
     case object ExperimentalMarathon extends Freq { // for DB BC
       override val name = "Experimental Marathon"
     }
-    val all: List[Freq] = List(Hourly, Daily, Nightly, Oriental, Weekly, Monthly, Marathon, ExperimentalMarathon)
+    val all: List[Freq] = List(Hourly, Daily, Nightly, Eastern, Weekly, Monthly, Marathon, ExperimentalMarathon)
     def apply(name: String) = all find (_.name == name)
   }
 
@@ -73,29 +73,29 @@ object Schedule {
     import chess.variant._
     Some((sched.freq, sched.speed, sched.variant) match {
 
-      case (Hourly, Bullet, _)                           => 26
-      case (Hourly, SuperBlitz, _)                       => 56
-      case (Hourly, Blitz, _)                            => 56
-      case (Hourly, Classical, _)                        => 0 // N/A
+      case (Hourly, Bullet, _)                          => 26
+      case (Hourly, SuperBlitz, _)                      => 56
+      case (Hourly, Blitz, _)                           => 56
+      case (Hourly, Classical, _)                       => 0 // N/A
 
-      case (Daily | Nightly | Oriental, Bullet, _)       => 60
-      case (Daily | Nightly | Oriental, SuperBlitz, _)   => 90
-      case (Daily | Nightly | Oriental, Blitz, Standard) => 90
-      case (Daily | Nightly | Oriental, Blitz, _)        => 60 // variant daily is shorter
-      case (Daily | Nightly | Oriental, Classical, _)    => 60 * 2
+      case (Daily | Nightly | Eastern, Bullet, _)       => 60
+      case (Daily | Nightly | Eastern, SuperBlitz, _)   => 90
+      case (Daily | Nightly | Eastern, Blitz, Standard) => 90
+      case (Daily | Nightly | Eastern, Blitz, _)        => 60 // variant daily is shorter
+      case (Daily | Nightly | Eastern, Classical, _)    => 60 * 2
 
-      case (Weekly, Bullet, _)                           => 90
-      case (Weekly, SuperBlitz, _)                       => 60 * 2
-      case (Weekly, Blitz, _)                            => 60 * 2
-      case (Weekly, Classical, _)                        => 60 * 3
+      case (Weekly, Bullet, _)                          => 90
+      case (Weekly, SuperBlitz, _)                      => 60 * 2
+      case (Weekly, Blitz, _)                           => 60 * 2
+      case (Weekly, Classical, _)                       => 60 * 3
 
-      case (Monthly, Bullet, _)                          => 60 * 2
-      case (Monthly, SuperBlitz, _)                      => 60 * 3
-      case (Monthly, Blitz, _)                           => 60 * 3
-      case (Monthly, Classical, _)                       => 60 * 4
+      case (Monthly, Bullet, _)                         => 60 * 2
+      case (Monthly, SuperBlitz, _)                     => 60 * 3
+      case (Monthly, Blitz, _)                          => 60 * 3
+      case (Monthly, Classical, _)                      => 60 * 4
 
-      case (Marathon, _, _)                              => 60 * 24 // lol
-      case (ExperimentalMarathon, _, _)                  => 60 * 4
+      case (Marathon, _, _)                             => 60 * 24 // lol
+      case (ExperimentalMarathon, _, _)                 => 60 * 4
 
     }) filter (0!=)
   }

--- a/modules/tournament/src/main/Schedule.scala
+++ b/modules/tournament/src/main/Schedule.scala
@@ -35,14 +35,15 @@ object Schedule {
   object Freq {
     case object Hourly extends Freq
     case object Daily extends Freq
-    case object Nightly extends Freq
+    case object Nightly extends Freq // deprecated - use Oriental instead
+    case object Oriental extends Freq
     case object Weekly extends Freq
     case object Monthly extends Freq
     case object Marathon extends Freq
     case object ExperimentalMarathon extends Freq { // for DB BC
       override val name = "Experimental Marathon"
     }
-    val all: List[Freq] = List(Hourly, Daily, Nightly, Weekly, Monthly, Marathon, ExperimentalMarathon)
+    val all: List[Freq] = List(Hourly, Daily, Nightly, Oriental, Weekly, Monthly, Marathon, ExperimentalMarathon)
     def apply(name: String) = all find (_.name == name)
   }
 
@@ -72,29 +73,29 @@ object Schedule {
     import chess.variant._
     Some((sched.freq, sched.speed, sched.variant) match {
 
-      case (Hourly, Bullet, _)                => 26
-      case (Hourly, SuperBlitz, _)            => 56
-      case (Hourly, Blitz, _)                 => 56
-      case (Hourly, Classical, _)             => 0 // N/A
+      case (Hourly, Bullet, _)                           => 26
+      case (Hourly, SuperBlitz, _)                       => 56
+      case (Hourly, Blitz, _)                            => 56
+      case (Hourly, Classical, _)                        => 0 // N/A
 
-      case (Daily | Nightly, Bullet, _)       => 60
-      case (Daily | Nightly, SuperBlitz, _)   => 90
-      case (Daily | Nightly, Blitz, Standard) => 90
-      case (Daily | Nightly, Blitz, _)        => 60 // variant daily is shorter
-      case (Daily | Nightly, Classical, _)    => 60 * 2
+      case (Daily | Nightly | Oriental, Bullet, _)       => 60
+      case (Daily | Nightly | Oriental, SuperBlitz, _)   => 90
+      case (Daily | Nightly | Oriental, Blitz, Standard) => 90
+      case (Daily | Nightly | Oriental, Blitz, _)        => 60 // variant daily is shorter
+      case (Daily | Nightly | Oriental, Classical, _)    => 60 * 2
 
-      case (Weekly, Bullet, _)                => 90
-      case (Weekly, SuperBlitz, _)            => 60 * 2
-      case (Weekly, Blitz, _)                 => 60 * 2
-      case (Weekly, Classical, _)             => 60 * 3
+      case (Weekly, Bullet, _)                           => 90
+      case (Weekly, SuperBlitz, _)                       => 60 * 2
+      case (Weekly, Blitz, _)                            => 60 * 2
+      case (Weekly, Classical, _)                        => 60 * 3
 
-      case (Monthly, Bullet, _)               => 60 * 2
-      case (Monthly, SuperBlitz, _)           => 60 * 3
-      case (Monthly, Blitz, _)                => 60 * 3
-      case (Monthly, Classical, _)            => 60 * 4
+      case (Monthly, Bullet, _)                          => 60 * 2
+      case (Monthly, SuperBlitz, _)                      => 60 * 3
+      case (Monthly, Blitz, _)                           => 60 * 3
+      case (Monthly, Classical, _)                       => 60 * 4
 
-      case (Marathon, _, _)                   => 60 * 24 // lol
-      case (ExperimentalMarathon, _, _)       => 60 * 4
+      case (Marathon, _, _)                              => 60 * 24 // lol
+      case (ExperimentalMarathon, _, _)                  => 60 * 4
 
     }) filter (0!=)
   }

--- a/modules/tournament/src/main/Scheduler.scala
+++ b/modules/tournament/src/main/Scheduler.scala
@@ -91,20 +91,20 @@ private[tournament] final class Scheduler(api: TournamentApi) extends Actor {
           Schedule(Daily, Blitz, Horde, std, at(tomorrow, 3))
         ),
 
-        List( // nightly tournaments!
-          Schedule(Nightly, Bullet, Standard, std, at(today, 6) |> orTomorrow),
-          Schedule(Nightly, SuperBlitz, Standard, std, at(today, 7) |> orTomorrow),
-          Schedule(Nightly, Blitz, Standard, std, at(today, 8) |> orTomorrow),
-          Schedule(Nightly, Classical, Standard, std, at(today, 9) |> orTomorrow)
+        List( // oriental tournaments!
+          Schedule(Oriental, Bullet, Standard, std, at(today, 6) |> orTomorrow),
+          Schedule(Oriental, SuperBlitz, Standard, std, at(today, 7) |> orTomorrow),
+          Schedule(Oriental, Blitz, Standard, std, at(today, 8) |> orTomorrow),
+          Schedule(Oriental, Classical, Standard, std, at(today, 9) |> orTomorrow)
         ),
 
-        List( // nightly variant tournaments!
-          Schedule(Nightly, Blitz, Chess960, std, at(today, 10) |> orTomorrow),
-          Schedule(Nightly, Blitz, KingOfTheHill, std, at(today, 11) |> orTomorrow),
-          Schedule(Nightly, Blitz, ThreeCheck, std, at(today, 12) |> orTomorrow),
-          Schedule(Nightly, Blitz, Antichess, std, at(today, 13) |> orTomorrow),
-          Schedule(Nightly, Blitz, Atomic, std, at(today, 14) |> orTomorrow),
-          Schedule(Nightly, Blitz, Horde, std, at(today, 15) |> orTomorrow)
+        List( // oriental variant tournaments!
+          Schedule(Oriental, Blitz, Chess960, std, at(today, 10) |> orTomorrow),
+          Schedule(Oriental, Blitz, KingOfTheHill, std, at(today, 11) |> orTomorrow),
+          Schedule(Oriental, Blitz, ThreeCheck, std, at(today, 12) |> orTomorrow),
+          Schedule(Oriental, Blitz, Antichess, std, at(today, 13) |> orTomorrow),
+          Schedule(Oriental, Blitz, Atomic, std, at(today, 14) |> orTomorrow),
+          Schedule(Oriental, Blitz, Horde, std, at(today, 15) |> orTomorrow)
         ),
 
         List( // random opening replaces hourly 2 times a day

--- a/modules/tournament/src/main/Scheduler.scala
+++ b/modules/tournament/src/main/Scheduler.scala
@@ -92,19 +92,19 @@ private[tournament] final class Scheduler(api: TournamentApi) extends Actor {
         ),
 
         List( // oriental tournaments!
-          Schedule(Oriental, Bullet, Standard, std, at(today, 6) |> orTomorrow),
-          Schedule(Oriental, SuperBlitz, Standard, std, at(today, 7) |> orTomorrow),
-          Schedule(Oriental, Blitz, Standard, std, at(today, 8) |> orTomorrow),
-          Schedule(Oriental, Classical, Standard, std, at(today, 9) |> orTomorrow)
+          Schedule(Eastern, Bullet, Standard, std, at(today, 6) |> orTomorrow),
+          Schedule(Eastern, SuperBlitz, Standard, std, at(today, 7) |> orTomorrow),
+          Schedule(Eastern, Blitz, Standard, std, at(today, 8) |> orTomorrow),
+          Schedule(Eastern, Classical, Standard, std, at(today, 9) |> orTomorrow)
         ),
 
         List( // oriental variant tournaments!
-          Schedule(Oriental, Blitz, Chess960, std, at(today, 10) |> orTomorrow),
-          Schedule(Oriental, Blitz, KingOfTheHill, std, at(today, 11) |> orTomorrow),
-          Schedule(Oriental, Blitz, ThreeCheck, std, at(today, 12) |> orTomorrow),
-          Schedule(Oriental, Blitz, Antichess, std, at(today, 13) |> orTomorrow),
-          Schedule(Oriental, Blitz, Atomic, std, at(today, 14) |> orTomorrow),
-          Schedule(Oriental, Blitz, Horde, std, at(today, 15) |> orTomorrow)
+          Schedule(Eastern, Blitz, Chess960, std, at(today, 10) |> orTomorrow),
+          Schedule(Eastern, Blitz, KingOfTheHill, std, at(today, 11) |> orTomorrow),
+          Schedule(Eastern, Blitz, ThreeCheck, std, at(today, 12) |> orTomorrow),
+          Schedule(Eastern, Blitz, Antichess, std, at(today, 13) |> orTomorrow),
+          Schedule(Eastern, Blitz, Atomic, std, at(today, 14) |> orTomorrow),
+          Schedule(Eastern, Blitz, Horde, std, at(today, 15) |> orTomorrow)
         ),
 
         List( // random opening replaces hourly 2 times a day

--- a/modules/tournament/src/main/TournamentRepo.scala
+++ b/modules/tournament/src/main/TournamentRepo.scala
@@ -144,9 +144,9 @@ object TournamentRepo {
     }.foldLeft(List[Tournament]() -> none[Freq]) {
       case ((tours, skip), (_, sched)) if skip.contains(sched.freq) => (tours, skip)
       case ((tours, skip), (tour, sched)) => (tour :: tours, sched.freq match {
-        case Freq.Daily   => Freq.Nightly.some
-        case Freq.Nightly => Freq.Daily.some
-        case _            => skip
+        case Freq.Daily    => Freq.Oriental.some
+        case Freq.Oriental => Freq.Daily.some
+        case _             => skip
       })
     }._1.reverse
   }

--- a/modules/tournament/src/main/TournamentRepo.scala
+++ b/modules/tournament/src/main/TournamentRepo.scala
@@ -144,9 +144,9 @@ object TournamentRepo {
     }.foldLeft(List[Tournament]() -> none[Freq]) {
       case ((tours, skip), (_, sched)) if skip.contains(sched.freq) => (tours, skip)
       case ((tours, skip), (tour, sched)) => (tour :: tours, sched.freq match {
-        case Freq.Daily    => Freq.Oriental.some
-        case Freq.Oriental => Freq.Daily.some
-        case _             => skip
+        case Freq.Daily   => Freq.Eastern.some
+        case Freq.Eastern => Freq.Daily.some
+        case _            => skip
       })
     }._1.reverse
   }


### PR DESCRIPTION
Daily tournaments are scheduled on lichess peak activity hours,
which match the Western world day.
Therefore nightlies are targetting the Oriental world.

- Why not call them nightlies?
because it's not night for those who play them

- Why not call them dailies?
because they won't be very successful, and I don't want
a half-empty tournament to be called "daily".
It would look bad to have weak daily tournaments.

This is a proposition, please discuss.