### PR TITLE
fixes #1717, use variant fen if not initial, for challenges

### DIFF
--- a/modules/challenge/src/main/Challenge.scala
+++ b/modules/challenge/src/main/Challenge.scala
@@ -135,7 +135,10 @@ object Challenge {
       _id = randomId,
       status = Status.Created,
       variant = variant,
-      initialFen = initialFen.ifTrue(variant == FromPosition),
+      initialFen = (variant == FromPosition).fold(
+        initialFen,
+        Some(variant.initialFen).ifFalse(variant.standardInitialPosition)
+      ),
       timeControl = timeControl,
       mode = mode,
       colorChoice = colorChoice,


### PR DESCRIPTION
Not sure if this is the right place to fix it. However I don't see any issue with it, the fen is ignored anyway when creating the actual game unless it's FromPosition.