### PR TITLE
Make user search field autofocusing

### DIFF
--- a/app/views/user/list.scala.html
+++ b/app/views/user/list.scala.html
@@ -39,7 +39,7 @@
 @side = {
 <div class="side">
   <form class="search public">
-    <input placeholder="@trans.search()" class="search_user user-autocomplete-jump" />
+    <input placeholder="@trans.search()" class="search_user user-autocomplete-jump" autofocus />
   </form>
   @if(isGranted(_.UserSearch)) {
   <form class="search" action="@routes.Mod.search" method="GET">


### PR DESCRIPTION
Sometimes I need to search a user. It would be easier if I can type right when I get to the page where the search is and not to click this field.