### PR TITLE
Require at least Vagrant 1.8.3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+
+Vagrant.require_version ">= 1.8.3"
+
 Vagrant.configure(2) do |config|
   config.vm.box = "boxcutter/ubuntu1510"
 


### PR DESCRIPTION
This is the first version that can deal with the new predictable network
interface names on Ubuntu: https://github.com/mitchellh/vagrant/pull/7253