### PR TITLE
Debounce explorer xhr instead of throttling

### DIFF
--- a/ui/analyse/src/explorer/explorerCtrl.js
+++ b/ui/analyse/src/explorer/explorerCtrl.js
@@ -46,7 +46,7 @@ module.exports = function(root, opts, allow) {
     m.redraw();
   };
 
-  var fetchOpening = throttle(2000, false, function(fen) {
+  var fetchOpening = throttle(250, function(fen) {
     openingXhr(opts.endpoint, effectiveVariant, fen, config.data, withGames).then(function(res) {
       res.opening = true;
       res.nbMoves = res.moves.length;
@@ -56,9 +56,9 @@ module.exports = function(root, opts, allow) {
       failing(false);
       m.redraw();
     }, handleFetchError);
-  });
+  }, false);
 
-  var fetchTablebase = throttle(500, false, function(fen) {
+  var fetchTablebase = throttle(250, function(fen) {
     tablebaseXhr(opts.tablebaseEndpoint, root.vm.node.fen).then(function(res) {
       res.nbMoves = res.moves.length;
       res.tablebase = true;
@@ -68,7 +68,7 @@ module.exports = function(root, opts, allow) {
       failing(false);
       m.redraw();
     }, handleFetchError);
-  });
+  }, false);
 
   var fetch = function(fen) {
     var hasTablebase = effectiveVariant === 'standard' || effectiveVariant === 'chess960';

--- a/ui/analyse/src/util.js
+++ b/ui/analyse/src/util.js
@@ -81,7 +81,7 @@ module.exports = {
     return name.toLowerCase();
   },
   /**
-   * https://github.com/niksy/throttle-debounce/blob/master/lib/throttle.js
+   * https://github.com/niksy/throttle-debounce/blob/master/throttle.js
    *
    * Throttle execution of a function. Especially useful for rate limiting
    * execution of handlers on events like resize and scroll.


### PR DESCRIPTION
Debouncing

```
.........X            .......................................X
```

is more appropriate for the explorer than throttling:

```
.........X            .........X.........X.........X.........X
```

Let's do that and with a much smaller delay.