### PR TITLE
Increasing the max number of reports displayed on the reports list page from 50 to 200

### DIFF
--- a/app/controllers/Report.scala
+++ b/app/controllers/Report.scala
@@ -14,7 +14,7 @@ object Report extends LilaController {
   private def api = Env.report.api
 
   def list = Secure(_.SeeReport) { implicit ctx => _ =>
-    api unprocessedAndRecent 50 map { reports =>
+    api unprocessedAndRecent 200 map { reports =>
       html.report.list(reports)
     }
   }


### PR DESCRIPTION
This will enable me to handle more communication reports before the entire queue is filled up by only engine reports.