### PR TITLE
remove tournament schedule holes

### DIFF
--- a/ui/tournamentSchedule/src/view.js
+++ b/ui/tournamentSchedule/src/view.js
@@ -82,27 +82,6 @@ function splitOverlaping(lanes) {
   return ret;
 }
 
-// Tries to compress lanes by moving tours
-// upwards until it hits another tournament.
-// Should not bubble past existing ones.
-function bubbleUp(lanes, tours) {
-  var returnLanes = lanes.concat([]);
-  tours.forEach(function(tour) {
-    var i = returnLanes.length - 1;
-    while (i >= 0) {
-      if (!fitLane(returnLanes[i], tour))
-        break;
-      i--;
-    }
-    if (i + 1 >= returnLanes.length) {
-      returnLanes.push([tour]);
-    } else {
-      returnLanes[i + 1].push(tour);
-    }
-  });
-  return returnLanes;
-}
-
 function tournamentClass(tour) {
   var classes = [
     'tournament',
@@ -225,7 +204,7 @@ module.exports = function(ctrl) {
 
   // group system tournaments into dedicated lanes for PerfType
   var tourLanes = splitOverlaping(
-    bubbleUp(group(ctrl.data.systemTours, laneGrouper), ctrl.data.userTours));
+    group(ctrl.data.systemTours, laneGrouper).concat([ctrl.data.userTours]));
 
   return m('div.schedule.dragscroll', {
     config: function(el, isUpdate) {


### PR DESCRIPTION
As usual there was too much code in the code.
All userTours are put into the same lane now,
and uses same splitOverlaping as systemTours.

## Example 1, Before
![2016-12-03-013452_818x898_scrot](https://cloud.githubusercontent.com/assets/81471/20855105/f6618712-b8f9-11e6-9c80-85351f509703.png)
### After
![2016-12-03-013518_807x821_scrot](https://cloud.githubusercontent.com/assets/81471/20855112/01bb5386-b8fa-11e6-8d7a-448390587ba6.png)

## Example 2, Before
![2016-12-03-013718_802x818_scrot](https://cloud.githubusercontent.com/assets/81471/20855114/05ca47d4-b8fa-11e6-9271-275cc0aa7dc7.png)
### After
![2016-12-03-013737_800x676_scrot](https://cloud.githubusercontent.com/assets/81471/20855116/0a06d4b6-b8fa-11e6-94b5-857db55ce253.png)
