### PR TITLE
Increase relation onlinePlayings expiry

### DIFF
--- a/modules/relation/src/main/RelationActor.scala
+++ b/modules/relation/src/main/RelationActor.scala
@@ -22,7 +22,7 @@ private[relation] final class RelationActor(
 
   private var onlines = Map[ID, LightUser]()
 
-  private val onlinePlayings = new ExpireSetMemo(1 hour)
+  private val onlinePlayings = new ExpireSetMemo(4 hour)
 
   override def preStart(): Unit = {
     context.system.lilaBus.subscribe(self, 'startGame)


### PR DESCRIPTION
Sometimes when people are playing 45/45 games the green TV on the friends list disappears as the game duration goes beyond an hour.

This pull request increases the expiry time so that this is very unlikely to happen.