### PR TITLE
Hide hidden chat instead of making it non-opaque

### DIFF
--- a/public/stylesheets/board.css
+++ b/public/stylesheets/board.css
@@ -938,7 +938,7 @@ div.under_chat .watchers:hover {
 }
 #chat.hidden ol.messages,
 #chat.hidden form {
-  opacity: 0;
+  display: none;
 }
 div.game_tournament {
   max-height: 300px;


### PR DESCRIPTION
An alternative is with `pointer-events: none;` if it's important to insist its existence for purposes like a screen reader or printing, but I doubt it.

http://ja.lichess.org/forum/lichess-feedback/lazy-implementation-of-the-chat-room-checkbox