### PR TITLE
Enable horde and racing kings ai

### DIFF
--- a/app/templating/SetupHelper.scala
+++ b/app/templating/SetupHelper.scala
@@ -61,6 +61,8 @@ trait SetupHelper { self: I18nHelper =>
       variantTuple(chess.variant.Chess960) :+
       variantTuple(chess.variant.KingOfTheHill) :+
       variantTuple(chess.variant.ThreeCheck) :+
+      variantTuple(chess.variant.Horde) :+
+      variantTuple(chess.variant.RacingKings) :+
       variantTuple(chess.variant.FromPosition)
 
   def translatedVariantChoicesWithVariantsAndFen(implicit ctx: Context) =

--- a/modules/game/src/main/Game.scala
+++ b/modules/game/src/main/Game.scala
@@ -493,7 +493,9 @@ object Game {
     chess.variant.Chess960,
     chess.variant.KingOfTheHill,
     chess.variant.ThreeCheck,
-    chess.variant.FromPosition)
+    chess.variant.FromPosition,
+    chess.variant.Horde,
+    chess.variant.RacingKings)
 
   val unanalysableVariants: Set[Variant] = Variant.all.toSet -- analysableVariants
 

--- a/modules/setup/src/main/Config.scala
+++ b/modules/setup/src/main/Config.scala
@@ -95,6 +95,8 @@ trait BaseConfig {
   val aiVariants = variants :+
     chess.variant.KingOfTheHill.id :+
     chess.variant.ThreeCheck.id :+
+    chess.variant.Horde.id :+
+    chess.variant.RacingKings.id :+
     chess.variant.FromPosition.id
   val variantsWithVariants =
     variants :+ chess.variant.Crazyhouse.id :+ chess.variant.KingOfTheHill.id :+ chess.variant.ThreeCheck.id :+ chess.variant.Antichess.id :+ chess.variant.Atomic.id :+ chess.variant.Horde.id :+ chess.variant.RacingKings.id

--- a/ui/analyse/src/ceval/cevalWorker.js
+++ b/ui/analyse/src/ceval/cevalWorker.js
@@ -8,7 +8,8 @@ var variantMap = {
   crazyhouse: 'House',
   kingOfTheHill: 'KingOfTheHill',
   racingKings: 'Race',
-  threeCheck: '3Check'
+  threeCheck: '3Check',
+  antichess: 'Anti'
 };
 
 module.exports = function(opts, name) {

--- a/ui/analyse/src/ctrl.js
+++ b/ui/analyse/src/ctrl.js
@@ -387,7 +387,7 @@ module.exports = function(opts) {
     });
   }.bind(this);
 
-  var cevalVariants = ['standard', 'fromPosition', 'chess960', 'kingOfTheHill', 'threeCheck'];
+  var cevalVariants = ['standard', 'fromPosition', 'chess960', 'kingOfTheHill', 'threeCheck', 'horde', 'racingKings'];
   var cevalPossible = function() {
     return (util.synthetic(this.data) || !game.playable(this.data)) &&
       cevalVariants.indexOf(this.data.game.variant.key) !== -1;


### PR DESCRIPTION
Update stockfish.js and enable Horde and RacingKings for local analysis, fishnet analysis and play against the ai.

There have been lots of improvements lately and I am pretty confident that Stockfish is a strong opponent in these variants.

cc @ddugovic, @ianfab