### PR TITLE
Scale advantage graph and display win% tooltip as in #1494.

### DIFF
--- a/public/javascripts/chart/advantage.js
+++ b/public/javascripts/chart/advantage.js
@@ -12,19 +12,21 @@ lichess.advantageChart = function(data) {
         var makeSerieData = function(d) {
           return d.treeParts.slice(1).map(function(node) {
             var white = null, black = null;
-            var y = null;
+            var y = null, eval = null;
             if (node.eval && typeof node.eval.cp !== 'undefined') {
-              y = max * (2 / (1 + Math.exp(-0.005 * node.eval.cp)) - 1);
+              y = max * (2 / (1 + Math.exp(-0.003 * node.eval.cp)) - 1);
+              eval = (node.eval.cp / 100.0).toFixed(1);
             }
             else if (node.eval && node.eval.mate) {
               y = (node.eval.mate < 0) ? -max : max;
+              eval = '#' + node.eval.mate;
             }
             var turn = Math.floor((node.ply - 1) / 2) + 1;
             var dots = node.ply % 2 === 1 ? '.' : '...';
             return y === null ? {
               y: null
             } : {
-              name: turn + dots + ' ' + node.san,
+              name: turn + dots + ' ' + node.san + ' (' + eval + ')',
               y: Math.round(y),
               white: Math.round(max + y),
               black: Math.round(max - y)

--- a/public/javascripts/chart/advantage.js
+++ b/public/javascripts/chart/advantage.js
@@ -8,15 +8,16 @@ lichess.advantageChart = function(data) {
         };
 
         var $elem = $('#adv_chart');
-        var max = 10;
-
+        var max = 50.0;
         var makeSerieData = function(d) {
           return d.treeParts.slice(1).map(function(node) {
+            var white = null, black = null;
             var y = null;
-            if (node.eval && typeof node.eval.cp !== 'undefined') y = node.eval.cp;
+            if (node.eval && typeof node.eval.cp !== 'undefined') {
+              y = max * (2 / (1 + Math.exp(-0.005 * node.eval.cp)) - 1);
+            }
             else if (node.eval && node.eval.mate) {
-              y = max * 100 - Math.abs(node.eval.mate);
-              if (node.eval.mate < 0) y = -y;
+              y = (node.eval.mate < 0) ? -max : max;
             }
             var turn = Math.floor((node.ply - 1) / 2) + 1;
             var dots = node.ply % 2 === 1 ? '.' : '...';
@@ -24,7 +25,9 @@ lichess.advantageChart = function(data) {
               y: null
             } : {
               name: turn + dots + ' ' + node.san,
-              y: Math.max(-9.9, Math.min(y / 100, 9.9))
+              y: Math.round(y),
+              white: Math.round(max + y),
+              black: Math.round(max - y)
             };
           });
         };
@@ -45,12 +48,12 @@ lichess.advantageChart = function(data) {
             data: serieData
           }],
           chart: {
-            type: 'area',
+            type: 'areaspline',
             animation: isFull,
             spacing: [2, 0, 2, 0]
           },
           plotOptions: {
-            area: {
+            areaspline: {
               fillColor: Highcharts.theme.lichess.area.white,
               negativeFillColor: Highcharts.theme.lichess.area.black,
               threshold: 0,
@@ -106,6 +109,11 @@ lichess.advantageChart = function(data) {
               width: 1,
               value: 0
             }]
+          },
+          tooltip: {
+            formatter: function() {
+              return '<b>' + this.point.name + '</b><br/>\u25CF White: <b>' + this.point.white + '%</b><br/>\u25CB Black: <b>' + this.point.black + '%</b>';
+            }
           }
         });
         lichess.analyse.onChange();


### PR DESCRIPTION
Scales the advantage graph the same way the eval gauge scales (for example, 62% instead of +1.0).

Currently deployed on my instance; example caption is:

```
21... Nxf3
White: 62%
Black: 38%
```
