### PR TITLE
[RFC] Support pre promotions

### DIFF
--- a/ui/round/src/ctrl.js
+++ b/ui/round/src/ctrl.js
@@ -77,6 +77,16 @@ module.exports = function(opts) {
     } else sound.move();
   }.bind(this);
 
+  var onPremove = function(orig, dest) {
+    promotion.start(this, orig, dest, true);
+    m.redraw();
+  }.bind(this);
+
+  var onCancelPremove = function() {
+    promotion.cancel(this);
+    m.redraw();
+  }.bind(this);
+
   var onPredrop = function(role) {
     this.vm.preDrop = role;
     m.redraw();
@@ -93,6 +103,8 @@ module.exports = function(opts) {
     onUserNewPiece: onUserNewPiece,
     onMove: onMove,
     onNewPiece: onNewPiece,
+    onPremove: onPremove,
+    onCancelPremove: onCancelPremove,
     onPredrop: onPredrop
   });
 

--- a/ui/round/src/ground.js
+++ b/ui/round/src/ground.js
@@ -49,10 +49,6 @@ function makeConfig(data, ply, flip) {
       enabled: data.pref.enablePremove,
       showDests: data.pref.destination,
       castle: data.game.variant.key !== 'antichess',
-      events: {
-        set: m.redraw,
-        unset: m.redraw
-      }
     },
     predroppable: {
       enabled: data.pref.enablePremove && data.game.variant.key === 'crazyhouse'
@@ -80,6 +76,10 @@ function make(opts) {
   config.events = {
     move: opts.onMove,
     dropNewPiece: opts.onNewPiece
+  };
+  config.premovable.events = {
+    set: opts.onPremove,
+    unset: opts.onCancelPremove
   };
   config.predroppable.events = {
     set: opts.onPredrop,


### PR DESCRIPTION
Premove a pawn to the eighth rank.

Previously: Wait for the reply. Then the promotion dialog pops up.

Now: You select the promotion piece type and it gets played once there
is a reponse.

![image](https://cloud.githubusercontent.com/assets/402777/21871957/d78ac7fa-d865-11e6-97e3-ee2d2c31fef6.png)
