### PR TITLE
Make space between tick and heading at the registration page a little bit longer

### DIFF
--- a/public/stylesheets/common.css
+++ b/public/stylesheets/common.css
@@ -97,6 +97,7 @@ time {
 }
 [data-icon].is-green::before {
   color: #759900;
+  margin-right: 5px;
 }
 [data-icon].is-red::before {
   color: #dc322f;


### PR DESCRIPTION
Before
![before](https://cloud.githubusercontent.com/assets/6885864/13924985/571f7e0e-efa8-11e5-90ad-040e0df89347.jpg)

After
![after](https://cloud.githubusercontent.com/assets/6885864/13924990/5c063f84-efa8-11e5-8381-a0f346b3630a.png)