### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
 
     # Give VM allocated system memory & access to all cpu cores on the host
     if host =~ /darwin/
-      cpus = `sysctl -n hw.ncpu`.to_i
+      cpus = `sysctl -n hw.physicalcpu`.to_i
       # sysctl returns Bytes and we need to convert to MB
       mem = `sysctl -n hw.memsize`.to_i / 1024 / 1024
     elsif host =~ /linux/


### PR DESCRIPTION
Use physical CPU count for virtual machine config.  

VirtualBox recommends limiting CPUs to physical cores (hyperthreading cores don't count).

Tested on OS X 10.11.4 -- vagrant updated the VM on next boot.