### PR TITLE
fix false-positives with dot at the end of origin

### DIFF
--- a/modules/security/src/main/CSRFRequestHandler.scala
+++ b/modules/security/src/main/CSRFRequestHandler.scala
@@ -18,7 +18,7 @@ final class CSRFRequestHandler(domain: String) {
         true
       case Some("file://") =>
         true
-      case Some(o) if isSubdomain(o) =>
+      case Some(o) if isSubdomain(o.stripSuffix(".")) =>
         true
       case Some(_) =>
         if (isSocket(req)) {


### PR DESCRIPTION
The logs had entries like `origin:https://en.lichess.org. referer:https://en.lichess.org./` from four distinct IPs today. Let's deal with the trailing dot.

Link for testing: [https://en.lichess.org.](https://en.lichess.org.)