### PR TITLE
Add link to privacy policy in full-screen menu

### DIFF
--- a/app/views/base/fpmenu.scala.html
+++ b/app/views/base/fpmenu.scala.html
@@ -93,7 +93,8 @@
     <a href="/donate">@trans.donate()</a> ı
     }
     <a href="/contact">@trans.contact()</a> ı
-    <a href="@routes.Page.tos">@trans.termsOfService()</a>
+    <a href="@routes.Page.tos">@trans.termsOfService()</a> ı
+    <a href="@routes.Page.privacy">@trans.privacy()</a>
     @NotForKids {
     ı <a href="https://github.com/ornicar/lila" target="_blank">@trans.sourceCode()</a>
     }


### PR DESCRIPTION
Despite it being a rather important document, a link to it appears very rare. This commit adds a link to the privacy policy in the full-screen menu (that menu that you can open with the hamburger icon in the top bar).