### PR TITLE
Clean up crazyhouse drop preview

### DIFF
--- a/public/stylesheets/board.css
+++ b/public/stylesheets/board.css
@@ -613,10 +613,10 @@ body.piece_letter .lichess_ground .replay move {
 }
 .pocket.usable piece {
   cursor: pointer;
-  transition: background-color 0.13s;
 }
 .pocket.usable piece:hover {
   background-color: #999;
+  transition: background-color 0.13s;
 }
 .pocket.usable piece[data-premove=true] {
   background-color: #555;

--- a/public/stylesheets/board.css
+++ b/public/stylesheets/board.css
@@ -618,7 +618,7 @@ body.piece_letter .lichess_ground .replay move {
 .pocket.usable piece:hover {
   background-color: #999;
 }
-.pocket piece[data-premove=true] {
+.pocket.usable piece[data-premove=true] {
   background-color: #555;
 }
 .pocket.usable piece:hover[data-premove=true] {

--- a/public/stylesheets/board.css
+++ b/public/stylesheets/board.css
@@ -618,6 +618,12 @@ body.piece_letter .lichess_ground .replay move {
 .pocket.usable piece:hover {
   background-color: #999;
 }
+.pocket piece[data-premove=true] {
+  background-color: #555;
+}
+.pocket.usable piece:hover[data-premove=true] {
+  background-color: #666;
+}
 .pocket piece[data-nb='0'] {
   cursor: auto;
   opacity: 0.1;

--- a/ui/round/src/crazy/crazyView.js
+++ b/ui/round/src/crazy/crazyView.js
@@ -11,7 +11,8 @@ module.exports = {
   pocket: function(ctrl, color, position) {
     var step = round.plyStep(ctrl.data, ctrl.vm.ply);
     if (!step.crazy) return;
-    var dropped = ctrl.vm.justDropped;
+    var droppedRole = ctrl.vm.justDropped;
+    var preDropRole = ctrl.vm.preDrop;
     var pocket = step.crazy.pockets[color === 'white' ? 0 : 1];
     var usablePos = position == (ctrl.vm.flip ? 'top' : 'bottom');
     var usable = usablePos && !ctrl.replaying() && game.isPlayerPlaying(ctrl.data);
@@ -33,11 +34,12 @@ module.exports = {
       },
       pieceRoles.map(function(role) {
         var nb = pocket[role] || 0;
-        if (dropped && dropped.role === role && dropped.ply === ctrl.vm.ply && (dropped.ply % 2 === 1) ^ (color === 'white')) nb--;
+        if (color === ctrl.data.player.color && droppedRole === role) nb--;
         return m('piece', {
           'data-role': role,
           'data-color': color,
           'data-nb': nb,
+          'data-premove': preDropRole === role,
           class: role + ' ' + color
         });
       })

--- a/ui/round/src/crazy/crazyView.js
+++ b/ui/round/src/crazy/crazyView.js
@@ -14,8 +14,9 @@ module.exports = {
     var droppedRole = ctrl.vm.justDropped;
     var preDropRole = ctrl.vm.preDrop;
     var pocket = step.crazy.pockets[color === 'white' ? 0 : 1];
-    var usablePos = position == (ctrl.vm.flip ? 'top' : 'bottom');
+    var usablePos = position === (ctrl.vm.flip ? 'top' : 'bottom');
     var usable = usablePos && !ctrl.replaying() && game.isPlayerPlaying(ctrl.data);
+    var activeColor = color === ctrl.data.player.color;
     return m('div', {
         class: 'pocket is2d ' + position + (usable ? ' usable' : ''),
         config: function(el, isUpdate, ctx) {
@@ -34,12 +35,12 @@ module.exports = {
       },
       pieceRoles.map(function(role) {
         var nb = pocket[role] || 0;
-        if (color === ctrl.data.player.color && droppedRole === role) nb--;
+        if (activeColor && droppedRole === role) nb--;
         return m('piece', {
           'data-role': role,
           'data-color': color,
           'data-nb': nb,
-          'data-premove': preDropRole === role,
+          'data-premove': activeColor && preDropRole === role,
           class: role + ' ' + color
         });
       })

--- a/ui/round/src/ctrl.js
+++ b/ui/round/src/ctrl.js
@@ -235,7 +235,6 @@ module.exports = function(opts) {
     this.setTitle();
     if (!this.replaying()) {
       this.vm.ply++;
-      this.vm.justDropped = null;
       if (o.isMove) this.chessground.apiMove(o.uci.substr(0, 2), o.uci.substr(2, 2));
       else this.chessground.apiNewPiece({
         role: o.role,
@@ -286,6 +285,7 @@ module.exports = function(opts) {
       check: o.check,
       crazy: o.crazyhouse
     });
+    this.vm.justDropped = null;
     game.setOnGame(d, playedColor, true);
     delete this.data.forecastCount;
     m.endComputation();

--- a/ui/round/src/ground.js
+++ b/ui/round/src/ground.js
@@ -55,11 +55,7 @@ function makeConfig(data, ply, flip) {
       }
     },
     predroppable: {
-      enabled: data.pref.enablePremove && data.game.variant.key === 'crazyhouse',
-      events: {
-        set: m.redraw,
-        unset: m.redraw
-      }
+      enabled: data.pref.enablePremove && data.game.variant.key === 'crazyhouse'
     },
     draggable: {
       enabled: data.pref.moveEvent > 0,
@@ -84,6 +80,10 @@ function make(opts) {
   config.events = {
     move: opts.onMove,
     dropNewPiece: opts.onNewPiece
+  };
+  config.predroppable.events = {
+    set: opts.onPredrop,
+    unset: opts.onPredrop
   };
   config.viewOnly = opts.data.player.spectator;
   return new chessground.controller(config);


### PR DESCRIPTION
- Clear drop when new move is received. As a result,
  the guard for ply is not needed.
- Don't clear droppedPiece in sendMove.
- Highlight pocket used for predrop.