### PR TITLE
No dekstop notification on valid premove

### DIFF
--- a/ui/round/src/ctrl.js
+++ b/ui/round/src/ctrl.js
@@ -134,6 +134,7 @@ module.exports = function(opts) {
   }.bind(this);
 
   var showYourMoveNotification = function() {
+    if (this.chessground.data.premovable.current) return;
     if (game.isPlayerTurn(this.data)) lichess.desktopNotification(this.trans('yourTurn'));
   }.bind(this);
 

--- a/ui/round/src/ctrl.js
+++ b/ui/round/src/ctrl.js
@@ -134,7 +134,13 @@ module.exports = function(opts) {
   }.bind(this);
 
   var showYourMoveNotification = function() {
-    if (this.chessground.data.premovable.current) return;
+    if (this.chessground.data.premovable.current)
+    {
+      var premove = this.chessground.data.premovable.current;
+      var orig = premove[0], dest = premove[1];
+      var canMove = chessground.board.canMove(this.chessground.data, orig, dest);
+      if (chessground.board.canMove(this.chessground.data, orig, dest)) return;
+    }
     if (game.isPlayerTurn(this.data)) lichess.desktopNotification(this.trans('yourTurn'));
   }.bind(this);
 
@@ -150,7 +156,6 @@ module.exports = function(opts) {
     d[d.player.color === 'black' ? 'player' : 'opponent'].offeringDraw = o.bDraw;
     d.possibleMoves = d.player.color === d.game.player ? o.dests : null;
     this.setTitle();
-    showYourMoveNotification();
     if (!this.replaying()) {
       this.vm.ply++;
       this.chessground.apiMove(o.uci.substr(0, 2), o.uci.substr(2, 2));
@@ -188,6 +193,7 @@ module.exports = function(opts) {
         check: o.check
       });
       if (o.check) $.sound.check();
+      showYourMoveNotification();
     }
     if (o.clock) {
       var c = o.clock


### PR DESCRIPTION
Partial #1159: the desktop notification is no longer shown if there's a valid (non-conditional) premove set; I couldn't figure out how to check for valid conditional premoves, so it's only this so far.