### PR TITLE
Autofocus chat input  WIP (do not merge)

### DIFF
--- a/ui/chat/src/discussion.js
+++ b/ui/chat/src/discussion.js
@@ -48,6 +48,7 @@ function input(ctrl) {
     autocomplete: 'off',
     maxlength: 140,
     disabled: ctrl.vm.isTimeout() || !ctrl.vm.writeable(),
+    autofocus: true,
     config: function(el, isUpdate) {
       if (!isUpdate) el.addEventListener('keypress', function(e) {
         if (e.which == 10 || e.which == 13) {


### PR DESCRIPTION
Adds autofocus element to chat input.  This may not always be desired, as it makes it harder to use keyboard shortcuts like 'f' to flip the board. However the benefits may outweigh this inconvenience.

Blocked by #2135 because currently in light theme, focus hides the placeholder message.

Fixes #2132.