### PR TITLE
Show country name as alt and title of flag image

### DIFF
--- a/app/views/user/mini.scala.html
+++ b/app/views/user/mini.scala.html
@@ -4,7 +4,7 @@
     @u.profileOrDefault.countryInfo.map {
     case (code, name) => {
     <span class="countrylang">
-      <img class="flag" src="@staticUrl(s"images/flags/$code.png")" />
+      <img class="flag" src="@staticUrl(s"images/flags/$code.png")" alt="@name" title="@name" />
       @if(u.username.size < 15) { @name }
     </span>
     }


### PR DESCRIPTION
In the mini user view, sometimes the country name will not be displayed if the username is too long. To keep up with the fun of discovering new countries, this change lets you hover the flag to see the name of the country it belongs to.