### PR TITLE
Add padding to "no new messages" text

### DIFF
--- a/app/views/message/inbox.scala.html
+++ b/app/views/message/inbox.scala.html
@@ -5,21 +5,23 @@ title = trans.inbox.str()) {
 <div id="lichess_message" class="content_box no_padding">
   <div class="head with_actions">
     <h1>@trans.inbox()</h1>
-    <div class="actions">
-      <select class="select">
-        <option value="">Select</option>
-        <option value="all">All</option>
-        <option value="none">None</option>
-        <option value="unread">Unread</option>
-        <option value="read">Read</option>
-      </select>
-      <select class="action">
-        <option value="">Do</option>
-        <option value="unread">Mark as unread</option>
-        <option value="read">Mark as read</option>
-        <option value="delete">Delete</option>
-      </select>
-    </div>
+    @if(threads.nbResults > 0) {
+      <div class="actions">
+        <select class="select">
+          <option value="">Select</option>
+          <option value="all">All</option>
+          <option value="none">None</option>
+          <option value="unread">Unread</option>
+          <option value="read">Read</option>
+        </select>
+        <select class="action">
+          <option value="">Do</option>
+          <option value="unread">Mark as unread</option>
+          <option value="read">Mark as read</option>
+          <option value="delete">Delete</option>
+        </select>
+      </div>
+    }
   </div>
   <table>
     @if(threads.nbResults > 0) {
@@ -47,8 +49,7 @@ title = trans.inbox.str()) {
     } else {
     <tbody>
       <tr>
-        <td colspan="4">
-          <br />
+        <td class="no_messages">
           @trans.noNewMessages()
         </td>
       </tr>

--- a/public/stylesheets/message.css
+++ b/public/stylesheets/message.css
@@ -44,7 +44,7 @@ div.sidebar a {
 #lichess_message td.check input {
   vertical-align: middle;
 }
-#lichess_message td.author {
+#lichess_message td.author, td.no_messages {
   padding: 1em 1em 1em 20px;
   width: 150px;
   max-width: 150px;


### PR DESCRIPTION
Also remove dropdown menus for marking/deleting messages when inbox is empty. Fixes #2438

<img width="821" alt="screen shot 2016-12-22 at 01 03 24" src="https://cloud.githubusercontent.com/assets/1413265/21410638/79396528-c7e2-11e6-801a-bacf57790d23.png">
