### PR TITLE
Forum edit improvements

### DIFF
--- a/app/views/forum/topic/show.scala.html
+++ b/app/views/forum/topic/show.scala.html
@@ -39,8 +39,8 @@ description = shorten(posts.currentPageResults.headOption.??(_.text).replace("\n
         @authorLink(post, "author".some)
 
         @if(post.hasEdits) {
+          <span class="post-edited">edited</span>
           @momentFromNow(post.updatedAt)
-          <span class="post-edited"> - Edited</span>
         } else {
           @momentFromNow(post.createdAt)
         }
@@ -61,8 +61,10 @@ description = shorten(posts.currentPageResults.headOption.??(_.text).replace("\n
       @if(ctx.userId.fold(false)(post.canBeEditedByNow(_))) {
       <form class="edit-post-form" method="post" action="@routes.ForumPost.edit(post.id)">
         <textarea name="changes" class="edit-post-box" minlength="3">@post.text</textarea>
-        <button type="submit" class="submit button">@trans.apply()</button>
-        <a class="edit-post-cancel" href="@routes.ForumPost.redirect(post.id)" style="margin-left:20px">@trans.cancel()</a>
+        <div class="edit-buttons">
+          <a class="edit-post-cancel" href="@routes.ForumPost.redirect(post.id)" style="margin-left:20px">@trans.cancel()</a>
+          <button type="submit" class="submit button">@trans.apply()</button>
+        </div>
       </form>
       }
     </div>

--- a/app/views/forum/topic/show.scala.html
+++ b/app/views/forum/topic/show.scala.html
@@ -50,16 +50,14 @@ description = shorten(posts.currentPageResults.headOption.??(_.text).replace("\n
         @if(isGranted(_.IpBan)) {
         <span class="mod postip">@post.ip</span>
         }
+        @if(ctx.userId.fold(false)(post.canBeEditedByNow(_))) {
+        <a class="mod thin edit button" onclick="editForumPost('@post.id', @post.number)" data-icon="m"> Edit</a>
+        }
         @if(isGrantedMod(categ.slug)) {
         <a class="mod thin delete button" href="@routes.ForumPost.delete(categ.slug, post.id)" data-icon="q"> Delete</a>
         }
       </div>
       <p class="message">@autoLink(post.text)</p>
-      @if(ctx.userId.fold(false)(post.canBeEditedBy(_)) && post.canStillBeEdited) {
-      <div class="edit-buttons">
-        <a class="mod" id="edit-button-@post.number" data-icon="r" onclick="editForumPost('@post.id', @post.number)">Edit</a>
-      </div>
-      }
     </div>
     }
   </div>

--- a/app/views/forum/topic/show.scala.html
+++ b/app/views/forum/topic/show.scala.html
@@ -60,7 +60,7 @@ description = shorten(posts.currentPageResults.headOption.??(_.text).replace("\n
       <p class="message">@autoLink(post.text)</p>
       @if(ctx.userId.fold(false)(post.shouldShowEditForm(_))) {
       <form class="edit-post-form" method="post" action="@routes.ForumPost.edit(post.id)">
-        <textarea name="changes" class="edit-post-box" minlength="3">@post.text</textarea>
+        <textarea name="changes" class="edit-post-box" minlength="3" required>@post.text</textarea>
         <div class="edit-buttons">
           <a class="edit-post-cancel" href="@routes.ForumPost.redirect(post.id)" style="margin-left:20px">@trans.cancel()</a>
           <button type="submit" class="submit button">@trans.apply()</button>

--- a/app/views/forum/topic/show.scala.html
+++ b/app/views/forum/topic/show.scala.html
@@ -51,13 +51,20 @@ description = shorten(posts.currentPageResults.headOption.??(_.text).replace("\n
         <span class="mod postip">@post.ip</span>
         }
         @if(ctx.userId.fold(false)(post.canBeEditedByNow(_))) {
-        <a class="mod thin edit button" onclick="editForumPost('@post.id', @post.number)" data-icon="m"> Edit</a>
+        <a class="mod thin edit button" data-icon="m"> Edit</a>
         }
         @if(isGrantedMod(categ.slug)) {
         <a class="mod thin delete button" href="@routes.ForumPost.delete(categ.slug, post.id)" data-icon="q"> Delete</a>
         }
       </div>
       <p class="message">@autoLink(post.text)</p>
+      @if(ctx.userId.fold(false)(post.canBeEditedByNow(_))) {
+      <form class="edit-post-form" method="post" action="@routes.ForumPost.edit(post.id)">
+        <textarea name="changes" class="edit-post-box" minlength="3">@post.text</textarea>
+        <button type="submit" class="submit button">@trans.apply()</button>
+        <a class="edit-post-cancel" href="@routes.ForumPost.redirect(post.id)" style="margin-left:20px">@trans.cancel()</a>
+      </form>
+      }
     </div>
     }
   </div>

--- a/app/views/forum/topic/show.scala.html
+++ b/app/views/forum/topic/show.scala.html
@@ -50,7 +50,7 @@ description = shorten(posts.currentPageResults.headOption.??(_.text).replace("\n
         @if(isGranted(_.IpBan)) {
         <span class="mod postip">@post.ip</span>
         }
-        @if(ctx.userId.fold(false)(post.canBeEditedByNow(_))) {
+        @if(ctx.userId.fold(false)(post.shouldShowEditForm(_))) {
         <a class="mod thin edit button" data-icon="m"> Edit</a>
         }
         @if(isGrantedMod(categ.slug)) {
@@ -58,7 +58,7 @@ description = shorten(posts.currentPageResults.headOption.??(_.text).replace("\n
         }
       </div>
       <p class="message">@autoLink(post.text)</p>
-      @if(ctx.userId.fold(false)(post.canBeEditedByNow(_))) {
+      @if(ctx.userId.fold(false)(post.shouldShowEditForm(_))) {
       <form class="edit-post-form" method="post" action="@routes.ForumPost.edit(post.id)">
         <textarea name="changes" class="edit-post-box" minlength="3">@post.text</textarea>
         <div class="edit-buttons">

--- a/modules/forum/src/main/Post.scala
+++ b/modules/forum/src/main/Post.scala
@@ -39,7 +39,10 @@ case class Post(
     updatedAt.plus(permitEditsFor.toMillis).isAfter(DateTime.now)
   }
 
-  def canBeEditedBy(editingId: String) : Boolean = userId.fold(false)(editingId == _)
+  def canBeEditedBy(editingId: String): Boolean = userId.fold(false)(editingId == _)
+
+  def canBeEditedByNow(editingId: String) =
+    canBeEditedBy(editingId) && canStillBeEdited
 
   def editPost(updated: DateTime, newText: String) : Post = {
     val oldVersion = new OldVersion(text, updatedAt)

--- a/modules/forum/src/main/Post.scala
+++ b/modules/forum/src/main/Post.scala
@@ -23,7 +23,8 @@ case class Post(
     createdAt: DateTime,
     updatedAt: DateTime) {
 
-  private val permitEditsFor = 3 hours
+  private val permitEditsFor = 4 hours
+  private val showEditFormFor = 3 hours
 
   def id = _id
 
@@ -41,8 +42,8 @@ case class Post(
 
   def canBeEditedBy(editingId: String): Boolean = userId.fold(false)(editingId == _)
 
-  def canBeEditedByNow(editingId: String) =
-    canBeEditedBy(editingId) && canStillBeEdited
+  def shouldShowEditForm(editingId: String) =
+    canBeEditedBy(editingId) && updatedAt.plus(showEditFormFor.toMillis).isAfter(DateTime.now)
 
   def editPost(updated: DateTime, newText: String) : Post = {
     val oldVersion = new OldVersion(text, updatedAt)

--- a/public/javascripts/forum-post.js
+++ b/public/javascripts/forum-post.js
@@ -1,8 +1,12 @@
 $(function () {
   $('.edit.button').add('.edit-post-cancel').click(function(e) {
     e.preventDefault();
+
     var post = $(this).closest('.post');
-    post.find('.message').toggle();
-    post.find('form.edit-post-form').toggle()[0].reset();
+    var message = post.find('.message').toggle();
+    var form = post.find('form.edit-post-form').toggle();
+
+    form[0].reset();
+    form.find('textarea').height(message.height());
   });
 });

--- a/public/javascripts/forum-post.js
+++ b/public/javascripts/forum-post.js
@@ -1,46 +1,8 @@
-
-// Map of old post contents by post number in case the user clicks 'edit' on multiple posts
-// on the same page (although rare.)
-var oldContents = {};
-
-var editForumPost = function(postId, postNumber) {
-    var postSelector = $("#" + postNumber);
-
-    // We grab the text element of the post and turn it into a textarea to make it editable
-    oldContents[postNumber] = postSelector.find(".message");
-
-    var old = oldContents[postNumber];
-
-    var postContents = old.text();
-
-    var editForm = $('<form>', {
-                                id: 'post-edit-form-' + postNumber,
-                                method: 'POST',
-                                action:"/forum/post/" + postId
-                                });
-
-    var formTextArea = $('<textarea>', {
-                                        id:'post-edit-area-' + postNumber,
-                                        name:"changes",
-                                        class:'edit-post-box',
-                                        'minlength': 3
-                                        });
-    formTextArea.text(postContents);
-
-    var formSubmitButton = $('<input>', {type:'submit', value: 'Submit'});
-    var formCancelButton = $('<a>', {'data-icon':'s', onclick:'cancelEdit(' + postNumber + ')' }).text("Cancel");
-
-    editForm.append(formTextArea);
-    editForm.append(formSubmitButton);
-    editForm.append(formCancelButton);
-
-    old.replaceWith(editForm);
-
-    $("#edit-button-" + postNumber).hide();
-};
-
-var cancelEdit = function(postNumber) {
-    $('#post-edit-form-' + postNumber).replaceWith(oldContents[postNumber]);
-
-    $("#edit-button-" + postNumber).show();
-}
+$(function () {
+  $('.edit.button').add('.edit-post-cancel').click(function(e) {
+    e.preventDefault();
+    var post = $(this).closest('.post');
+    post.find('.message').toggle();
+    post.find('form.edit-post-form').toggle()[0].reset();
+  });
+});

--- a/public/stylesheets/forum.css
+++ b/public/stylesheets/forum.css
@@ -201,6 +201,10 @@ div.post a.post-edited {
     float: left;
 }
 
+.edit-post-form {
+  display: none;
+}
+
 div.post .button-hidden {
     display: none;
 }

--- a/public/stylesheets/forum.css
+++ b/public/stylesheets/forum.css
@@ -183,30 +183,28 @@ div.post .message {
   line-height: 1.5em;
 }
 
-div.post .edit-buttons {
-    float: right;
-}
-
-div.post .edit-post-box {
-    width: 100%;
-    height: 250px;
-}
-
-div.post a.post-edited {
-    font-size: 0.8em;
-    font-style: bold;
-    color: #aaa;
-    margin-top: 0.3em;
-    margin-left: 1em;
-    float: left;
-}
-
-.edit-post-form {
+form.edit-post-form {
   display: none;
+  margin-top: 1.5em;
 }
-
-div.post .button-hidden {
-    display: none;
+form.edit-post-form textarea {
+  width: 728px;
+  border: 1px solid #D4D4D4;
+  padding: 0.5em;
+}
+div.post .edit-buttons {
+  text-align: right;
+  margin-top: 0.5em;
+}
+div.post .edit-buttons a {
+  margin-right: 1em;
+}
+div.post .post-edited {
+  font-size: 0.8em;
+  color: #aaa;
+  margin-top: 0.3em;
+  margin-left: 1em;
+  float: left;
 }
 
 div.topicReply,


### PR DESCRIPTION
Some follow up improvements for forum post editing /cc @Happy0 

Most importantly allow users to edit their original raw text. (Currently line breaks will be dropped from the text when opening the edit form.) This is done by rendering hidden forms on the server side.

A couple of CSS and styling improvements included also.