### PR TITLE
fix ceval and explorer hover glitch (closes #2473)

### DIFF
--- a/ui/analyse/src/autoShape.js
+++ b/ui/analyse/src/autoShape.js
@@ -37,7 +37,7 @@ module.exports = {
     var instance = ctrl.getCeval(),
       n = ctrl.vm.node,
       shapes = [],
-      hoveringUci = ctrl.explorer.hoveringUci() || instance.hoveringUci();
+      hovering = ctrl.explorer.hovering() || instance.hovering();
     var color = ctrl.chessground.data.movable.color;
     var rcolor = color === 'white' ? 'black' : 'white';
     if (ctrl.retro && ctrl.retro.showBadNode()) {
@@ -45,11 +45,11 @@ module.exports = {
         lineWidth: 8
       });
     }
-    if (hoveringUci) shapes = shapes.concat(makeAutoShapesFromUci(color, hoveringUci, 'paleBlue'));
+    if (hovering && hovering.fen === n.fen) shapes = shapes.concat(makeAutoShapesFromUci(color, hovering.uci, 'paleBlue'));
     if (ctrl.vm.showAutoShapes() && ctrl.vm.showComputer()) {
       if (n.eval && n.eval.best)
         shapes = shapes.concat(makeAutoShapesFromUci(rcolor, n.eval.best, 'paleGreen'));
-      if (!hoveringUci) {
+      if (!hovering) {
         var nextBest = ctrl.nextNodeBest();
         if (!nextBest && instance.enabled() && n.ceval && n.ceval.best) nextBest = n.ceval.best;
         if (nextBest) shapes = shapes.concat(makeAutoShapesFromUci(color, nextBest, 'paleBlue'));

--- a/ui/analyse/src/explorer/explorerCtrl.js
+++ b/ui/analyse/src/explorer/explorerCtrl.js
@@ -23,7 +23,7 @@ module.exports = function(root, opts, allow) {
   if (location.hash === '#opening' && !root.embed) enabled(true);
   var loading = m.prop(true);
   var failing = m.prop(false);
-  var hoveringUci = m.prop(null);
+  var hovering = m.prop(null);
   var movesAway = m.prop(0);
 
   var cache = {};
@@ -105,7 +105,7 @@ module.exports = function(root, opts, allow) {
     setNode: setNode,
     loading: loading,
     failing: failing,
-    hoveringUci: hoveringUci,
+    hovering: hovering,
     movesAway: movesAway,
     config: config,
     withGames: withGames,
@@ -124,8 +124,11 @@ module.exports = function(root, opts, allow) {
         root.autoScroll();
       }
     },
-    setHoveringUci: function(uci) {
-      hoveringUci(uci);
+    setHovering: function(fen, uci) {
+      hovering(uci ? {
+        fen: fen,
+        uci: uci,
+      } : null);
       root.setAutoShapes();
     },
     fetchMasterOpening: (function() {

--- a/ui/analyse/src/explorer/explorerView.js
+++ b/ui/analyse/src/explorer/explorerView.js
@@ -21,13 +21,14 @@ var lastShow = null;
 
 function moveTableAttributes(ctrl, fen) {
   return {
+    'data-fen': fen,
     config: function(el, isUpdate, ctx) {
       if (!isUpdate) {
         el.addEventListener('mouseover', function(e) {
-          ctrl.explorer.setHoveringUci($(e.target).parents('tr').attr('data-uci'));
+          ctrl.explorer.setHovering($(el).attr('data-fen'), $(e.target).parents('tr').attr('data-uci'));
         });
         el.addEventListener('mouseout', function(e) {
-          ctrl.explorer.setHoveringUci(null);
+          ctrl.explorer.setHovering($(el).attr('data-fen'), null);
         });
         el.addEventListener('mousedown', function(e) {
           var uci = $(e.target).parents('tr').attr('data-uci');
@@ -38,7 +39,7 @@ function moveTableAttributes(ctrl, fen) {
       if (ctx.lastFen === fen) return;
       ctx.lastFen = fen;
       setTimeout(function() {
-        ctrl.explorer.setHoveringUci($(el).find('tr:hover').attr('data-uci'));
+        ctrl.explorer.setHovering($(el).attr('data-fen'), $(el).find('tr:hover').attr('data-uci'));
       }, 100);
     }
   };

--- a/ui/ceval/src/ctrl.js
+++ b/ui/ceval/src/ctrl.js
@@ -22,7 +22,7 @@ module.exports = function(opts) {
   var allowed = m.prop(true);
   var enabled = m.prop(opts.possible && allowed() && enableStorage.get() == '1');
   var started = false;
-  var hoveringUci = m.prop(null);
+  var hovering = m.prop(null);
 
   var pool = makePool(stockfishProtocol, {
     asmjs: '/assets/vendor/stockfish.js/stockfish.js?v=9',
@@ -150,9 +150,12 @@ module.exports = function(opts) {
     multiPv: multiPv,
     threads: threads,
     hashSize: hashSize,
-    hoveringUci: hoveringUci,
-    setHoveringUci: function(uci) {
-      hoveringUci(uci);
+    hovering: hovering,
+    setHovering: function(fen, uci) {
+      hovering(uci ? {
+        fen: fen,
+        uci: uci
+      } : null);
       opts.setAutoShapes();
     },
     toggle: function() {

--- a/ui/ceval/src/view.js
+++ b/ui/ceval/src/view.js
@@ -164,13 +164,14 @@ module.exports = {
     else
       pvs = [];
     return m('div.pv_box', {
+      'data-fen': ctrl.vm.node.fen,
       config: function(el, isUpdate, ctx) {
         if (!isUpdate) {
           el.addEventListener('mouseover', function(e) {
-            instance.setHoveringUci($(e.target).closest('div.pv').attr('data-uci'));
+            instance.setHovering($(el).attr('data-fen'), $(e.target).closest('div.pv').attr('data-uci'));
           });
           el.addEventListener('mouseout', function(e) {
-            instance.setHoveringUci(null);
+            instance.setHovering($(el).attr('data-fen'), null);
           });
           el.addEventListener('mousedown', function(e) {
             var uci = $(e.target).closest('div.pv').attr('data-uci');
@@ -178,7 +179,7 @@ module.exports = {
           });
         }
         setTimeout(function() {
-          instance.setHoveringUci($(el).find('div.pv:hover').attr('data-uci'));
+          instance.setHovering($(el).attr('data-fen'), $(el).find('div.pv:hover').attr('data-uci'));
         }, 100);
       }
     }, range(multiPv).map(function(i) {


### PR DESCRIPTION
Put data from mouse events in the context of their FEN. Then render hovering arrows iff `hovering.fen === ctrl.vm.node.fen`.