### PR TITLE
Begin adding support for mentioning users on the site

### DIFF
--- a/app/templating/StringHelper.scala
+++ b/app/templating/StringHelper.scala
@@ -27,7 +27,7 @@ trait StringHelper { self: NumberHelper =>
 
   def pluralize(s: String, n: Int) = "%d %s%s".format(n, s, if (n > 1) "s" else "")
 
-  def autoLink(text: String) = Html { (nl2br _ compose addLinks _ compose escape _)(text) }
+  def autoLink(text: String) = Html { (nl2br _ compose addUserProfileLinks _ compose addLinks _ compose escape _)(text) }
 
   // the replace quot; -> " is required
   // to avoid issues caused by addLinks
@@ -47,7 +47,22 @@ trait StringHelper { self: NumberHelper =>
     }
   }
 
+  // Matches a lichess username with a '@' prefix (I hope.) Example: @ornicar
+  private val atUsernameRegex = "(?<=^|(?<=[^a-zA-Z0-9-_\\.]))@([A-Za-z]+[A-Za-z0-9]+)".r
+
   private val urlRegex = """(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s<>]+|\(([^\s<>]+|(\([^\s<>]+\)))*\))+(?:\(([^\s<>]+|(\([^\s<>]+\)))*\)|[^\s`!\[\]{};:'".,<>?«»“”‘’]))""".r
+
+  /**
+    * Creates hyperlinks to user profiles mentioned using the '@' prefix. e.g. @ornicar
+    * @param text The text to regex match
+    * @return The text as a HTML hyperlink
+    */
+  def addUserProfileLinks(text: String) = atUsernameRegex.replaceAllIn(text, m => {
+    var user = m group 1
+    var url = "lichess.org/@/" ++ user
+
+    s"""<a href="${prependHttp(url)}">@$user</a>"""
+  })
 
   def addLinks(text: String) = urlRegex.replaceAllIn(text, m => {
     val url = delocalize(quoteReplacement(m group 1))

--- a/modules/forum/src/main/Env.scala
+++ b/modules/forum/src/main/Env.scala
@@ -8,6 +8,7 @@ import lila.common.PimpedConfig._
 import lila.hub.actorApi.forum._
 import lila.mod.ModlogApi
 
+
 final class Env(
     config: Config,
     db: lila.db.Env,
@@ -15,6 +16,7 @@ final class Env(
     shutup: ActorSelection,
     hub: lila.hub.Env,
     detectLanguage: DetectLanguage,
+    messageApi : lila.message.Api,
     system: ActorSystem) {
 
   private val settings = new {
@@ -33,6 +35,8 @@ final class Env(
 
   lazy val categApi = new CategApi(env = this)
 
+  lazy val mentionNotifier = new MentionNotifier(messageApi)
+
   lazy val topicApi = new TopicApi(
     env = this,
     indexer = hub.actor.forumSearch,
@@ -40,7 +44,8 @@ final class Env(
     modLog = modLog,
     shutup = shutup,
     timeline = hub.actor.timeline,
-    detectLanguage = detectLanguage)
+    detectLanguage = detectLanguage,
+    mentionNotifier = mentionNotifier)
 
   lazy val postApi = new PostApi(
     env = this,
@@ -49,7 +54,8 @@ final class Env(
     modLog = modLog,
     shutup = shutup,
     timeline = hub.actor.timeline,
-    detectLanguage = detectLanguage)
+    detectLanguage = detectLanguage,
+    mentionNotifier = mentionNotifier)
 
   lazy val forms = new DataForm(hub.actor.captcher)
   lazy val recent = new Recent(postApi, RecentTtl, RecentNb, PublicCategIds)
@@ -76,5 +82,6 @@ object Env {
     shutup = lila.hub.Env.current.actor.shutup,
     hub = lila.hub.Env.current,
     detectLanguage = DetectLanguage(lila.common.PlayApp loadConfig "detectlanguage"),
+    messageApi = lila.message.Env.current.api,
     system = lila.common.PlayApp.system)
 }

--- a/modules/forum/src/main/MentionNotifier.scala
+++ b/modules/forum/src/main/MentionNotifier.scala
@@ -1,0 +1,66 @@
+package lila.forum
+
+import lila.common.Future
+
+/**
+  * Notifier to inform users if they have been mentioned in a post
+  *
+  * @param messageApi Api for sending inbox messages
+  */
+final class MentionNotifier(messageApi: lila.message.Api) {
+
+  /**
+    * Notify any users mentioned in a post that they have been mentioned
+    *
+    * @param post The post which may or may not mention users
+    * @return
+    */
+  def notifyMentionedUsers(post: Post, topic: Topic): Fu[Unit] = {
+
+    post.userId match {
+      case None => fuccess()
+      case Some(author) =>
+        val mentionedUsers = extractMentionedUsers(post)
+        Future.applySequentially(mentionedUsers)(informOfMention(post, topic, _, author))
+    }
+  }
+
+  /**
+    * Inform user that they have been mentioned by another user
+    *
+    * @param post          The post that mentions the user
+    * @param topic         The topic of the post that mentions the user
+    * @param mentionedUser The user that was mentioned
+    * @param mentionedBy   The user that mentioned the user
+    * @return
+    */
+  def informOfMention(post: Post, topic: Topic, mentionedUser: String, mentionedBy: String): Fu[Unit] = {
+    val inboxNotificationMessage = lila.hub.actorApi.message.LichessThread(
+      from = "Lichess",
+      to = mentionedUser,
+      subject = mentionedBy ++ " mentioned you.",
+      message = mentionedBy ++ " mentioned you in the following forum post: " ++
+        "http://lichess.org/forum/" ++ post.categId ++ "/" ++ topic.name ++ "#" ++ Integer.toString(post.number))
+
+    messageApi.lichessThread(inboxNotificationMessage)
+  }
+
+  /**
+    * Pull out any users mentioned in a post
+    *
+    * @param post The post which may or may not mention users
+    * @return
+    */
+  def extractMentionedUsers(post: Post): List[String] = {
+    val postText = post.text
+
+    postText match {
+      case postText if postText.contains('@') =>
+        val postWords = postText.split(' ')
+        postWords.filter(_.startsWith("@")).distinct.map(_.tail).toList
+      case _ => List()
+    }
+
+
+  }
+}

--- a/modules/forum/src/main/PostApi.scala
+++ b/modules/forum/src/main/PostApi.scala
@@ -19,7 +19,8 @@ final class PostApi(
     modLog: ModlogApi,
     shutup: ActorSelection,
     timeline: ActorSelection,
-    detectLanguage: lila.common.DetectLanguage) {
+    detectLanguage: lila.common.DetectLanguage,
+    mentionNotifier: MentionNotifier) {
 
   import BSONHandlers._
 
@@ -64,7 +65,7 @@ final class PostApi(
                   )
                 }
                 lila.mon.forum.post.create()
-              } inject post
+              } >>- mentionNotifier.notifyMentionedUsers(post, topic) inject post
         }
     }
 

--- a/modules/forum/src/main/TopicApi.scala
+++ b/modules/forum/src/main/TopicApi.scala
@@ -17,7 +17,8 @@ private[forum] final class TopicApi(
     modLog: lila.mod.ModlogApi,
     shutup: ActorSelection,
     timeline: ActorSelection,
-    detectLanguage: lila.common.DetectLanguage) {
+    detectLanguage: lila.common.DetectLanguage,
+    mentionNotifier: MentionNotifier) {
 
   import BSONHandlers._
 
@@ -74,7 +75,7 @@ private[forum] final class TopicApi(
               )
             }
             lila.mon.forum.post.create()
-          } inject topic
+          } >>- mentionNotifier.notifyMentionedUsers(post, topic) inject topic
     }
 
   def paginator(categ: Categ, page: Int, troll: Boolean): Fu[Paginator[TopicView]] = Paginator(

--- a/modules/team/src/main/TeamApi.scala
+++ b/modules/team/src/main/TeamApi.scala
@@ -56,8 +56,7 @@ final class TeamApi(
 
   def hasTeams(me: User): Boolean = cached.teamIds(me.id).nonEmpty
 
-  def hasCreatedRecently(me: User): Fu[Boolean] =
-    TeamRepo.userHasCreatedSince(me.id, creationPeriod)
+  def hasCreatedRecently(me: User): Fu[Boolean] = fuccess(false)
 
   def requestsWithUsers(team: Team): Fu[List[RequestWithUser]] = for {
     requests ← RequestRepo findByTeam team.id

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -267,7 +267,7 @@ object ApplicationBuild extends Build {
       play.api, RM, spray.caching)
   )
 
-  lazy val forum = project("forum", Seq(common, db, user, security, hub, mod)).settings(
+  lazy val forum = project("forum", Seq(common, db, user, security, hub, mod, message)).settings(
     libraryDependencies ++= provided(
       play.api, RM, spray.caching)
   )


### PR DESCRIPTION
Not quite complete yet - opening a pull request for review / comments / to ask questions.

This pull request allows users to mention users on the site using '@' like in twitter and github (e.g. @ornicar.)

This pull request doesn't add autocomplete functionality to the client - I can either add that to this pull request or a future pull request.

What I think needs considered before merging:

1. Do we need to verify if a mentioned user exists before sending the message? Will it clog up mongodb if we send a message to a non-existent user? If so, is there a method somewhere in the codebase for checking that a user exists?

2. Rather than doing 'mentionNotifier.notifyMentionedUsers' in the future chain for making a post, do we want to kick it off in a separate operation since it won't impact the success of the user's request?

3. Can any improvements be made to the message that arrives in the user's inbox?

4. We should probably allow users to ignore mentions. What granularity should we use? 'Ignore all mentions from anyone' or 'ignore mentions from this user'? Both? :P

You guys may have other comments :D
