### PR TITLE
Stockfish Protocol improvements.

### DIFF
--- a/ui/ceval/src/ctrl.js
+++ b/ui/ceval/src/ctrl.js
@@ -31,9 +31,7 @@ module.exports = function(opts) {
     onCrash: opts.onCrash
   }, {
     minDepth: minDepth,
-    maxDepth: maxDepth,
     variant: opts.variant,
-    multiPv: multiPv,
     threads: pnaclSupported && threads,
     hashSize: pnaclSupported && hashSize
   });
@@ -97,6 +95,7 @@ module.exports = function(opts) {
       path: path,
       ply: step.ply,
       maxDepth: maxD,
+      multiPv: parseInt(multiPv()),
       threatMode: threatMode,
       emit: function(res) {
         if (enabled()) onEmit(res);

--- a/ui/ceval/src/stockfishProtocol.js
+++ b/ui/ceval/src/stockfishProtocol.js
@@ -91,7 +91,7 @@ module.exports = function(worker, opts) {
     } else {
       // emit timeout in case there aren't a full set of PVs.
       clearTimeout(state.emitTimer);
-      state.emitTimer = setTimeout(emit, 100);
+      state.emitTimer = setTimeout(emit, 50);
     }
   };
 


### PR DESCRIPTION
- Cleaned up regex to avoid backtracking
- Organized regex extraction logic
- Fixed bug where opts.multiPv was not evaluated correctly.
- Removed lowerbound/upperbound messages for now. Their PVs are
  bad and their evals are not suitable for the eval box.

This patch prepares possible enhancements such as:
- Heuristics to avoid changing the displayed PV / best move too
  frequently, or to avoid replacing a good PV with a worse PV.
- Using lowerbound/upperbound scores to indicate uncertainty in
  the eval bar.

@niklasf