### PR TITLE
[RFC] finegrained cswsh defence

### DIFF
--- a/app/controllers/Challenge.scala
+++ b/app/controllers/Challenge.scala
@@ -138,10 +138,11 @@ object Challenge extends LilaController {
   }
 
   def websocket(id: String, apiVersion: Int) = SocketOption[JsValue] { implicit ctx =>
-    env.api byId id flatMap {
+    if (!ctx.sameOrigin) fuccess(none)
+    else env.api byId id flatMap {
       _ ?? { c =>
         get("sri") ?? { uid =>
-          env.socketHandler.join(id, uid, ctx.userId, isMine(c))
+          env.socketHandler.join(id, uid, ctx.userId, ctx.sameOrigin, isMine(c))
         }
       }
     }

--- a/app/controllers/Lobby.scala
+++ b/app/controllers/Lobby.scala
@@ -54,6 +54,7 @@ object Lobby extends LilaController {
       Env.lobby.socketHandler(
         uid = uid,
         user = ctx.me,
+        sameOrigin = ctx.sameOrigin,
         mobile = getBool("mobile")) map some
     }
   }

--- a/app/controllers/Main.scala
+++ b/app/controllers/Main.scala
@@ -37,7 +37,7 @@ object Main extends LilaController {
 
   def websocket = SocketOption { implicit ctx =>
     get("sri") ?? { uid =>
-      Env.site.socketHandler(uid, ctx.userId, get("flag")) map some
+      Env.site.socketHandler(uid, ctx.userId, ctx.sameOrigin, get("flag")) map some
     }
   }
 

--- a/app/controllers/Round.scala
+++ b/app/controllers/Round.scala
@@ -30,6 +30,7 @@ object Round extends LilaController with TheftPrevention {
         colorName = color,
         uid = uid,
         user = ctx.me,
+        sameOrigin = ctx.sameOrigin,
         ip = ctx.ip,
         userTv = get("userTv"),
         apiVersion = lila.api.Mobile.Api.currentVersion // yeah it should be in the URL
@@ -43,7 +44,7 @@ object Round extends LilaController with TheftPrevention {
         if (isTheft(pov)) fuccess(Left(theftResponse))
         else get("sri") match {
           case Some(uid) => requestAiMove(pov) >> env.socketHandler.player(
-            pov, uid, ~get("ran"), ctx.me, ctx.ip, ApiVersion(apiVersion)
+            pov, uid, ~get("ran"), ctx.me, ctx.sameOrigin, ctx.ip, ApiVersion(apiVersion)
           ) map Right.apply
           case None => fuccess(Left(NotFound))
         }

--- a/app/controllers/Simul.scala
+++ b/app/controllers/Simul.scala
@@ -116,7 +116,7 @@ object Simul extends LilaController {
 
   def websocket(id: String, apiVersion: Int) = SocketOption[JsValue] { implicit ctx =>
     get("sri") ?? { uid =>
-      env.socketHandler.join(id, uid, ctx.me)
+      env.socketHandler.join(id, uid, ctx.me, ctx.sameOrigin)
     }
   }
 

--- a/app/controllers/Study.scala
+++ b/app/controllers/Study.scala
@@ -145,6 +145,7 @@ object Study extends LilaController {
             studyId = id,
             uid = lila.socket.Socket.Uid(uid),
             user = ctx.me,
+            sameOrigin = ctx.sameOrigin,
             owner = ctx.userId.exists(study.isOwner))
         }
       }

--- a/app/controllers/Tournament.scala
+++ b/app/controllers/Tournament.scala
@@ -188,7 +188,7 @@ object Tournament extends LilaController {
 
   def websocket(id: String, apiVersion: Int) = SocketOption[JsValue] { implicit ctx =>
     get("sri") ?? { uid =>
-      env.socketHandler.join(id, uid, ctx.me)
+      env.socketHandler.join(id, uid, ctx.me, ctx.sameOrigin)
     }
   }
 }

--- a/modules/api/src/main/Context.scala
+++ b/modules/api/src/main/Context.scala
@@ -90,7 +90,7 @@ final class HeaderContext(
 object Context {
 
   def apply(req: RequestHeader): HeaderContext =
-    new HeaderContext(UserContext(req, none), PageData.default)
+    new HeaderContext(UserContext(req, none, false), PageData.default)
 
   def apply(userContext: HeaderUserContext, pageData: PageData): HeaderContext =
     new HeaderContext(userContext, pageData)

--- a/modules/challenge/src/main/Socket.scala
+++ b/modules/challenge/src/main/Socket.scala
@@ -42,9 +42,9 @@ private final class Socket(
 
     case GetVersion => sender ! history.version
 
-    case Socket.Join(uid, userId, owner) =>
+    case Socket.Join(uid, userId, sameOrigin, owner) =>
       val (enumerator, channel) = Concurrent.broadcast[JsValue]
-      val member = Socket.Member(channel, userId, owner)
+      val member = Socket.Member(channel, userId, sameOrigin, owner)
       addMember(uid, member)
       sender ! Socket.Connected(enumerator, member)
 
@@ -59,11 +59,12 @@ private object Socket {
   case class Member(
       channel: JsChannel,
       userId: Option[String],
+      sameOrigin: Boolean,
       owner: Boolean) extends lila.socket.SocketMember {
     val troll = false
   }
 
-  case class Join(uid: String, userId: Option[String], owner: Boolean)
+  case class Join(uid: String, userId: Option[String], sameOrigin: Boolean, owner: Boolean)
   case class Connected(enumerator: JsEnumerator, member: Member)
 
   case object Reload

--- a/modules/challenge/src/main/SocketHandler.scala
+++ b/modules/challenge/src/main/SocketHandler.scala
@@ -22,9 +22,10 @@ private[challenge] final class SocketHandler(
     challengeId: Challenge.ID,
     uid: String,
     userId: Option[User.ID],
+    sameOrigin: Boolean,
     owner: Boolean): Fu[Option[JsSocketHandler]] = for {
     socket ← socketHub ? Get(challengeId) mapTo manifest[ActorRef]
-    join = Socket.Join(uid = uid, userId = userId, owner = owner)
+    join = Socket.Join(uid = uid, userId = userId, sameOrigin = sameOrigin, owner = owner)
     handler ← Handler(hub, socket, uid, join, userId) {
       case Socket.Connected(enum, member) =>
         (controller(socket, challengeId, uid, member), enum, member)

--- a/modules/chat/src/main/Socket.scala
+++ b/modules/chat/src/main/Socket.scala
@@ -14,12 +14,12 @@ object Socket {
     socket: ActorRef,
     chat: ActorSelection): Handler.Controller = {
 
-    case ("talk", o) => for {
+    case ("talk", o) if member.sameOrigin => for {
       text <- o str "d"
       userId <- member.userId
     } chat ! actorApi.UserTalk(chatId, userId, text)
 
-    case ("timeout", o) => for {
+    case ("timeout", o) if member.sameOrigin => for {
       data ← o obj "d"
       modId <- member.userId
       userId <- data.str("userId")

--- a/modules/lobby/src/main/Socket.scala
+++ b/modules/lobby/src/main/Socket.scala
@@ -53,9 +53,9 @@ private[lobby] final class Socket(
       }
     }
 
-    case Join(uid, user, blocks, mobile) =>
+    case Join(uid, user, sameOrigin, blocks, mobile) =>
       val (enumerator, channel) = Concurrent.broadcast[JsValue]
-      val member = Member(channel, user, blocks, uid, mobile)
+      val member = Member(channel, user, blocks, uid, sameOrigin, mobile)
       addMember(uid, member)
       sender ! Connected(enumerator, member)
 

--- a/modules/lobby/src/main/actorApi.scala
+++ b/modules/lobby/src/main/actorApi.scala
@@ -32,6 +32,7 @@ private[lobby] case class Member(
     channel: JsChannel,
     user: Option[LobbyUser],
     uid: String,
+    sameOrigin: Boolean,
     mobile: Boolean) extends SocketMember {
 
   val userId = user map (_.id)
@@ -40,10 +41,11 @@ private[lobby] case class Member(
 
 private[lobby] object Member {
 
-  def apply(channel: JsChannel, user: Option[User], blocking: Set[String], uid: String, mobile: Boolean): Member = Member(
+  def apply(channel: JsChannel, user: Option[User], blocking: Set[String], uid: String, sameOrigin: Boolean, mobile: Boolean): Member = Member(
     channel = channel,
     user = user map { LobbyUser.make(_, blocking) },
     uid = uid,
+    sameOrigin = sameOrigin,
     mobile = mobile)
 }
 
@@ -64,7 +66,7 @@ private[lobby] case class BiteHook(hookId: String, uid: String, user: Option[Lob
 private[lobby] case class BiteSeek(seekId: String, user: LobbyUser)
 private[lobby] case class JoinHook(uid: String, hook: Hook, game: Game, creatorColor: chess.Color)
 private[lobby] case class JoinSeek(userId: String, seek: Seek, game: Game, creatorColor: chess.Color)
-private[lobby] case class Join(uid: String, user: Option[User], blocking: Set[String], mobile: Boolean)
+private[lobby] case class Join(uid: String, user: Option[User], sameOrigin: Boolean, blocking: Set[String], mobile: Boolean)
 private[lobby] case object Resync
 private[lobby] case class HookIds(ids: Vector[String])
 

--- a/modules/round/src/main/Socket.scala
+++ b/modules/round/src/main/Socket.scala
@@ -141,9 +141,9 @@ private[round] final class Socket(
           blackIsGone = blackIsGone)
       } pipeTo sender
 
-    case Join(uid, user, color, playerId, ip, userTv, apiVersion) =>
+    case Join(uid, user, sameOrigin, color, playerId, ip, userTv, apiVersion) =>
       val (enumerator, channel) = Concurrent.broadcast[JsValue]
-      val member = Member(channel, user, color, playerId, ip, userTv = userTv, apiVersion = apiVersion)
+      val member = Member(channel, user, sameOrigin, color, playerId, ip, userTv = userTv, apiVersion = apiVersion)
       addMember(uid, member)
       notifyCrowd
       playerDo(color, _.ping)

--- a/modules/round/src/main/actorApi.scala
+++ b/modules/round/src/main/actorApi.scala
@@ -33,6 +33,7 @@ object Member {
   def apply(
     channel: JsChannel,
     user: Option[User],
+    sameOrigin: Boolean,
     color: Color,
     playerIdOption: Option[String],
     ip: String,
@@ -40,8 +41,8 @@ object Member {
     apiVersion: ApiVersion): Member = {
     val userId = user map (_.id)
     val troll = user.??(_.troll)
-    playerIdOption.fold[Member](Watcher(channel, userId, color, troll, ip, userTv, apiVersion)) { playerId =>
-      Owner(channel, userId, playerId, color, troll, ip, apiVersion)
+    playerIdOption.fold[Member](Watcher(channel, userId, sameOrigin, color, troll, ip, userTv, apiVersion)) { playerId =>
+      Owner(channel, userId, sameOrigin, playerId, color, troll, ip, apiVersion)
     }
   }
 }
@@ -49,6 +50,7 @@ object Member {
 case class Owner(
     channel: JsChannel,
     userId: Option[String],
+    sameOrigin: Boolean,
     playerId: String,
     color: Color,
     troll: Boolean,
@@ -62,6 +64,7 @@ case class Owner(
 case class Watcher(
     channel: JsChannel,
     userId: Option[String],
+    sameOrigin: Boolean,
     color: Color,
     troll: Boolean,
     ip: String,
@@ -74,6 +77,7 @@ case class Watcher(
 case class Join(
   uid: String,
   user: Option[User],
+  sameOrigin: Boolean,
   color: Color,
   playerId: Option[String],
   ip: String,

--- a/modules/simul/src/main/Socket.scala
+++ b/modules/simul/src/main/Socket.scala
@@ -82,9 +82,9 @@ private[simul] final class Socket(
 
     case Socket.GetUserIds => sender ! userIds
 
-    case Join(uid, user) =>
+    case Join(uid, user, sameOrigin) =>
       val (enumerator, channel) = Concurrent.broadcast[JsValue]
-      val member = Member(channel, user)
+      val member = Member(channel, user, sameOrigin)
       addMember(uid, member)
       notifyCrowd
       sender ! Connected(enumerator, member)

--- a/modules/simul/src/main/SocketHandler.scala
+++ b/modules/simul/src/main/SocketHandler.scala
@@ -23,12 +23,13 @@ private[simul] final class SocketHandler(
   def join(
     simId: String,
     uid: String,
-    user: Option[User]): Fu[Option[JsSocketHandler]] =
+    user: Option[User],
+    sameOrigin: Boolean): Fu[Option[JsSocketHandler]] =
     exists(simId) flatMap {
       _ ?? {
         for {
           socket ← socketHub ? Get(simId) mapTo manifest[ActorRef]
-          join = Join(uid = uid, user = user)
+          join = Join(uid = uid, user = user, sameOrigin = sameOrigin)
           handler ← Handler(hub, socket, uid, join, user map (_.id)) {
             case Connected(enum, member) =>
               (controller(socket, simId, uid, member), enum, member)

--- a/modules/simul/src/main/actorApi.scala
+++ b/modules/simul/src/main/actorApi.scala
@@ -8,12 +8,14 @@ import lila.game.Game
 private[simul] case class Member(
   channel: JsChannel,
   userId: Option[String],
+  sameOrigin: Boolean,
   troll: Boolean) extends SocketMember
 
 private[simul] object Member {
-  def apply(channel: JsChannel, user: Option[User]): Member = Member(
+  def apply(channel: JsChannel, user: Option[User], sameOrigin: Boolean): Member = Member(
     channel = channel,
     userId = user map (_.id),
+    sameOrigin = sameOrigin,
     troll = user.??(_.troll))
 }
 
@@ -21,7 +23,8 @@ private[simul] case class Messadata(trollish: Boolean = false)
 
 private[simul] case class Join(
   uid: String,
-  user: Option[User])
+  user: Option[User],
+  sameOrigin: Boolean)
 private[simul] case class Talk(tourId: String, u: String, t: String, troll: Boolean)
 private[simul] case class StartGame(game: Game, hostId: String)
 private[simul] case class StartSimul(firstGame: Game, hostId: String)

--- a/modules/site/src/main/Socket.scala
+++ b/modules/site/src/main/Socket.scala
@@ -16,9 +16,9 @@ private[site] final class Socket(timeout: Duration) extends SocketActor[Member](
 
   def receiveSpecific = {
 
-    case Join(uid, username, tags) => {
+    case Join(uid, sameOrigin, username, tags) => {
       val (enumerator, channel) = Concurrent.broadcast[JsValue]
-      val member = Member(channel, username, tags)
+      val member = Member(channel, sameOrigin, username, tags)
       addMember(uid, member)
       sender ! Connected(enumerator, member)
     }

--- a/modules/site/src/main/SocketHandler.scala
+++ b/modules/site/src/main/SocketHandler.scala
@@ -17,9 +17,10 @@ private[site] final class SocketHandler(
   def apply(
     uid: String,
     userId: Option[String],
+    sameOrigin: Boolean,
     flag: Option[String]): Fu[JsSocketHandler] = {
 
-    Handler(hub, socket, uid, Join(uid, userId, flag), userId) {
+    Handler(hub, socket, uid, Join(uid, userId, sameOrigin, flag), userId) {
       case Connected(enum, member) => (Handler.emptyController, enum, member)
     }
   }

--- a/modules/site/src/main/actorApi.scala
+++ b/modules/site/src/main/actorApi.scala
@@ -8,6 +8,7 @@ import lila.socket.SocketMember
 case class Member(
   channel: JsChannel,
   userId: Option[String],
+  sameOrigin: Boolean,
   flag: Option[String]) extends SocketMember {
 
   val troll = false
@@ -15,5 +16,5 @@ case class Member(
   def hasFlag(f: String) = flag ?? (f ==)
 }
 
-case class Join(uid: String, userId: Option[String], flag: Option[String])
+case class Join(uid: String, userId: Option[String], sameOrigin: Boolean, flag: Option[String])
 private[site] case class Connected(enumerator: JsEnumerator, member: Member)

--- a/modules/socket/src/main/SocketMember.scala
+++ b/modules/socket/src/main/SocketMember.scala
@@ -5,6 +5,7 @@ import play.api.libs.json.JsValue
 trait SocketMember extends Ordered[SocketMember] {
 
   protected val channel: JsChannel
+  val sameOrigin: Boolean
   val userId: Option[String]
   val troll: Boolean
 
@@ -23,10 +24,11 @@ trait SocketMember extends Ordered[SocketMember] {
 
 object SocketMember {
 
-  def apply(c: JsChannel): SocketMember = apply(c, none, false)
+  def apply(c: JsChannel, sameOrigin: Boolean): SocketMember = apply(c, sameOrigin, none, false)
 
-  def apply(c: JsChannel, uid: Option[String], tr: Boolean): SocketMember = new SocketMember {
+  def apply(c: JsChannel, so: Boolean, uid: Option[String], tr: Boolean): SocketMember = new SocketMember {
     val channel = c
+    val sameOrigin = so
     val userId = uid
     val troll = tr
   }

--- a/modules/study/src/main/Socket.scala
+++ b/modules/study/src/main/Socket.scala
@@ -134,10 +134,10 @@ private final class Socket(
 
     case GetVersion => sender ! history.version
 
-    case Socket.Join(uid, userId, troll, owner) =>
+    case Socket.Join(uid, userId, sameOrigin, troll, owner) =>
       import play.api.libs.iteratee.Concurrent
       val (enumerator, channel) = Concurrent.broadcast[JsValue]
-      val member = Socket.Member(channel, userId, troll = troll, owner = owner)
+      val member = Socket.Member(channel, userId, sameOrigin = sameOrigin, troll = troll, owner = owner)
       addMember(uid.value, member)
       notifyCrowd
       sender ! Socket.Connected(enumerator, member)
@@ -208,6 +208,7 @@ private object Socket {
   case class Member(
     channel: JsChannel,
     userId: Option[String],
+    sameOrigin: Boolean,
     troll: Boolean,
     owner: Boolean) extends lila.socket.SocketMember
 
@@ -215,7 +216,7 @@ private object Socket {
   import JsonView.uidWriter
   implicit private val whoWriter = Json.writes[Who]
 
-  case class Join(uid: Uid, userId: Option[User.ID], troll: Boolean, owner: Boolean)
+  case class Join(uid: Uid, userId: Option[User.ID], sameOrigin: Boolean, troll: Boolean, owner: Boolean)
   case class Connected(enumerator: JsEnumerator, member: Member)
 
   case class ReloadUid(uid: Uid)

--- a/modules/study/src/main/SocketHandler.scala
+++ b/modules/study/src/main/SocketHandler.scala
@@ -240,9 +240,10 @@ private[study] final class SocketHandler(
     studyId: Study.ID,
     uid: Uid,
     user: Option[User],
+    sameOrigin: Boolean,
     owner: Boolean): Fu[Option[JsSocketHandler]] = for {
     socket ← socketHub ? Get(studyId) mapTo manifest[ActorRef]
-    join = Socket.Join(uid = uid, userId = user.map(_.id), troll = user.??(_.troll), owner = owner)
+    join = Socket.Join(uid = uid, userId = user.map(_.id), sameOrigin = sameOrigin, troll = user.??(_.troll), owner = owner)
     handler ← Handler(hub, socket, uid.value, join, user.map(_.id)) {
       case Socket.Connected(enum, member) =>
         (controller(socket, studyId, uid, member, owner = owner), enum, member)

--- a/modules/tournament/src/main/Socket.scala
+++ b/modules/tournament/src/main/Socket.scala
@@ -78,9 +78,9 @@ private[tournament] final class Socket(
 
     case GetVersion => sender ! history.version
 
-    case Join(uid, user) =>
+    case Join(uid, user, sameOrigin) =>
       val (enumerator, channel) = Concurrent.broadcast[JsValue]
-      val member = Member(channel, user)
+      val member = Member(channel, user, sameOrigin)
       addMember(uid, member)
       notifyCrowd
       sender ! Connected(enumerator, member)

--- a/modules/tournament/src/main/SocketHandler.scala
+++ b/modules/tournament/src/main/SocketHandler.scala
@@ -24,12 +24,13 @@ private[tournament] final class SocketHandler(
   def join(
     tourId: String,
     uid: String,
-    user: Option[User]): Fu[Option[JsSocketHandler]] =
+    user: Option[User],
+    sameOrigin: Boolean): Fu[Option[JsSocketHandler]] =
     TournamentRepo.exists(tourId) flatMap {
       _ ?? {
         for {
           socket ← socketHub ? Get(tourId) mapTo manifest[ActorRef]
-          join = Join(uid = uid, user = user)
+          join = Join(uid = uid, user = user, sameOrigin = sameOrigin)
           handler ← Handler(hub, socket, uid, join, user map (_.id)) {
             case Connected(enum, member) =>
               (controller(socket, tourId, uid, member), enum, member)

--- a/modules/tournament/src/main/actorApi.scala
+++ b/modules/tournament/src/main/actorApi.scala
@@ -8,12 +8,14 @@ import lila.user.User
 private[tournament] case class Member(
   channel: JsChannel,
   userId: Option[String],
+  sameOrigin: Boolean,
   troll: Boolean) extends SocketMember
 
 private[tournament] object Member {
-  def apply(channel: JsChannel, user: Option[User]): Member = Member(
+  def apply(channel: JsChannel, user: Option[User], sameOrigin: Boolean): Member = Member(
     channel = channel,
     userId = user map (_.id),
+    sameOrigin = sameOrigin,
     troll = user.??(_.troll))
 }
 
@@ -21,7 +23,8 @@ private[tournament] case class Messadata(trollish: Boolean = false)
 
 private[tournament] case class Join(
   uid: String,
-  user: Option[User])
+  user: Option[User],
+  sameOrigin: Boolean)
 private[tournament] case class Talk(tourId: String, u: String, t: String, troll: Boolean)
 private[tournament] case object Reload
 private[tournament] case class StartGame(game: Game)


### PR DESCRIPTION
Since the recent CSRF patch all cross site websockets are downgraded to anonymous. This prevents the really bad stuff, but leaves a couple of gaps. This is an attempt to add finegrained checks in the socket handlers.

If we're gonna keep the logging, we can call CSRFRequestHandler.check() only once per request, so I added the result to the context. Might be a bit intrusive.

---

An alternative might be to completely deny cross site access to all existing socket endpoints and add a new websocket (api) endpoint that can (only) observe all the stuff.