### PR TITLE
Added 2 missing mainstream email domains

### DIFF
--- a/modules/security/src/main/DisposableEmailDomain.scala
+++ b/modules/security/src/main/DisposableEmailDomain.scala
@@ -75,7 +75,7 @@ object DisposableEmailDomain {
     "email.com", "games.com" /* AOL */ , "gmx.net", "hush.com", "hushmail.com", "icloud.com", "inbox.com",
     "lavabit.com", "love.com" /* AOL */ , "outlook.com", "pobox.com", "rocketmail.com" /* Yahoo */ ,
     "safe-mail.net", "wow.com" /* AOL */ , "ygm.com" /* AOL */ , "ymail.com" /* Yahoo */ , "zoho.com", "fastmail.fm",
-    "yandex.com",
+    "yandex.com", "cock.li", "airmail.cc"
 
     /* United States ISP domains */
     "bellsouth.net", "charter.net", "comcast.net", "cox.net", "earthlink.net", "juno.com",


### PR DESCRIPTION
These domains are legit.

Also I verified that registering email addresses on them requires solving CAPTCHA, so spamming with them is not possible.