### PR TITLE
Sunsetter improvements

### DIFF
--- a/ui/analyse/src/ceval/sunsetterWorker.js
+++ b/ui/analyse/src/ceval/sunsetterWorker.js
@@ -30,7 +30,7 @@ module.exports = function(opts, name) {
     if (text.indexOf('move ') == 0) {
       aiMoves++;
       best = text.split(' ')[1];
-      send('analyze');
+      if (!stopping) send('analyze');
       return;
     }
 
@@ -49,7 +49,7 @@ module.exports = function(opts, name) {
       if (matches) {
         cp = parseInt(matches[2], 10);
         if (!aiMoves) best = matches[1];
-        send('analyze');
+        if (!stopping) send('analyze');
       } else {
         return;
       }


### PR DESCRIPTION
Improve sunsetter output and behavior, especially in
positions close to mate.

- fix eval sign in "analyze" mode, which is
  used after sunsetter plays a forced move
- enter analyze mode if sunsetter quickly picks an obvious move
  without fully evaluating. For example, if alternatives allow
  mate in 1, sunsetter might move with only depth 1 evaluation,
  giving the best move but an incorrect eval score.
- approximate depth when sunsetter finds mate but doesn't give
  a depth.

Fixes #2198 and #2199.