### PR TITLE
notify: Improve notifications load performance

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -45,11 +45,13 @@ lichess.notifyApp = (function() {
     else readPending = true;
   });
 
+  var element = document.getElementById('notify_app');
+
   var load = function() {
     var isDev = $('body').data('dev');
     lichess.loadCss('/assets/stylesheets/notifyApp.css');
     lichess.loadScript("/assets/compiled/lichess.notify" + (isDev ? '' : '.min') + '.js').done(function() {
-      instance = LichessNotify(document.getElementById('notify_app'), {
+      instance = LichessNotify(element, {
         setCount: function(nb) {
           $toggle.attr('data-count', nb);
         }
@@ -61,7 +63,14 @@ lichess.notifyApp = (function() {
     });
   };
 
-  return {};
+  return {
+    updateAndMarkAsReadIfMenuOpen : function() {
+        var notificationMenuOpen = $(element).is(':visible');
+        if (instance && notificationMenuOpen) {
+            instance.updateAndMarkAsRead();
+        }
+    }
+  };
 })();
 
 (function() {
@@ -182,7 +191,7 @@ lichess.notifyApp = (function() {
         }
       },
       new_notification: function(e) {
-        var notification = e.notification;
+        lichess.notifyApp.updateAndMarkAsReadIfMenuOpen();
 
         $('#site_notifications_tag').attr('data-count', e.unread || 0);
         $.sound.newPM();

--- a/ui/notify/src/ctrl.js
+++ b/ui/notify/src/ctrl.js
@@ -28,7 +28,7 @@ module.exports = function(env) {
     return xhr.markAllRead().then(function(p) {
       this.setPager(p);
       env.setCount(0);
-    });
+    }.bind(this));
   }.bind(this);
 
   this.nextPage = function() {


### PR DESCRIPTION
When the user receives a new notification, the 'notifications' model should be updated with the most recent notifications so that when the user clicks the 'notifications' menu they see the new notification content instantly. We want to avoid irritating the user with loading spinners since we're 'demanding' their attention.

Details:
- We still perform the xhr 'recent notifications' request when the user clicks the widget to update the notifications as read.
- If the user already has the notifications widget open and is on page 2, don't update the model, bringing the user to page 1. Increase the notification count and let the user load the new ones in full the next time they click the menu.
- If the user is on page one of the notifications, show the new one immediately (update the model.)
- Only potentially show the 'loading' spinner if there is no data - e.g. when initially lazily loading the menu. The preload may save us from even that,
- Lazy load the 'notification' module if it hasn't been loaded already when receiving a 'new_notification' web socket message so that it's ready for the user to view when they click the menu.