### PR TITLE
Fix auto scroll when other user jumps in study

### DIFF
--- a/ui/analyse/src/ctrl.js
+++ b/ui/analyse/src/ctrl.js
@@ -59,7 +59,7 @@ module.exports = function(opts) {
     flip: false,
     showAutoShapes: util.storedProp('show-auto-shapes', true),
     showGauge: util.storedProp('show-gauge', true),
-    autoScroll: null,
+    autoScrollRequested: false,
     element: opts.element,
     redirecting: false,
     contextMenuPath: null
@@ -148,7 +148,7 @@ module.exports = function(opts) {
   }.bind(this), false) : $.noop;
 
   this.autoScroll = function() {
-    this.vm.autoScroll && this.vm.autoScroll();
+    this.vm.autoScrollRequested = true;
   }.bind(this);
 
   this.jump = function(path) {

--- a/ui/analyse/src/view.js
+++ b/ui/analyse/src/view.js
@@ -17,14 +17,12 @@ var explorerView = require('./explorer/explorerView');
 var studyView = require('./study/studyView');
 var contextMenu = require('./contextMenu');
 
-function autoScroll(el) {
-  return util.throttle(300, false, function() {
-    raf(function() {
-      var plyEl = el.querySelector('.active') || el.querySelector('turn:first-child');
-      if (plyEl) el.scrollTop = plyEl.offsetTop - el.offsetHeight / 2 + plyEl.offsetHeight / 2;
-    });
+var autoScroll = util.throttle(300, false, function(el) {
+  raf(function() {
+    var plyEl = el.querySelector('.active') || el.querySelector('turn:first-child');
+    if (plyEl) el.scrollTop = plyEl.offsetTop - el.offsetHeight / 2 + plyEl.offsetHeight / 2;
   });
-}
+});
 
 function renderAnalyse(ctrl) {
   var result;
@@ -70,9 +68,9 @@ function renderAnalyse(ctrl) {
         return false;
       },
       config: function(el, isUpdate) {
-        if (!isUpdate) {
-          ctrl.vm.autoScroll = autoScroll(el);
-          ctrl.vm.autoScroll();
+        if (ctrl.vm.autoScrollRequested || !isUpdate) {
+          autoScroll(el);
+          ctrl.vm.autoScrollRequested = false;
         }
       }
     },


### PR DESCRIPTION
The issue:

Open a study with a long game in two browser windows A and B. In A, scroll down in the move list and jump to move 20.

In B, the new move gets the `.active` class, but is not centered.

In A, jump to move 40.

In B, move 40 gets the `.active` class, but only now is move 20 centered.

The fix: Defer auto scrolling until after the new `.active` class is in the rendered DOM by calling it from the config callback.