### PR TITLE
Advanced search: 45 min / 45 sec increment options in clock dropdown menus.

### DIFF
--- a/modules/gameSearch/src/main/Query.scala
+++ b/modules/gameSearch/src/main/Query.scala
@@ -75,10 +75,10 @@ object Query {
     (0, "0 seconds"),
     (30, "30 seconds"),
     (45, "45 seconds")
-  ) ::: options(List(60 * 1, 60 * 2, 60 * 3, 60 * 5, 60 * 10, 60 * 15, 60 * 20, 60 * 30, 60 * 60, 60 * 90, 60 * 120, 60 * 150, 60 * 180), _ / 60, "%d minute{s}").toList
+  ) ::: options(List(60 * 1, 60 * 2, 60 * 3, 60 * 5, 60 * 10, 60 * 15, 60 * 20, 60 * 30, 60 * 45, 60 * 60, 60 * 90, 60 * 120, 60 * 150, 60 * 180), _ / 60, "%d minute{s}").toList
 
   val clockIncs =
-    options(List(0, 1, 2, 3, 5, 10, 15, 20, 30, 60, 90, 120, 150, 180), "%d second{s}").toList
+    options(List(0, 1, 2, 3, 5, 10, 15, 20, 30, 45, 60, 90, 120, 150, 180), "%d second{s}").toList
 
   val winnerColors = List(1 -> "White", 2 -> "Black", 3 -> "None")
 


### PR DESCRIPTION
I was curious about how many games with the 45 min / 45 sec increment clock settings had been played on the site and what their durations were.

I noticed that you can't currently ask about such games in the advanced search view.