### PR TITLE
chrome crash workaround, fixes #2051

### DIFF
--- a/ui/analyse/src/view.js
+++ b/ui/analyse/src/view.js
@@ -183,7 +183,7 @@ function icon(c) {
 function buttons(ctrl) {
   return m('div.game_control',
     m('div.buttons', {
-      onmousedown: function(e) {
+      onmouseup: function(e) {
         var action = e.target.getAttribute('data-act') || e.target.parentNode.getAttribute('data-act');
         if (action === 'explorer') ctrl.explorer.toggle();
         else if (action === 'menu') ctrl.actionMenu.toggle();


### PR DESCRIPTION
Basically, chrome crashes when doing a mousedrag over an element with css content (the icon) if some parent has their number of children changing in amount (toggling the menu) at the exact same moment; or something like that. This will only generate normal mousemove events with the mouse button released.