### PR TITLE
[RFC] Use same origin policy for unsafe endpoints

### DIFF
--- a/app/controllers/Account.scala
+++ b/app/controllers/Account.scala
@@ -148,10 +148,12 @@ object Account extends LilaController {
       Ok(html.account.kid(me)).fuccess
   }
 
-  def kidConfirm = Auth { ctx =>
+  def kidConfirm = Auth { implicit ctx =>
     me =>
-      implicit val req = ctx.req
-      (UserRepo toggleKid me) inject Redirect(routes.Account.kid)
+      SameOrigin(Ok(html.account.kid(me)).fuccess) {
+        implicit val req = ctx.req
+        (UserRepo toggleKid me) inject Redirect(routes.Account.kid)
+      }
   }
 
   private def currentSessionId(implicit ctx: Context) =

--- a/app/controllers/Main.scala
+++ b/app/controllers/Main.scala
@@ -21,17 +21,19 @@ object Main extends LilaController {
   ))
 
   def toggleBlindMode = OpenBody { implicit ctx =>
-    implicit val req = ctx.body
-    fuccess {
-      blindForm.bindFromRequest.fold(
-        err => BadRequest, {
-          case (enable, redirect) =>
-            Redirect(redirect) withCookies lila.common.LilaCookie.cookie(
-              Env.api.Accessibility.blindCookieName,
-              if (enable == "0") "" else Env.api.Accessibility.hash,
-              maxAge = Env.api.Accessibility.blindCookieMaxAge.some,
-              httpOnly = true.some)
-        })
+    SameOrigin(Redirect(routes.Lobby.home).fuccess) {
+      implicit val req = ctx.body
+      fuccess {
+        blindForm.bindFromRequest.fold(
+          err => BadRequest, {
+            case (enable, redirect) =>
+              Redirect(redirect) withCookies lila.common.LilaCookie.cookie(
+                Env.api.Accessibility.blindCookieName,
+                if (enable == "0") "" else Env.api.Accessibility.hash,
+                maxAge = Env.api.Accessibility.blindCookieMaxAge.some,
+                httpOnly = true.some)
+          })
+      }
     }
   }
 

--- a/app/controllers/Timeline.scala
+++ b/app/controllers/Timeline.scala
@@ -33,6 +33,8 @@ object Timeline extends LilaController {
 
   def unsub(channel: String) = Auth { implicit ctx =>
     me =>
-      Env.timeline.unsubApi.set(channel, me.id, ~get("unsub") == "on")
+      SameOrigin() {
+        Env.timeline.unsubApi.set(channel, me.id, ~get("unsub") == "on")
+      }
   }
 }

--- a/modules/common/src/main/HTTPRequest.scala
+++ b/modules/common/src/main/HTTPRequest.scala
@@ -28,6 +28,7 @@ object HTTPRequest {
   def isChrome(req: RequestHeader) = uaContains(req, "Chrome/")
   def isSafari(req: RequestHeader) = uaContains(req, "Safari/") && !isChrome(req)
 
+  def origin(req: RequestHeader): Option[String] = req.headers get HeaderNames.ORIGIN
   def referer(req: RequestHeader): Option[String] = req.headers get HeaderNames.REFERER
 
   def lastRemoteAddress(req: RequestHeader): String =


### PR DESCRIPTION
Regarding ornicar/lichess-sysadmin#19: I stand corrected: The Origin header seems like a good way to add CSRF protection, assuming users logged in to lichess always use relatively modern browsers (likely) and browser plugins aren't fucking with them (too bad) [1].

Checking some headers seems a lot easier than introducing CSRF tokens (to deal with all the browsers and rouge browser plugins) [2] and is probably a good compromise. Aditionally this is automatically backwards compatible with the mobile app.

Here's a sample implementation for a couple of endpoints. Of course there are a lot more, but I guess early feedback/discussion would be nice.

[1] https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet
[2] https://www.playframework.com/documentation/2.5.x/ScalaCsrf#Applying-CSRF-filtering-on-a-per-action-basis