### PR TITLE
Fix animation when clicking O-O in explorer

### DIFF
--- a/ui/analyse/src/ctrl.js
+++ b/ui/analyse/src/ctrl.js
@@ -447,7 +447,7 @@ module.exports = function(opts) {
         role: sanToRole[uci[0]]
       },
       move[1])
-    else if (!move[2]) this.chessground.apiMove(move[0], move[1])
+    else if (!move[2]) sendMove(move[0], move[1])
     else sendMove(move[0], move[1], sanToRole[move[2].toUpperCase()]);
     this.explorer.loading(true);
   }.bind(this);


### PR DESCRIPTION
Fixes a subtle issue with the castling animation: When clicking O-O or O-O-O in the opening explorer, the king moves first to the a or h file, then to its target square.