### PR TITLE
maybe fixes some tabs not breaking into 2 lines

### DIFF
--- a/app/templating/UserHelper.scala
+++ b/app/templating/UserHelper.scala
@@ -273,8 +273,8 @@ trait UserHelper { self: I18nHelper with StringHelper with NumberHelper =>
     case GameFilter.Playing  => info.nbPlaying + " playing"
     case GameFilter.Bookmark => trans.nbBookmarks(info.nbBookmark)
     case GameFilter.Imported => trans.nbImportedGames(info.nbImported)
-    case GameFilter.Search   => Html(trans.advancedSearch.str().replaceFirst(" ", "\n"))
-  }).toString)
+    case GameFilter.Search   => trans.advancedSearch()
+  }).toString().replaceFirst(" ", "\n"))
 
   def describeUser(user: User) = {
     val name = user.titleUsername


### PR DESCRIPTION
The previous issue is that even after adding spaces to the set of translations, some tabs won't break into two lines (probably because the cardinal string isn't purely a number):
![](https://i.imgur.com/6wEjqkA.png)

this PR probably fixes that. or it breaks something. I'm not sure.
