### PR TITLE
Removed orphan quote in big.js

### DIFF
--- a/public/javascripts/big.js
+++ b/public/javascripts/big.js
@@ -1071,7 +1071,7 @@ lichess.unique = function(xs) {
           success: function(list) {
             $links.find('ul').prepend(list.map(function(lang) {
               var klass = $.fp.contains(langs, lang[0]) ? 'class="accepted"' : '';
-              return '<li><button type="submit" ' + klass + '" name="lang" value="' + lang[0] + '">' + lang[1] + '</button></li>';
+              return '<li><button type="submit" ' + klass + ' name="lang" value="' + lang[0] + '">' + lang[1] + '</button></li>';
             }).join(''));
           }
         });


### PR DESCRIPTION
In the code for generating the I18n dropdown items, the generated HTML contained a quote which didn't have to be there.