### PR TITLE
Fix import of master games

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -388,13 +388,13 @@ tv {
   }
 }
 explorer {
-  endpoint = "//expl.lichess.org"
+  endpoint = "https://expl.lichess.org"
   index_flow = false
   mass_import = {
     endpoint = "http://expl.lichess.org"
   }
   tablebase = {
-    endpoint = "//expl.lichess.org/tablebase"
+    endpoint = "https://expl.lichess.org/tablebase"
   }
 }
 gameSearch {


### PR DESCRIPTION
Problem: We can't us protocol relative URLs with WS.

Reported here: https://de.lichess.org/forum/lichess-feedback/cant-access-imported-games#3

Example: https://en.stage.lichess.org/import/master/v1thiEGv/white?fen=rnbqkb1r/pppppp1p/5np1/8/5P2/6P1/PPPPP2P/RNBQKBNR%20w%20KQkq%20-%200%203

Stacktrace:
```
[error] application - 

! @70cfdoaoo - Internal server error, for (GET) [/import/master/9CizUxa6/white?fen=rnbqkbnr/pp1p1ppp/8/2p1p3/2P5/6P1/PP1PPP1P/RNBQKBNR%20w%20KQkq%20-%200%203] ->
 
play.api.http.HttpErrorHandlerExceptions$$anon$1: Execution exception[[NullPointerException: scheme]]
	at play.api.http.HttpErrorHandlerExceptions$.throwableToUsefulException(HttpErrorHandler.scala:265) ~[play_2.11-2.4.6.jar:2.4.6]
	at play.api.http.DefaultHttpErrorHandler.onServerError(HttpErrorHandler.scala:191) ~[play_2.11-2.4.6.jar:2.4.6]
	at play.api.GlobalSettings$class.onError(GlobalSettings.scala:179) [play_2.11-2.4.6.jar:2.4.6]
	at lila.app.Global$.onError(Global.scala:48) [classes/:na]
	at play.api.http.GlobalSettingsHttpErrorHandler.onServerError(HttpErrorHandler.scala:94) [play_2.11-2.4.6.jar:2.4.6]
	at play.core.server.netty.PlayDefaultUpstreamHandler$$anonfun$9$$anonfun$apply$1.applyOrElse(PlayDefaultUpstreamHandler.scala:151) [play-netty-server_2.11-2.4.6.jar:2.4.6]
	at play.core.server.netty.PlayDefaultUpstreamHandler$$anonfun$9$$anonfun$apply$1.applyOrElse(PlayDefaultUpstreamHandler.scala:148) [play-netty-server_2.11-2.4.6.jar:2.4.6]
	at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:36) [scala-library-2.11.8.jar:na]
	at scala.util.Failure$$anonfun$recover$1.apply(Try.scala:216) [scala-library-2.11.8.jar:na]
	at scala.util.Try$.apply(Try.scala:192) [scala-library-2.11.8.jar:na]
Caused by: java.lang.NullPointerException: scheme
	at com.ning.http.client.uri.Uri.<init>(Uri.java:56) ~[async-http-client-1.9.21.jar:na]
	at com.ning.http.client.uri.Uri.create(Uri.java:32) ~[async-http-client-1.9.21.jar:na]
	at com.ning.http.client.uri.Uri.create(Uri.java:25) ~[async-http-client-1.9.21.jar:na]
	at com.ning.http.client.RequestBuilderBase.setUrl(RequestBuilderBase.java:307) ~[async-http-client-1.9.21.jar:na]
	at com.ning.http.client.RequestBuilder.setUrl(RequestBuilder.java:165) ~[async-http-client-1.9.21.jar:na]
	at play.api.libs.ws.ning.NingWSRequest.buildRequest(NingWS.scala:218) ~[play-ws_2.11-2.4.6.jar:2.4.6]
	at play.api.libs.ws.ning.NingWSRequest.execute(NingWS.scala:128) ~[play-ws_2.11-2.4.6.jar:2.4.6]
	at play.api.libs.ws.WSRequest$class.get(WS.scala:408) ~[play-ws_2.11-2.4.6.jar:2.4.6]
	at play.api.libs.ws.ning.NingWSRequest.get(NingWS.scala:81) ~[play-ws_2.11-2.4.6.jar:2.4.6]
	at lila.explorer.Env.fetchPgn(Env.scala:29) ~[classes/:na]
```