### PR TITLE
Add source to UserGameApi JSON

### DIFF
--- a/modules/api/src/main/UserGameApi.scala
+++ b/modules/api/src/main/UserGameApi.scala
@@ -35,7 +35,7 @@ final class UserGameApi(bookmarkApi: lila.bookmark.BookmarkApi) {
     "correspondence" -> g.daysPerTurn.map { d =>
       Json.obj("daysPerTurn" -> d)
     },
-    "opening" -> g.opening,
+    "source" -> g.source.map(_.name),
     "players" -> JsObject(g.players map { p =>
       p.color.name -> Json.obj(
         "userId" -> p.userId,


### PR DESCRIPTION
(and remove duplicate `opening` field)

It would be nice to have players title as well, for the coherence with the website and the rest of the app. But I leave that to you since user infos are not yet present in this api.