### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.require_version ">= 1.8.3"
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "boxcutter/ubuntu1510"
+  config.vm.box = "boxcutter/ubuntu1604"
 
   # Use this script to set up and compile the Lila installation. We set
   # `privileged` to `false` because otherwise the provisioning script will run


### PR DESCRIPTION
The VM box "boxcutter/ubuntu1510" is not available for download. The "vagrant up" command for creating the development environment fails.

Changed to "boxcutter/ubuntu1604". Is this sound? It worked fine for me.