### PR TITLE
reintegrate Opening resource into topmenu view's 'Learn' dropdown

### DIFF
--- a/app/views/base/topmenu.scala.html
+++ b/app/views/base/topmenu.scala.html
@@ -15,6 +15,7 @@
       <a href="@routes.Learn.index">Chess basics</a>
       <a href="@routes.Puzzle.home">@trans.training()</a>
       <a href="@routes.Coordinate.home">@trans.coordinates()</a>
+      <a href="@routes.Opening.home">@trans.opening()</a>
       <a href="@routes.Study.allDefault(1)">Study</a>
       <a href="@routes.Coach.allDefault(1)">Chess coaches</a>
     </div>


### PR DESCRIPTION
Noticed that `/training/opening` is still a live resource, but is no longer included in the `topmenu` view. I'm making a big assumption that this isn't intentional, but figured i'd put in a quick PR in the event that it was an oversight.

As this is my first PR/contrib to Lichess, feel free to let me me know if I can better adhere to contrib protocols going forward (branch naming conventions, mentions, always preceding a PR with an issue, etc.)
