### PR TITLE
Adjust crazyhouse increment schedule

### DIFF
--- a/modules/tournament/src/main/Schedule.scala
+++ b/modules/tournament/src/main/Schedule.scala
@@ -156,7 +156,8 @@ object Schedule {
 
     (s.speed, s.variant, s.freq) match {
       // Special cases.
-      case (Blitz, Crazyhouse, Hourly) if zhInc(s)         => TC(4 * 60, 1)
+      case (SuperBlitz, Crazyhouse, Hourly) if zhInc(s)    => TC(3 * 60, 1)
+      case (Blitz, Crazyhouse, Hourly) if zhInc(s)         => TC(4 * 60, 2)
       case (Blitz, Standard, Hourly) if standardInc(s)     => TC(3 * 60, 2)
 
       case (HyperBullet, _, _)                             => TC(30, 0)


### PR DESCRIPTION
Feedback for 4+1 was largely positive. However some pointed out that 4+1
is a shorter time control than 5+0 and crazyhouse doesn't have any 10+0
tourneys like standard chess. So bring back a slow tourney, the +2 gives
a very different feel for zh where games last until they are done.

Also add 3+1, which has been suggested a couple times. The logic is setup
to avoid 2 consecutive increment tourneys.