### PR TITLE
Change mask-icon colour.

### DIFF
--- a/app/views/base/layout.scala.html
+++ b/app/views/base/layout.scala.html
@@ -41,7 +41,7 @@ withLangAnnotations: Boolean = true)(body: Html)(implicit ctx: Context)
     @atom.getOrElse {
     <link href="@routes.Blog.atom()" type="application/atom+xml" rel="alternate" title="Latest blog posts" />
     }
-    <link rel="mask-icon" href="@staticUrl("favicon.svg")" color="white">
+    <link rel="mask-icon" href="@staticUrl("favicon.svg")" color="black">
     @if(withLangAnnotations){@langAnnotations}
     @ctx.transpBgImg.map { img =>
     <style type="text/css" id="bg-data">body.transp::before{background-image:url('@img');}</style>


### PR DESCRIPTION
The icon is visible when not in focus.

<img width="125" alt=“Icon." src="https://cloud.githubusercontent.com/assets/10669859/11529669/92fcd5c4-9914-11e5-8b33-06d92ac34297.png">

It disappears when brought in focus.

<img width="271" alt="screen shot 2015-12-02 at 4 45 06 pm" src="https://cloud.githubusercontent.com/assets/10669859/11529722/fc0a5eec-9914-11e5-829b-26240d77c3f3.png">


Setting the color attribute to something non-white ought to fix this.

[See also.] (https://developer.apple.com/library/prerelease/ios/documentation/AppleApplications/Reference/SafariWebContent/pinnedTabs/pinnedTabs.html)

To quote:

> You can improve the visibility of your icon by avoiding a light color, such as white, bright yellow, or light gray.