### PR TITLE
Unhide inbox replies

### DIFF
--- a/app/views/mod/communication.scala.html
+++ b/app/views/mod/communication.scala.html
@@ -71,11 +71,7 @@ side = side.some) {
       @thread.posts.map { post =>
       <div class="post">
         @userIdLink(thread.senderOf(post).some)
-        @if(thread.isWrittenBy(post, u)) {
         @autoLink(post.text)
-        } else {
-        [hidden]
-        }
       </div>
       }
     </div>


### PR DESCRIPTION
Rationale:

1. Like chat messages, replies provides context for why the user's attitude changes by a huge tangent, to assist making decisions on whether the behaviour in the response is disruptive and unreasonable.
2. The communication report of the other user can already be navigated to. There's no real need to add that minor inconvenience - It's not like moderators don't know not to use the knowledge to stir up trouble - especially when the other report may be missing the fragment of the message we're looking for (since the size is limited) and make it difficult to judge.
3. There are a lot of insult-type reports daily. Appending the information makes it easier to commit a reliable decision quicker, hence enhancing effectiveness of reviewing.