### PR TITLE
Fix forum mention notification regression

### DIFF
--- a/ui/notify/src/view.js
+++ b/ui/notify/src/view.js
@@ -25,7 +25,7 @@ function drawTime(notification) {
 };
 
 var handlers = {
-  mentioned: {
+  mention: {
     html: function(notification) {
       var content = notification.content;
       var url = "/forum/redirect/post/" + content.postId


### PR DESCRIPTION
The expected 'type' value for the forum mention notification was out of date (was 'mentioned', is now 'mention')

Fixes #2123