### PR TITLE
Switch from Fathom to tbserve

### DIFF
--- a/ui/analyse/src/explorer/explorerCtrl.js
+++ b/ui/analyse/src/explorer/explorerCtrl.js
@@ -9,8 +9,7 @@ var replayable = require('game').game.replayable;
 function tablebaseRelevant(fen) {
   var parts = fen.split(/\s/);
   var pieceCount = parts[0].split(/[nbrqkp]/i).length - 1;
-  var castling = parts[2];
-  return pieceCount <= 6 && castling === '-';
+  return pieceCount <= 7;
 }
 
 module.exports = function(root, opts, allow) {
@@ -58,7 +57,7 @@ module.exports = function(root, opts, allow) {
   }, false);
 
   var fetchTablebase = throttle(250, function(fen) {
-    xhr.tablebase(opts.tablebaseEndpoint, root.vm.node.fen).then(function(res) {
+    xhr.tablebase(opts.tablebaseEndpoint, effectiveVariant, root.vm.node.fen).then(function(res) {
       res.nbMoves = res.moves.length;
       res.tablebase = true;
       res.fen = fen;

--- a/ui/analyse/src/explorer/explorerView.js
+++ b/ui/analyse/src/explorer/explorerView.js
@@ -204,19 +204,22 @@ function show(ctrl) {
     var moves = data.moves;
     if (moves.length) lastShow = m('div.data', [
       showTablebase(ctrl, 'Winning', moves.filter(function(move) {
-        return move.real_wdl === -2;
+        return move.wdl === -2;
+      }), data.fen),
+      showTablebase(ctrl, 'Unknown', moves.filter(function(move) {
+        return move.wdl === null;
       }), data.fen),
       showTablebase(ctrl, 'Win prevented by 50-move rule', moves.filter(function(move) {
-        return move.real_wdl === -1;
+        return move.wdl === -1;
       }), data.fen),
       showTablebase(ctrl, 'Drawn', moves.filter(function(move) {
-        return move.real_wdl === 0;
+        return move.wdl === 0;
       }), data.fen),
       showTablebase(ctrl, 'Loss saved by 50-move rule', moves.filter(function(move) {
-        return move.real_wdl === 1;
+        return move.wdl === 1;
       }), data.fen),
       showTablebase(ctrl, 'Losing', moves.filter(function(move) {
-        return move.real_wdl === 2;
+        return move.wdl === 2;
       }), data.fen)
     ])
     else if (data.checkmate) lastShow = showGameEnd(ctrl, 'Checkmate')

--- a/ui/analyse/src/explorer/openingXhr.js
+++ b/ui/analyse/src/explorer/openingXhr.js
@@ -25,11 +25,11 @@ module.exports = {
       data: params
     });
   },
-  tablebase: function(endpoint, fen) {
+  tablebase: function(endpoint, variant, fen) {
     return m.request({
       background: true,
       method: 'GET',
-      url: endpoint,
+      url: endpoint + '/' + variant,
       data: {
         fen: fen
       }


### PR DESCRIPTION
I have rewritten the tablebase server based on @ddugovic's Stockfish: https://github.com/niklasf/tbserve

New:

* It can show transitions from 7 piece endgames and endgames with castling rights
* Support for atomic tablebases (not yet enabled, still generating the tables on my private server)
* Preperations for suicide tablebase support

expl.lichess.org is already configured. The new endpoint is https://expl.lichess.org/tablebase/standard (base.conf does not change, variant appended dynamically) instead of https://expl.lichess.org/tablebase. Once lila is updated I can remove the old endpoint.