### PR TITLE
Add Watkins antichess solution to explorer

### DIFF
--- a/ui/analyse/src/explorer/explorerConfig.js
+++ b/ui/analyse/src/explorer/explorerConfig.js
@@ -4,17 +4,20 @@ var storedProp = require('common').storedProp;
 var storedJsonProp = require('common').storedJsonProp;
 
 module.exports = {
-  controller: function(variant, onClose) {
+  controller: function(game, withGames, onClose) {
+    var variant = (game.variant.key === 'fromPosition') ? 'standard' : game.variant.key;
+
     var available = ['lichess'];
-    if (variant.key === 'standard' || variant.key === 'fromPosition') {
-      available.push('masters');
+    if (variant === 'standard') available.push('masters');
+    else if (variant === 'antichess' && withGames && game.initialFen === 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1') {
+        available.push('watkins');
     }
 
     var data = {
       open: m.prop(false),
       db: {
         available: available,
-        selected: available.length > 1 ? storedProp('explorer.db', available[0]) : function() {
+        selected: available.length > 1 ? storedProp('explorer.db.' + variant, available[0]) : function() {
           return available[0];
         }
       },
@@ -69,6 +72,9 @@ module.exports = {
       d.db.selected() === 'masters' ? m('div.masters.message', [
         m('i[data-icon=C]'),
         m('p', "Two million OTB games of 2200+ FIDE rated players from 1952 to 2016"),
+      ]) : (d.db.selected() === 'watkins' ? m('div.masters.message', [
+        m('i[data-icon=@]'),
+        m('p', "Watkins antichess solution: 1. e3 is a win for white")
       ]) : m('div', [
         m('section.rating', [
           m('label', 'Players\' average rating'),
@@ -92,7 +98,7 @@ module.exports = {
             })
           )
         ])
-      ]),
+      ])),
       m('section.save',
         m('button.button.text[data-icon=E]', {
           onclick: ctrl.toggleOpen

--- a/ui/analyse/src/explorer/explorerView.js
+++ b/ui/analyse/src/explorer/explorerView.js
@@ -130,6 +130,27 @@ function showTablebase(ctrl, title, moves, fen) {
   ];
 }
 
+function showWatkins(ctrl, moves, fen) {
+  return [
+    m('div.title', 'Watkins antichess solution'),
+    m('table.tablebase', [
+      m('tbody', moveTableAttributes(ctrl, fen), moves.map(function(move) {
+        return m('tr', {
+          key: move.uci,
+          'data-uci': move.uci
+        }, [
+          m('td', move.san),
+          m('td', [
+            m('result.white', {
+              title: 'Proof tree size'
+            }, move.nodes + ' nodes')
+          ])
+        ]);
+      }))
+    ])
+  ];
+}
+
 function winner(stm, move) {
   if ((stm[0] == 'w' && move.wdl < 0) || (stm[0] == 'b' && move.wdl > 0))
     return 'white';
@@ -227,6 +248,10 @@ function show(ctrl) {
     else if (data.stalemate) lastShow = showGameEnd(ctrl, 'Stalemate')
     else if (data.variant_win || data.variant_loss) lastShow = showGameEnd(ctrl, 'Variant end');
     else lastShow = showEmpty(ctrl);
+  } else if (data && data.watkins) {
+    if (data.game_over) lastShow = showGameEnd(ctrl, 'Antichess win');
+    else if (data.moves && data.moves.length) lastShow = showWatkins(ctrl, data.moves, data.fen);
+    else lastShow = showEmpty(ctrl);
   }
   return lastShow;
 }
@@ -258,7 +283,7 @@ function showFailing(ctrl) {
 }
 
 module.exports = function(ctrl) {
-  var explorer = ctrl.explorer
+  var explorer = ctrl.explorer;
   if (!explorer.enabled()) return;
   var data = explorer.current();
   var config = explorer.config;

--- a/ui/analyse/src/explorer/openingXhr.js
+++ b/ui/analyse/src/explorer/openingXhr.js
@@ -23,6 +23,9 @@ module.exports = {
       method: 'GET',
       url: endpoint + url,
       data: params
+    }).then(function (data) {
+      data.opening = true;
+      return data;
     });
   },
   tablebase: function(endpoint, variant, fen) {
@@ -33,6 +36,25 @@ module.exports = {
       data: {
         fen: fen
       }
+    }).then(function(data) {
+      data.tablebase = true;
+      return data;
+    });
+  },
+  watkins: function(endpoint, moves) {
+    return m.request({
+      background: true,
+      method: 'POST',
+      url: endpoint + '/watkins',
+      data: {
+        moves: moves.join(' ')
+      },
+      serialize: function(data) {
+        return data.moves;
+      }
+    }).then(function(data) {
+      data.watkins = true;
+      return data;
     });
   }
 };


### PR DESCRIPTION
Given the number of antichess players you were not very exited about hosting Watkins antichess solution, especially if it takes 6 GB of RAM. I worked on it anyway, for the fun of it, reducing that requirement to 128 MB: https://github.com/niklasf/antichess-tree-server

API endpoint: https://tablebase.lichess.org/watkins?moves=e2e3

![image](https://cloud.githubusercontent.com/assets/402777/21578434/aa21e076-cf7f-11e6-983e-c2c6f11abc08.png)

Integration with the explorer is barely noticable in the minified size (but of course adds a bit of complexity).

Watkins proof trees end in tablebase land, which makes for a nice transition.