### PR TITLE
Fixes firefox buggy rendering

### DIFF
--- a/public/stylesheets/board.css
+++ b/public/stylesheets/board.css
@@ -4,6 +4,8 @@
   width: 512px;
   height: 512px;
   position: relative;
+  /* Fixes render artifacts after dropping a piece in firefox 47,48 */
+  -moz-transform: translate3d(0, 0, 0);
 }
 .cg-board {
   position: relative;


### PR DESCRIPTION
In version 47 and 48, after switching tabs back and forth twice (or
maybe after a delay), and when dropping a piece on the board it would
not clear the areas around it from the hovering piece. This seems to be
solved in firefox 49 and 50.