### PR TITLE
Improve logic for displaying next tourney box

### DIFF
--- a/ui/tournament/src/view/finished.js
+++ b/ui/tournament/src/view/finished.js
@@ -21,7 +21,7 @@ function confetti(data) {
 }
 
 function stats(st) {
-  return m('div.stats.box', [
+  if (st) return m('div.stats.box', [
     m('h2', 'Tournament complete'),
     m('table', [
       numberRow('Average rating', st.averageRating),
@@ -33,6 +33,35 @@ function stats(st) {
       numberRow('Berserk rate', [st.berserks / 2, st.games], 'percent')
     ])
   ]);
+}
+
+function nextTournament(t) {
+  if (t) return [
+    m('a.next', {
+      href: '/tournament/' + t.id
+    }, [
+      m('i', {
+        'data-icon': t.perf.icon
+      }),
+      m('span.content', [
+        m('span', 'Next ' + t.perf.name + ' tournament:'),
+        m('span.name', t.name),
+        m('span.more', [
+          ctrl.trans('nbConnectedPlayers', t.nbPlayers),
+          ' • ',
+          t.finishesAt ? [
+            'finishes ',
+            m('time.moment-from-now', {
+              datetime: t.finishesAt
+            }, t.finishesAt)
+          ] : m('time.moment-from-now', {
+            datetime: t.startsAt
+          }, t.startsAt)
+        ])
+      ])
+    ]),
+    m('a.others[href=/tournament]', 'View more tournaments')
+  ];
 }
 
 module.exports = {
@@ -48,9 +77,12 @@ module.exports = {
     ];
   },
   side: function(ctrl) {
-    return ctrl.vm.playerInfo.id ? playerInfo(ctrl) : [
-      stats ? stats(ctrl.data.stats) : null,
-      pairings(ctrl)
+    var player = ctrl.vm.playerInfo.id;
+    return [
+      nextTournament(ctrl.data.next),
+      player ? playerInfo(ctrl) : null,
+      player ? null : stats(ctrl.data.stats),
+      player ? null : pairings(ctrl)
     ];
   }
 };

--- a/ui/tournament/src/view/pairings.js
+++ b/ui/tournament/src/view/pairings.js
@@ -23,41 +23,11 @@ function featuredPlayer(f, orientation) {
 }
 
 function featured(f) {
-  return m('div.featured', [
+  if (f) return m('div.featured', [
     featuredPlayer(f, 'top'),
     util.miniBoard(f),
     featuredPlayer(f, 'bottom')
   ]);
-}
-
-function nextTournament(ctrl) {
-  var t = ctrl.data.next;
-  if (t) return [
-    m('a.next', {
-      href: '/tournament/' + t.id
-    }, [
-      m('i', {
-        'data-icon': t.perf.icon
-      }),
-      m('span.content', [
-        m('span', 'Next ' + t.perf.name + ' tournament:'),
-        m('span.name', t.name),
-        m('span.more', [
-          ctrl.trans('nbConnectedPlayers', t.nbPlayers),
-          ' • ',
-          t.finishesAt ? [
-            'finishes ',
-            m('time.moment-from-now', {
-              datetime: t.finishesAt
-            }, t.finishesAt)
-          ] : m('time.moment-from-now', {
-            datetime: t.startsAt
-          }, t.startsAt)
-        ])
-      ])
-    ]),
-    m('a.others[href=/tournament]', 'View more tournaments')
-  ];
 }
 
 function renderPairing(p) {
@@ -78,7 +48,7 @@ function renderPairing(p) {
 
 module.exports = function(ctrl) {
   return [
-    ctrl.data.featured ? featured(ctrl.data.featured) : nextTournament(ctrl),
+    featured(ctrl.data.featured),
     m('div.box.all_pairings.scroll-shadow-soft', {
       onclick: function() {
         return !ctrl.vm.disableClicks;


### PR DESCRIPTION
Show box after tourney is finished, regardles of whether
pairings or a specific player is being viewed.

Note: while this patch should be safe, I have not thoroughly
tested it. In particular, I am not sure if `undefined`
is safe to return in a mithril render list.