### PR TITLE
show "What about these ones?" only on suggestions

### DIFF
--- a/app/views/i18n/contribute.scala.html
+++ b/app/views/i18n/contribute.scala.html
@@ -14,8 +14,10 @@ Lichess is open source and needs contributors to get better.
 @if(mines.nonEmpty) {
 <h2>Do you speak @{ (mines.size > 1).fold("these languages", "this language") }?</h2>
 @i18n.translations(mines)
-}
 <br />
 <h2>What about these ones?</h2>
+} else {
+<h2>You can help by translating any languages you know.</h2>
+}
 @i18n.translations(all)
 }


### PR DESCRIPTION
The "What about these ones?" message is out of context when the "Do you know these languages?" message isn't displayed.