### PR TITLE
Resize move list and charts when using 3D board (fixes #1706)

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -712,6 +712,9 @@ lichess.notifyApp = (function() {
           $('body > .content').css("margin-left", 'calc(50% - ' + px(246.5 + 256 * zoom) + ')');
         }
 
+        // reflow charts
+        window.dispatchEvent(new Event('resize'));
+
         document.body.dispatchEvent(new Event('chessground.resize'));
       };
 

--- a/public/stylesheets/board-3d.css
+++ b/public/stylesheets/board-3d.css
@@ -42,8 +42,7 @@ body.coords_2 .is3d square[data-coord-x]::after {
 .is3d #lichess {
   min-height: 479.08572px;
 }
-.is3d div.lichess_game,
-.is3d div.lichess_game div.lichess_ground {
+.is3d div.lichess_game {
   height: 479.08572px;
 }
 /* 3D boards */


### PR DESCRIPTION
`div.lichess_ground` itself should not have an explicit height, so it inherits the height from the sourrounding `div.lichess_game`.

For reflowing charts, also see http://api.highcharts.com/highcharts#Chart.reflow