### PR TITLE
Add schema.org action to activation mails

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -344,6 +344,7 @@ mailgun {
     key = "???"
   }
   sender = "lichess.org <noreply@lichess.org>"
+  reply_to = "lichess.org <contact@lichess.org>"
   base_url = ${net.base_url}
 }
 lobby {

--- a/modules/security/src/main/EmailConfirm.scala
+++ b/modules/security/src/main/EmailConfirm.scala
@@ -31,6 +31,7 @@ final class EmailConfirmMailGun(
     apiUrl: String,
     apiKey: String,
     sender: String,
+    replyTo: String,
     baseUrl: String,
     secret: String,
     system: ActorSystem) extends EmailConfirm {
@@ -45,6 +46,8 @@ final class EmailConfirmMailGun(
     WS.url(s"$apiUrl/messages").withAuth("api", apiKey, WSAuthScheme.BASIC).post(Map(
       "from" -> Seq(sender),
       "to" -> Seq(email),
+      "h:Reply-To" -> Seq(replyTo),
+      "o:tag" -> Seq("registration"),
       "subject" -> Seq(s"Confirm your lichess.org account, ${user.username}"),
       "text" -> Seq(s"""
 Final step!
@@ -54,8 +57,30 @@ Confirm your email address to complete your lichess account. It's easy — just 
 $url
 
 
-Please do not reply to this message; it was sent from an unmonitored email address. This message is a service email related to your use of lichess.org.
-"""))).void addFailureEffect {
+This is a service email related to your use of lichess.org. If you did not register with Lichess you can safely ignore this message.
+"""),
+      "html" -> Seq(s"""<!doctype html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Confirm your lichess.org account, ${user.username}</title>
+  </head>
+  <body>
+    <div itemscope itemtype="http://schema.org/EmailMessage">
+      <strong>Final step!</strong>
+      <p itemprop="description">Confirm your email address to activate your Lichess account. It's easy — just click the link below.</p>
+      <div itemprop="potentialAction" itemscope itemtype="http://schema.org/ViewAction">
+        <meta itemprop="name" content="Activate account">
+        <meta itemprop="url" content="$url">
+        <p><a itemprop="target" href="$url">$url</a></p>
+      </div>
+      <div itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
+        <small>This is a service email related to your use of <a itemprop="url" href="https://lichess.org/"><span itemprop="name">lichess.org</span></a>. If you did not register with Lichess you can safely ignore this message.</small>
+      </div>
+    </div>
+  </body>
+</html>"""))).void addFailureEffect {
       case e: java.net.ConnectException => lila.mon.http.mailgun.timeout()
       case _                            =>
     } recoverWith {

--- a/modules/security/src/main/Env.scala
+++ b/modules/security/src/main/Env.scala
@@ -30,6 +30,7 @@ final class Env(
     val EmailConfirmMailgunApiUrl = config getString "email_confirm.mailgun.api.url"
     val EmailConfirmMailgunApiKey = config getString "email_confirm.mailgun.api.key"
     val EmailConfirmMailgunSender = config getString "email_confirm.mailgun.sender"
+    val EmailConfirmMailgunReplyTo = config getString "email_confirm.mailgun.reply_to"
     val EmailConfirmMailgunBaseUrl = config getString "email_confirm.mailgun.base_url"
     val EmailConfirmSecret = config getString "email_confirm.secret"
     val EmailConfirmEnabled = config getBoolean "email_confirm.enabled"
@@ -86,6 +87,7 @@ final class Env(
       apiUrl = EmailConfirmMailgunApiUrl,
       apiKey = EmailConfirmMailgunApiKey,
       sender = EmailConfirmMailgunSender,
+      replyTo = EmailConfirmMailgunReplyTo,
       baseUrl = EmailConfirmMailgunBaseUrl,
       secret = EmailConfirmSecret,
       system = system)

--- a/modules/security/src/main/Env.scala
+++ b/modules/security/src/main/Env.scala
@@ -37,6 +37,7 @@ final class Env(
     val PasswordResetMailgunApiUrl = config getString "password_reset.mailgun.api.url"
     val PasswordResetMailgunApiKey = config getString "password_reset.mailgun.api.key"
     val PasswordResetMailgunSender = config getString "password_reset.mailgun.sender"
+    val PasswordResetMailgunReplyTo = config getString "password_reset.mailgun.reply_to"
     val PasswordResetMailgunBaseUrl = config getString "password_reset.mailgun.base_url"
     val PasswordResetSecret = config getString "password_reset.secret"
     val LoginTokenSecret = config getString "login_token.secret"
@@ -97,6 +98,7 @@ final class Env(
     apiUrl = PasswordResetMailgunApiUrl,
     apiKey = PasswordResetMailgunApiKey,
     sender = PasswordResetMailgunSender,
+    replyTo = PasswordResetMailgunReplyTo,
     baseUrl = PasswordResetMailgunBaseUrl,
     secret = PasswordResetSecret)
 

--- a/modules/security/src/main/PasswordReset.scala
+++ b/modules/security/src/main/PasswordReset.scala
@@ -11,6 +11,7 @@ final class PasswordReset(
     apiUrl: String,
     apiKey: String,
     sender: String,
+    replyTo: String,
     baseUrl: String,
     secret: String) {
 
@@ -20,6 +21,8 @@ final class PasswordReset(
     WS.url(s"$apiUrl/messages").withAuth("api", apiKey, WSAuthScheme.BASIC).post(Map(
       "from" -> Seq(sender),
       "to" -> Seq(email),
+      "h:Reply-To" -> Seq(replyTo),
+      "o:tag" -> Seq("password"),
       "subject" -> Seq("Reset your lichess.org password"),
       "text" -> Seq(s"""
 We received a request to reset the password for your account, ${user.username}.
@@ -29,8 +32,30 @@ If you made this request, click the link below. If you didn't make this request,
 $url
 
 
-Please do not reply to this message; it was sent from an unmonitored email address. This message is a service email related to your use of lichess.org.
-"""))).void addFailureEffect {
+This message is a service email related to your use of lichess.org.
+"""),
+      "html" -> Seq(s"""<!doctype html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Reset your lichess.org password</title>
+  </head>
+  <body>
+    <div itemscope itemtype="http://schema.org/EmailMessage">
+      <p itemprop="description">We received a request to reset the password for your account, ${user.username}.</p>
+      <p>If you made this request, click the link below. If you didn't make this request, you can ignore this email.</p>
+      <div itemprop="potentialAction" itemscope itemtype="http://schema.org/ViewAction">
+        <meta itemprop="name" content="Reset password">
+        <meta itemprop="url" content="$url">
+        <p><a itemprop="target" href="$url">$url</a></p>
+      </div>
+      <div itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
+        <small>This is a service email related to your use of <a itemprop="url" href="https://lichess.org/"><span itemprop="name">lichess.org</span></a>.</small>
+      </div>
+    </div>
+  </body>
+</html>"""))).void addFailureEffect {
       case e: java.net.ConnectException => lila.mon.http.mailgun.timeout()
       case _                            =>
     }


### PR DESCRIPTION
This should be ready to deploy. Tested using https://www.google.com/webmasters/markup-tester and self-sending. (It's orthogonal to other improvements like #1543.)

Action links won't (normally) show in gmail yet. We'll have to ask approval once it is on prod.

![image](https://cloud.githubusercontent.com/assets/402777/21751787/3453b528-d5cd-11e6-89df-b46ce503d5f0.png)

---

Based on #1268 by @Unihedro.

* Use ViewAction: The link is valid indefinitely and logs the user into
  lichess. (ConfirmActions run in the background and only once, status
  200 expected.)

* Actually use properties as markup.

* Add organization information and Reply-To.