### PR TITLE
revert analysis note margin

### DIFF
--- a/public/stylesheets/analyse.css
+++ b/public/stylesheets/analyse.css
@@ -609,7 +609,7 @@ body.dark .explorer_box .black {
 }
 .lichess_ground .replay .black {
   border-right: 3px solid;
-  margin-right: 2px;
+  overflow-x: hidden;
 }
 body .lichess_ground .replay .inaccuracy {
   border-color: #56B4E9;


### PR DESCRIPTION
not needed with custom styled scrollbars
#### before chrome/fx
![2016-07-13-215927_559x594_scrot](https://cloud.githubusercontent.com/assets/81471/16818012/db8ab1bc-4945-11e6-80f7-1e2735b1bd6d.png)
#### after
![2016-07-13-215959_570x589_scrot](https://cloud.githubusercontent.com/assets/81471/16818013/dbaa6368-4945-11e6-8cd0-3807831f3cfd.png)
