### PR TITLE
udpate vargant box ubuntu version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 Vagrant.configure(2) do |config|
-  config.vm.box = "boxcutter/ubuntu1504"
+  config.vm.box = "boxcutter/ubuntu1510"
 
   # Use this script to set up and compile the Lila installation. We set
   # `privileged` to `false` because otherwise the provisioning script will run


### PR DESCRIPTION
vagrant up
"The box 'boxcutter/ubuntu1504' could not be found or could not be accessed in the remote catalog."
"URL: ["https://atlas.hashicorp.com/boxcutter/ubuntu1504"] Error: The requested URL returned error: 404 Not Found"

End of life for Ubuntu 15.04
Ubuntu Server 15.04 (Vivid Vervet) daily builds [END OF LIFE - for Archive reference only]
https://cloud-images.ubuntu.com/vagrant/