### PR TITLE
update SpamTest after removal of in

### DIFF
--- a/modules/security/src/test/SpamTest.scala
+++ b/modules/security/src/test/SpamTest.scala
@@ -10,20 +10,17 @@ class SpamTest extends Specification {
   val foobar = """foo bar"""
   val _vc = """almost as cool as lichess.  \r\n\r\nhttps://www.velocitychess.com/ref/2573698"""
   val _cb = s"""with $cb cheat. http://$cb.com/ http://$cb.com/bot/ChessBot.RAR"""
-  val _in = s"""his webpage: http://$in/2014/04/23/lichess-org-chess-bot/ http://$in/pages/lichess-bot/#lichess-bot"""
 
   "spam" should {
     "detect" in {
       detect(foobar) must beFalse
       detect(_vc) must beTrue
       detect(_cb) must beTrue
-      detect(_in) must beTrue
     }
     "replace" in {
       replace(foobar) must_== foobar
       replace(_vc) must_== """almost as cool as lichess.  \r\n\r\nhttps://www.velocitychess.com"""
       replace(_cb) must_== s"""with $tosUrl cheat. $tosUrl $tosUrl"""
-      replace(_in) must_== s"""his webpage: $tosUrl $tosUrl"""
     }
   }
 }


### PR DESCRIPTION
With the removal of $in in ecb55568a1b38081e6409b31f752 tests were failing.