### PR TITLE
[DO NOT MERGE] Fix logic for tournament display

### DIFF
--- a/modules/tournament/src/main/Tournament.scala
+++ b/modules/tournament/src/main/Tournament.scala
@@ -59,7 +59,7 @@ case class Tournament(
   def isAlmostFinished = secondsToFinish < math.max(30, math.min(clock.limit / 2, 120))
 
   def isStillWorthEntering = isMarathonOrUnique || {
-    secondsToFinish > (minutes * 60 / 3).max(20 * 60)
+    secondsToFinish > (minutes * 60 / 3).min(20 * 60)
   }
 
   def isRecentlyFinished = isFinished && (nowSeconds - finishesAt.getSeconds) < 30 * 60


### PR DESCRIPTION
Tourneys should be listed if tourney is either >1/3 left *or* has at least 20 minutes left -- thus the operator should be min.