### PR TITLE
Show rating when selecting crazyhouse in game setup

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -1449,6 +1449,9 @@ lichess.notifyApp = (function() {
               else key = 'classical';
             } else key = 'correspondence';
             break;
+          case '10':
+            key = 'crazyhouse';
+            break;
           case '2':
             key = 'chess960';
             break;


### PR DESCRIPTION
Before this commit, the game setup dialog did not show your rating when selecting 'Crazyhouse' as variant. This fixes it.