### PR TITLE
Use secure cookies on HTTPS connections

### DIFF
--- a/modules/common/src/main/LilaCookie.scala
+++ b/modules/common/src/main/LilaCookie.scala
@@ -33,6 +33,6 @@ object LilaCookie {
     maxAge orElse Session.maxAge orElse 86400.some,
     "/",
     domain(req).some,
-    Session.secure,
+    Session.secure || req.headers.get("X-Forwarded-Proto").exists(_ == "https"),
     httpOnly | Session.httpOnly)
 }


### PR DESCRIPTION
In the current configuration an attacker could steal the session cookie in a MITM attack if they get the user to connect lichess.org via plain HTTP (say `<img src="http://lichess.org/?asdfghjk">` on their site).

`play.http.session.secure = true` can be used to force all cookies to be HTTPS only, but this is too much for old versions of the app.

Instead let's upgrade to secure cookies if nginx indicates the user connected via https.

(`X-Forwarded-Proto` still needs to be configured next to the exisiting `X-Forwarded-For`: `proxy_set_header X-Forwarded-Proto $scheme`).