### PR TITLE
Allow filling in the import form via GET

### DIFF
--- a/app/controllers/Importer.scala
+++ b/app/controllers/Importer.scala
@@ -9,9 +9,11 @@ object Importer extends LilaController {
 
   private def env = Env.importer
 
-  def importGame = Open { implicit ctx =>
+  def importGame = OpenBody { implicit ctx =>
     fuccess {
-      Ok(html.game.importGame(env.forms.importForm))
+      val pgn = ctx.body.queryString.get("pgn").flatMap(_.headOption).getOrElse("")
+      val data = lila.importer.ImportData(pgn, None)
+      Ok(html.game.importGame(env.forms.importForm.fill(data)))
     }
   }
 


### PR DESCRIPTION
One legit use case that popped up in the CSRF logs: http://spawk.fish/play/ allows to import a game. Proposed solution: Allow filling in the form via a GET parameter (but let the user confirm the submission).