### PR TITLE
auto claim threefold after offering a draw (fixes #883)

### DIFF
--- a/modules/round/src/main/Drawer.scala
+++ b/modules/round/src/main/Drawer.scala
@@ -15,7 +15,8 @@ private[round] final class Drawer(
 
   def autoThreefold(game: Game)(implicit proxy: GameProxy): Fu[Option[Pov]] = Pov(game).map { pov =>
     import Pref.PrefZero
-    pov.player.userId ?? prefApi.getPref map { pref =>
+    if (game.playerHasOfferedDraw(pov.color)) fuccess(pov.some)
+    else pov.player.userId ?? prefApi.getPref map { pref =>
       pref.autoThreefold == Pref.AutoThreefold.ALWAYS || {
         pref.autoThreefold == Pref.AutoThreefold.TIME &&
           game.clock ?? { _.remainingTime(pov.color) < 30 }


### PR DESCRIPTION
Scenario: You do a move and want to claim threefold repetition, but your opponent made a premove (or moved very fast otherwise).

To reliably claim, just offer a draw before making the move.

This is similar to OTB chess. There you claim a draw and then demonstrate that you can play a move that repeats for the third time.