### PR TITLE
add capture sounds when reviewing puzzle solution

### DIFF
--- a/ui/puzzle/src/ctrl.js
+++ b/ui/puzzle/src/ctrl.js
@@ -172,7 +172,14 @@ module.exports = function(cfg, router, i18n) {
   this.jump = function(to) {
     var prevStep = this.data.replay.step;
     chessground.anim(puzzle.jump, this.chessground.data)(this.data, to);
-    if (prevStep != this.data.replay.step) $.sound.move();
+    if (prevStep + 1 == to) {
+      // step forward, call onMove to play sound
+      var state = this.data.replay.history[to];
+      onMove(state.move[0], state.move[1], state.capture);
+    } else if (prevStep - 1 == to) {
+      // step backward, play move sound
+      $.sound.move();
+    }
   }.bind(this);
 
   this.router = router;

--- a/ui/puzzle/src/puzzle.js
+++ b/ui/puzzle/src/puzzle.js
@@ -78,10 +78,12 @@ function makeHistory(data) {
   var line = findBestLineFromProgress(data.puzzle.lines, data.progress);
   var c = chess.make(data.puzzle.fen);
   return [data.puzzle.initialMove].concat(line.map(str2move)).map(function(m) {
+    var cap = c.get(m[1]); // was last move a capture?
     chess.move(c, m);
     return {
       move: m,
       fen: c.fen(),
+      capture: cap,
       check: c.in_check(),
       turnColor: c.turn() == 'w' ? 'white' : 'black'
     };


### PR DESCRIPTION
note: untested because i can't figure out how to get mock puzzles (is that ok?)

- only play move sounds when stepping forward/back
  perhaps stepping back should have a different kind of sound?
  and jumps to the beginning/end of the puzzle?