### PR TITLE
Add the underscore character to the invalid username error message

### DIFF
--- a/modules/security/src/main/DataForm.scala
+++ b/modules/security/src/main/DataForm.scala
@@ -36,7 +36,7 @@ final class DataForm(
       Constraints maxLength 20,
       Constraints.pattern(
         regex = User.usernameRegex,
-        error = "Invalid username. Please use only letters, numbers and dash"),
+        error = "Invalid username. Please use only letters, numbers, underscore and dash"),
       Constraints.pattern(
         regex = """^[^\d].+$""".r,
         error = "The username must not start with a number")


### PR DESCRIPTION
Currently, if you try to register with an invalid username the resulting error message
will ask you to use "letters, numbers and dash" characters. However, the underscore `_`
character is also valid, as determined by the username regex: `^[\w-]+$`