### PR TITLE
Sunsetter: use analyze mode

### DIFF
--- a/ui/analyse/src/ceval/sunsetterProtocol.js
+++ b/ui/analyse/src/ceval/sunsetterProtocol.js
@@ -16,37 +16,35 @@ module.exports = function(worker, opts) {
     }
     if (!work) return;
 
-    var depth, cp, mate, best, pv;
-
     var matches = text.match(/^(\d+) ([-+]?\d+) \d+ \d+ (.*)$/);
     if (matches) {
-      depth = parseInt(matches[1], 10);
-      cp = parseInt(matches[2], 10);
-      pv = matches[3];
-      best = pv.split(' ')[0];
-    }
+      var depth = parseInt(matches[1], 10);
+      var cp = parseInt(matches[2], 10);
+      var pv = matches[3].trim();
+      var best = pv.split(' ')[0];
 
-    // transform mate scores
-    if (Math.abs(cp) > 20000) {
-      mate = Math.sign(cp) * Math.floor(30000 - Math.abs(cp));
-      cp = undefined;
-    }
+      // transform mate scores
+      if (Math.abs(cp) > 20000) {
+        var mate = Math.sign(cp) * Math.floor(30000 - Math.abs(cp));
+        cp = undefined;
+      }
 
-    work.emit({
-      work: work,
-      eval: {
-        depth: depth,
-        cp: cp,
-        mate: mate,
-        best: best,
-        pvs: [{
+      work.emit({
+        work: work,
+        eval: {
+          depth: depth,
           cp: cp,
           mate: mate,
           best: best,
-          pv: pv
-        }]
-      }
-    });
+          pvs: [{
+            cp: cp,
+            mate: mate,
+            best: best,
+            pv: pv
+          }]
+        }
+      });
+    }
   };
 
   return {

--- a/ui/analyse/src/ceval/sunsetterProtocol.js
+++ b/ui/analyse/src/ceval/sunsetterProtocol.js
@@ -10,7 +10,6 @@ module.exports = function(worker, opts) {
   worker.send('reset crazyhouse');
 
   var processOutput = function(text) {
-    // console.warn("<-- %s", text);
     if (text === 'tellics stopped') {
       if (stopped) stopped.resolve(true);
       return;
@@ -65,9 +64,6 @@ module.exports = function(worker, opts) {
       if (!stopped) {
         stopped = m.deferred();
         work = null;
-        aiMoves = 0;
-        best = undefined;
-        pv = undefined;
         worker.send('exit');
         worker.send('tellics stopped');
       }


### PR DESCRIPTION
Switch sunsetter to analyze mode. This fixes a number
of issues and improves analysis strength. Also fix
the parsing of Sunsetter 9 mate score.

Possible further improvements, pending engine changes:
- Can we use currentFen instead of initialFen + moves?
  One blocker on this: georgvonzimmermann/Sunsetter#11
- Mate *much* better, but off by 1/2 move.
  georgvonzimmermann/Sunsetter#9
- Use set depth 'sd' option. Blocked by bugs such as
  georgvonzimmermann/Sunsetter#10