### PR TITLE
show resign button even when opponent left

### DIFF
--- a/ui/round/src/view/table.js
+++ b/ui/round/src/view/table.js
@@ -85,7 +85,7 @@ function renderTablePlay(ctrl) {
       )) : null
   ]);
   return [
-    renderReplay(ctrl), (ctrl.vm.moveToSubmit || ctrl.vm.dropToSubmit || ctrl.forceResignable()) ? null : (
+    renderReplay(ctrl), (ctrl.vm.moveToSubmit || ctrl.vm.dropToSubmit) ? null : (
       isSpinning(ctrl) ? null : m('div.control.icons', [
         game.abortable(d) ? button.standard(ctrl, null, 'L', 'abortGame', 'abort') :
         button.standard(ctrl, game.takebackable, 'i', 'proposeATakeback', 'takeback-yes', ctrl.takebackYes),


### PR DESCRIPTION
fixes
http://en.lichess.org/qa/1255/why-cant-we-choose-to-forfeit-if-an-enemy-disconnects

Thought about adding a button with text similar to the others, but it would need more code and probably support confirmation... lazily went with less code and just kept the regular buttons
![2016-03-24-223340_247x190_scrot](https://cloud.githubusercontent.com/assets/81471/14032221/9b47dc50-f211-11e5-86dd-b589c42becb9.png)