### PR TITLE
Return all perfs in user JSON view

### DIFF
--- a/modules/round/src/main/JsonView.scala
+++ b/modules/round/src/main/JsonView.scala
@@ -54,7 +54,7 @@ final class JsonView(
               "color" -> player.color.name,
               "version" -> socket.version,
               "spectator" -> false,
-              "user" -> playerUser.map { userJsonView(_, game.perfType) },
+              "user" -> playerUser.map(userJsonView(_)),
               "rating" -> player.rating,
               "ratingDiff" -> player.ratingDiff,
               "provisional" -> player.provisional.option(true),
@@ -69,7 +69,7 @@ final class JsonView(
             "opponent" -> Json.obj(
               "color" -> opponent.color.name,
               "ai" -> opponent.aiLevel,
-              "user" -> opponentUser.map { userJsonView(_, game.perfType) },
+              "user" -> opponentUser.map(userJsonView(_)),
               "rating" -> opponent.rating,
               "ratingDiff" -> opponent.ratingDiff,
               "provisional" -> opponent.provisional.option(true),

--- a/modules/user/src/main/JsonView.scala
+++ b/modules/user/src/main/JsonView.scala
@@ -13,6 +13,7 @@ final class JsonView(isOnline: String => Boolean) {
     Json.obj(
       "games" -> o.nb,
       "rating" -> o.glicko.rating.toInt,
+      "provisional" -> o.glicko.provisional,
       "rd" -> o.glicko.deviation.toInt,
       "prog" -> o.progress)
   }


### PR DESCRIPTION
I suppose it can be improved by filtering perfs that have at least one game played, to save bandwidth.