### PR TITLE
disables server verification for recaptcha in dev

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -263,6 +263,7 @@ recaptcha {
   endpoint = "https://www.google.com/recaptcha/api/siteverify"
   public_key = "6LeMhwsTAAAAAElD4KwTo_IUmqIXqx7hkSLLaNSP"
   private_key = ""
+  enabled = false
 }
 shutup {
   collection.shutup = shutup

--- a/modules/security/src/main/Env.scala
+++ b/modules/security/src/main/Env.scala
@@ -45,6 +45,7 @@ final class Env(
     val DisposableEmailRefreshDelay = config duration "disposable_email.refresh_delay"
     val RecaptchaPrivateKey = config getString "recaptcha.private_key"
     val RecaptchaEndpoint = config getString "recaptcha.endpoint"
+    val RecaptchaEnabled = config getBoolean "recaptcha.enabled"
   }
   import settings._
 
@@ -57,9 +58,11 @@ final class Env(
 
   lazy val flood = new Flood(FloodDuration)
 
-  lazy val recaptcha = new Recaptcha(
-    privateKey = RecaptchaPrivateKey,
-    endpoint = RecaptchaEndpoint)
+  lazy val recaptcha: Recaptcha =
+    if (RecaptchaEnabled) new RecaptchaGoogle(
+      privateKey = RecaptchaPrivateKey,
+      endpoint = RecaptchaEndpoint)
+    else RecaptchaSkip
 
   lazy val forms = new DataForm(
     captcher = captcher,

--- a/modules/security/src/main/Recaptcha.scala
+++ b/modules/security/src/main/Recaptcha.scala
@@ -6,9 +6,19 @@ import play.api.Play.current
 
 import lila.common.PimpedJson._
 
-final class Recaptcha(
+trait Recaptcha {
+
+  def verify(response: String, req: RequestHeader): Fu[Boolean]
+}
+
+object RecaptchaSkip extends Recaptcha {
+
+  def verify(response: String, req: RequestHeader) = fuccess(true)
+}
+
+final class RecaptchaGoogle(
     endpoint: String,
-    privateKey: String) {
+    privateKey: String) extends Recaptcha {
 
   def verify(response: String, req: RequestHeader) = {
     WS.url(endpoint).post(Map(


### PR DESCRIPTION
I've seen at least 2 new devs getting stuck on this in irc, registering doesn't work without the private key.

Make sure to turn in on in server conf. This doesn't disable the client
UI; to verify it is verifying try registering with random stuff in
the textarea named g-recaptcha-response.