### PR TITLE
Avoid links to ongoing private tournaments (fixes #1691)

### DIFF
--- a/app/views/game/side.scala.html
+++ b/app/views/game/side.scala.html
@@ -80,13 +80,13 @@
   case Some(m) if !m.tour.isCreated => { @tournament.gameStanding(m) }
   case Some(m) => {
   <div class="game_tournament side_box no_padding">
-    <p class="top text" data-icon="g"><a href="@routes.Tournament.show(m.tour.id)">@m.tour.fullName</a></p>
+    <p class="top">@tournamentLink(m.tour)</p>
   </div>
   }
   case _ => {
   @game.tournamentId.map { tourId =>
   <div class="game_tournament side_box no_padding">
-    <p class="top text" data-icon="g"><a href="@routes.Tournament.show(tourId)">@tournamentIdToName(tourId)</a></p>
+    <p class="top">@tournamentLink(tourId)</p>
   </div>
   }
   }

--- a/modules/api/src/main/RoundApi.scala
+++ b/modules/api/src/main/RoundApi.scala
@@ -139,7 +139,7 @@ private[api] final class RoundApi(
   private def withTournament(pov: Pov, tourOption: Option[TourAndRanks], hideTourneyIdIfPrivate: Boolean)(json: JsObject) =
     tourOption.fold(json) { data =>
       json + ("tournament" -> Json.obj(
-        "id" -> (if (hideTourneyIdIfPrivate && data.tour.`private` && !data.tour.isFinished) -1 else data.tour.id),
+        "id" -> (if (hideTourneyIdIfPrivate && data.tour.`private` && !data.tour.isFinished) JsNull else data.tour.id),
         "name" -> data.tour.name,
         "running" -> data.tour.isStarted,
         "secondsToFinish" -> data.tour.isStarted.option(data.tour.secondsToFinish),

--- a/modules/tournament/src/main/Cached.scala
+++ b/modules/tournament/src/main/Cached.scala
@@ -14,7 +14,16 @@ private[tournament] final class Cached(
     default = _ => none,
     logger = logger)
 
+  private val tournamentCache = MixedCache[String, Option[Tournament]](
+    ((id: String) => TournamentRepo byId id),
+    timeToLive = 6 hours,
+    default = _ => none,
+    logger = logger
+  )
+
   def name(id: String): Option[String] = nameCache get id
+
+  def byId(id: String): Option[Tournament] = tournamentCache get id
 
   val promotable = AsyncCache.single(
     TournamentRepo.promotable,

--- a/ui/round/src/view/button.js
+++ b/ui/round/src/view/button.js
@@ -177,7 +177,7 @@ module.exports = {
         'data-hint': ctrl.trans('joinTheGame'),
         href: router.game(ctrl.data.game.rematch, ctrl.data.opponent.color)
       }, ctrl.trans('rematchOfferAccepted')) : null,
-      d.tournament ? m('a.button', {
+      d.tournament && d.tournament.id !== -1 ? m('a.button', {
         href: '/tournament/' + d.tournament.id
       }, ctrl.trans('viewTournament')) : null,
       newable ? m('a.button', {
@@ -195,7 +195,7 @@ module.exports = {
       d.game.rematch ? m('a.button.text[data-icon=v]', {
         href: router.game(d.game.rematch, d.opponent.color)
       }, ctrl.trans('viewRematch')) : null,
-      d.tournament ? m('a.button', {
+      d.tournament && d.tournament.id !== -1 ? m('a.button', {
         href: '/tournament/' + d.tournament.id
       }, ctrl.trans('viewTournament')) : null,
       game.replayable(d) ? m('a.button', {

--- a/ui/round/src/view/button.js
+++ b/ui/round/src/view/button.js
@@ -177,7 +177,7 @@ module.exports = {
         'data-hint': ctrl.trans('joinTheGame'),
         href: router.game(ctrl.data.game.rematch, ctrl.data.opponent.color)
       }, ctrl.trans('rematchOfferAccepted')) : null,
-      d.tournament && d.tournament.id !== -1 ? m('a.button', {
+      d.tournament && d.tournament.id ? m('a.button', {
         href: '/tournament/' + d.tournament.id
       }, ctrl.trans('viewTournament')) : null,
       newable ? m('a.button', {
@@ -195,7 +195,7 @@ module.exports = {
       d.game.rematch ? m('a.button.text[data-icon=v]', {
         href: router.game(d.game.rematch, d.opponent.color)
       }, ctrl.trans('viewRematch')) : null,
-      d.tournament && d.tournament.id !== -1 ? m('a.button', {
+      d.tournament && d.tournament.id ? m('a.button', {
         href: '/tournament/' + d.tournament.id
       }, ctrl.trans('viewTournament')) : null,
       game.replayable(d) ? m('a.button', {


### PR DESCRIPTION
When people are in a private tournament, a link to the tournament is still available on their profile, or on the sidebar of an ongoing tournament game, or using the "View tournament" button on TV. This commit makes sure that those links are not displayed for ongoing tournaments. When the tournaments are finished, the links can be displayed because joining is no longer possible, so there's no reason to keep those tournaments private.