### PR TITLE
add chess960 support for local eval (fixes #1586)

### DIFF
--- a/ui/analyse/src/ceval/cevalWorker.js
+++ b/ui/analyse/src/ceval/cevalWorker.js
@@ -40,10 +40,13 @@ module.exports = function(opts, name) {
   // warmup
   send('uci');
 
+  // support chess960 and use standard chess as a subset
+  send('setoption name UCI_Chess960 value true');
+
   return {
     start: function(work) {
       switching(true);
-      send(['position', 'fen', work.position, 'moves', work.moves].join(' '));
+      send(['position', 'fen', work.position, 'moves'].concat(work.moves).join(' '));
       send('go depth ' + opts.maxDepth);
       instance.onmessage = function(msg) {
         processOutput(msg.data, work);


### PR DESCRIPTION
We can safely cut off the move list before the latest castling move. Stockfish only needs the move for repetition detection, and this can not occur anyway.

Doing that, we can avoid to actually parse the FEN and look at the position (in order to correctly `fixCastles` in all cases).