### PR TITLE
Fix #1552

### DIFF
--- a/public/javascripts/big.js
+++ b/public/javascripts/big.js
@@ -358,10 +358,14 @@ lichess.desktopNotification = function(msg) {
   var title = 'lichess.org';
   var icon = 'http://lichess1.org/assets/images/logo.256.png';
   var notify = function() {
-    lichess.notifications.push(new Notification(title, {
+    var notification = new Notification(title, {
       icon: icon,
       body: msg
-    }));
+    });
+    notification.onclick = function() {
+      window.focus();
+    }
+    lichess.notifications.push(notification);
   };
   if (lichess.isPageVisible || !('Notification' in window) || Notification.permission === 'denied') return;
   if (Notification.permission === 'granted') notify();


### PR DESCRIPTION
Clicking on a desktop notification didn't bring you to the page on Chrome. After calling `window.focus()` on the click event, it does.