### PR TITLE
Disable resize for the note textarea.

### DIFF
--- a/public/stylesheets/chat.css
+++ b/public/stylesheets/chat.css
@@ -62,6 +62,7 @@ div.mchat .note textarea {
   color: #707070;
   line-height: 1.7em;
   outline: none;
+  resize: none;
 }
 div.mchat .lichess_say {
   border: 0;


### PR DESCRIPTION
Prevent users from the resizing the text area beyond the size of the container.

Before & After:

![screen shot 2016-07-07 at 00 22 14](https://cloud.githubusercontent.com/assets/861811/16637734/f90a930a-43d8-11e6-8d04-846520b4293d.png)
![screen shot 2016-07-07 at 00 22 42](https://cloud.githubusercontent.com/assets/861811/16637736/fa0a55ba-43d8-11e6-899f-3ff23008b6ac.png)
