### PR TITLE
fix dependencies for brand new projects in clean environments

### DIFF
--- a/bin/build-deps.sh
+++ b/bin/build-deps.sh
@@ -12,6 +12,7 @@ cd ..
 
 git clone https://github.com/ornicar/ReactiveMongo --branch lichess
 cd ReactiveMongo
+git checkout c6f20ab919f0cc
 sbt publish-local
 cd ..
 


### PR DESCRIPTION
This seems to work for master, it's avoiding the latest commit https://github.com/ornicar/ReactiveMongo/commit/bc0a485883bd56240417efd95452f07572571365
I hardly know anything about these play libraries and what version is needed for what...

fixes: #1845 java.lang.NoSuchMethodError:
play.api.libs.iteratee.Execution$Implicits$.trampoline()Lscala/concurrent/ExecutionContext;