### PR TITLE
fix syntactical error in coordinate.css

### DIFF
--- a/public/stylesheets/coordinate.css
+++ b/public/stylesheets/coordinate.css
@@ -86,9 +86,9 @@ form.color .color_3 i {
   font-size: 30px;
   opacity: 0.4;
 }
+#trainer #next_coord1,
+#trainer #next_coord2,
 #trainer #next_coord0 {
-  #trainer #next_coord1,
-  #trainer #next_coord2,
   -webkit-user-select: none;
   -moz-user-select: none;
 }


### PR DESCRIPTION
Tested with http://csslint.net
File: https://lichess1.org/assets/stylesheets/coordinate.css?v=1239

![](https://i.imgur.com/spUNS5a.png)