### PR TITLE
IPv6 support

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -18,6 +18,7 @@ object Global extends GlobalSettings {
 
   override def onRouteRequest(req: RequestHeader): Option[Handler] = {
     lila.mon.http.request.all()
+    if (req.remoteAddress contains ":") lila.mon.http.request.ipv6()
     Env.i18n.requestHandler(req) orElse super.onRouteRequest(req)
   }
 

--- a/modules/common/src/main/mon.scala
+++ b/modules/common/src/main/mon.scala
@@ -270,6 +270,7 @@ object mon {
     object selector {
       val count = inc("puzzle.selector")
       val time = rec("puzzle.selector")
+      val vote = rec("puzzle.selector.vote") // vote sum of selected puzzle
     }
     object attempt {
       val user = inc("puzzle.attempt.user")

--- a/modules/common/src/main/mon.scala
+++ b/modules/common/src/main/mon.scala
@@ -11,6 +11,7 @@ object mon {
   object http {
     object request {
       val all = inc("http.request.all")
+      val ipv6 = inc("http.request.ipv6")
     }
     object response {
       val code400 = inc("http.response.4.00")

--- a/modules/puzzle/src/main/Selector.scala
+++ b/modules/puzzle/src/main/Selector.scala
@@ -43,7 +43,11 @@ private[puzzle] final class Selector(
           tryRange(rating, step, step, difficultyDecay(difficulty), ids, isMate)
         }
     }
-  }.mon(_.puzzle.selector.time)
+  }.mon(_.puzzle.selector.time) addEffect {
+    _ foreach { puzzle =>
+      lila.mon.puzzle.selector.vote(puzzle.vote.sum)
+    }
+  }
 
   private def toleranceStepFor(rating: Int) =
     math.abs(1500 - rating) match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,6 @@ object Dependencies {
     val typesafe = "typesafe.com" at "http://repo.typesafe.com/typesafe/releases/"
     val sonatype = "sonatype" at "https://oss.sonatype.org/content/repositories/releases"
     // val sonatypeS = "sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
-    val t2v = "t2v.jp repo" at "http://www.t2v.jp/maven-repo/"
     val jgitMaven = "jgit-maven" at "http://download.eclipse.org/jgit/maven"
     val awesomepom = "awesomepom" at "https://raw.github.com/jibs/maven-repo-scala/master"
     val sprayRepo = "spray repo" at "http://repo.spray.io"
@@ -22,7 +21,8 @@ object Dependencies {
       awesomepom,
       typesafe,
       prismic,
-      t2v, jgitMaven, sprayRepo)
+      jgitMaven,
+      sprayRepo)
   }
 
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.9"


### PR DESCRIPTION
Should be good to go.

---

Just working:

* Tor.isExitNode
* Geo IP lookup
* ipintel
* Log on profile

Support added in:

* [X] lila.security.Firewall
* [X] lila.mod.UserSearch

We only ever have to deal with addresses in their standard form, no compressed addresses (like ::1), no leading zeros in components (like 0:0:0:0000:0:0:0:0).

/ref lichess-org/sysadmin#20