### PR TITLE
Fix chat message padding CSS in Safari (#2039)

### DIFF
--- a/public/stylesheets/chat.css
+++ b/public/stylesheets/chat.css
@@ -71,6 +71,7 @@ div.mchat .lichess_say {
   box-sizing: border-box;
 }
 div.mchat .messages {
+  display: block;
   height: 100%;
   overflow: hidden;
   overflow-y: auto;


### PR DESCRIPTION
The chat message padding in safari is broken due to to the display mode of the outer container. This should fix #2039.

Before & After:

![screen shot 2016-06-29 at 19 30 21](https://cloud.githubusercontent.com/assets/861811/16464357/ba3944de-3e31-11e6-8f6c-b089a6bd946a.png)

![screen shot 2016-06-29 at 19 30 37](https://cloud.githubusercontent.com/assets/861811/16464363/be461dea-3e31-11e6-957d-528f8557bfbd.png)

