### PR TITLE
Improve username regex

### DIFF
--- a/app/templating/StringHelper.scala
+++ b/app/templating/StringHelper.scala
@@ -52,7 +52,7 @@ trait StringHelper { self: NumberHelper =>
   // https://github.com/ornicar/lila/blob/master/modules/security/src/main/DataForm.scala#L34-L44
   // Example: everyone says @ornicar is a pretty cool guy
   // False example: Write to lichess.contact@gmail.com, @1
-  private val atUsernameRegex = """\B@(?>[a-zA-Z_-][\w-]{1,19})(?![\w-])""".r
+  private val atUsernameRegex = """\B@(?>[a-zA-Z_-][\w-]{1,19})(?U)(?![\w-])""".r
 
   private val urlRegex = """(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s<>]+|\(([^\s<>]+|(\([^\s<>]+\)))*\))+(?:\(([^\s<>]+|(\([^\s<>]+\)))*\)|[^\s`!\[\]{};:'".,<>?«»“”‘’]))""".r
 

--- a/app/templating/StringHelper.scala
+++ b/app/templating/StringHelper.scala
@@ -47,9 +47,12 @@ trait StringHelper { self: NumberHelper =>
     }
   }
 
-  // Matches a lichess username with a '@' prefix (I hope), in the middle of word boundaries
+  // Matches a lichess username with a '@' prefix only if it doesn't follow another '@',
+  // if it isn't after a word character (that'd be an email) and fits constains in
+  // https://github.com/ornicar/lila/blob/master/modules/security/src/main/DataForm.scala#L34-L44
   // Example: everyone says @ornicar is a pretty cool guy
-  private val atUsernameRegex = """\B(@([\w-]+))""".r
+  // False example: Write to lichess.contact@gmail.com, @1
+  private val atUsernameRegex = """\B@(?>\D[\w-]{1,19})(?![\w-])""".r
 
   private val urlRegex = """(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s<>]+|\(([^\s<>]+|(\([^\s<>]+\)))*\))+(?:\(([^\s<>]+|(\([^\s<>]+\)))*\)|[^\s`!\[\]{};:'".,<>?«»“”‘’]))""".r
 

--- a/app/templating/StringHelper.scala
+++ b/app/templating/StringHelper.scala
@@ -47,12 +47,12 @@ trait StringHelper { self: NumberHelper =>
     }
   }
 
-  // Matches a lichess username with a '@' prefix only if it doesn't follow another '@',
-  // if it isn't after a word character (that'd be an email) and fits constains in
+  // Matches a lichess username with a '@' prefix only if the next char isn't a digit,
+  // if it isn't after a word character (that'd be an email) and fits constraints in
   // https://github.com/ornicar/lila/blob/master/modules/security/src/main/DataForm.scala#L34-L44
   // Example: everyone says @ornicar is a pretty cool guy
   // False example: Write to lichess.contact@gmail.com, @1
-  private val atUsernameRegex = """\B@(?>\D[\w-]{1,19})(?![\w-])""".r
+  private val atUsernameRegex = """\B@(?>[a-zA-Z_-][\w-]{1,19})(?![\w-])""".r
 
   private val urlRegex = """(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s<>]+|\(([^\s<>]+|(\([^\s<>]+\)))*\))+(?:\(([^\s<>]+|(\([^\s<>]+\)))*\)|[^\s`!\[\]{};:'".,<>?«»“”‘’]))""".r
 

--- a/app/templating/StringHelper.scala
+++ b/app/templating/StringHelper.scala
@@ -52,7 +52,7 @@ trait StringHelper { self: NumberHelper =>
   // https://github.com/ornicar/lila/blob/master/modules/security/src/main/DataForm.scala#L34-L44
   // Example: everyone says @ornicar is a pretty cool guy
   // False example: Write to lichess.contact@gmail.com, @1
-  private val atUsernameRegex = """\B@(?>[a-zA-Z_-][\w-]{1,19})(?U)(?![\w-])""".r
+  private val atUsernameRegex = """\B@(?>([a-zA-Z_-][\w-]{1,19}))(?U)(?![\w-])""".r
 
   private val urlRegex = """(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s<>]+|\(([^\s<>]+|(\([^\s<>]+\)))*\))+(?:\(([^\s<>]+|(\([^\s<>]+\)))*\)|[^\s`!\[\]{};:'".,<>?«»“”‘’]))""".r
 
@@ -62,7 +62,7 @@ trait StringHelper { self: NumberHelper =>
     * @return The text as a HTML hyperlink
     */
   def addUserProfileLinks(text: String) = atUsernameRegex.replaceAllIn(text, m => {
-    var user = m group 2
+    var user = m group 1
     var url = s"$netDomain/@/$user"
 
     s"""<a href="${prependHttp(url)}">@$user</a>"""


### PR DESCRIPTION
based on https://github.com/ornicar/lila/blob/master/modules/security/src/main/DataForm.scala#L34-L44

it now asserts that the username length is exactly 2-20 correctly, as well that the first letter isn't a digit, and does it without backtracking. (It's probably even more performant than before, despite that it's longer)

tested with a throwaway ideone script, haven't actually compiled and tested it

doesn't check for https://github.com/ornicar/lila/blob/master/modules/common/src/main/LameName.scala but I think running that every time is an overkill?