### PR TITLE
keep pre promotion dialog (closes #2532)

### DIFF
--- a/ui/round/src/ctrl.js
+++ b/ui/round/src/ctrl.js
@@ -84,7 +84,7 @@ module.exports = function(opts) {
   }.bind(this);
 
   var onCancelPremove = function() {
-    promotion.cancel(this);
+    promotion.cancelPrePromotion(this);
     m.redraw();
   }.bind(this);
 
@@ -317,7 +317,10 @@ module.exports = function(opts) {
       // https://github.com/ornicar/lila/issues/343
       var premoveDelay = d.game.variant.key === 'atomic' ? 100 : 10;
       setTimeout(function() {
-        if (!this.chessground.playPremove() && !playPredrop()) showYourMoveNotification();
+        if (!this.chessground.playPremove() && !playPredrop()) {
+          promotion.cancel(this);
+          showYourMoveNotification();
+        }
       }.bind(this), premoveDelay);
     }
     this.vm.autoScroll && this.vm.autoScroll.now();
@@ -429,6 +432,7 @@ module.exports = function(opts) {
   this.takebackYes = function() {
     this.socket.sendLoading('takeback-yes');
     this.chessground.cancelPremove();
+    promotion.cancel(this);
   }.bind(this);
 
   this.resign = function(v) {


### PR DESCRIPTION
Previously: Make a pre promotion. The dialog pops up. Your opponent moves. The dialog closes.

Now: The dialog only closes if the promotion move is no longer possible.

Follow up for #2515.