### PR TITLE
Exclude highcharts javascript from code climate analysis

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,2 @@
+exclude_paths:
+  - public/vendor/highcharts**/*


### PR DESCRIPTION
Hi there, I really like what you are doing with lichess.org!

I am looking to make contributions so in addition to checking the issue tracker, I went to the code climate page to check out some of the code.  Quite a few pages of the issues are only related to the highcharts javascript directory.  That makes it difficult to find issues in the code that aren't related to this third party file.

Removing this directory from the code climate analysis would make it easier for newbies like me to get a feel for the project. I also believe it would also drastically increase the overall code climate rating, which in turn makes the project more appealing.

Let me know what you think!
