### PR TITLE
Update PVs to latest emit with equal depth

### DIFF
--- a/ui/analyse/src/ctrl.js
+++ b/ui/analyse/src/ctrl.js
@@ -443,9 +443,9 @@ module.exports = function(opts) {
       emit: function(res) {
         this.tree.updateAt(res.work.path, function(node) {
           if (res.work.threatMode) {
-            if (!node.threat || node.threat.depth < res.eval.depth || node.threat.maxDepth < res.eval.maxDepth)
+            if (!node.threat || node.threat.depth <= res.eval.depth || node.threat.maxDepth < res.eval.maxDepth)
               node.threat = res.eval;
-          } else if (!node.ceval || node.ceval.depth < res.eval.depth || node.ceval.maxDepth < res.eval.maxDepth)
+          } else if (!node.ceval || node.ceval.depth <= res.eval.depth || node.ceval.maxDepth < res.eval.maxDepth)
             node.ceval = res.eval;
           if (res.work.path === this.vm.path) {
             this.setAutoShapes();

--- a/ui/puzzle/src/ctrl.js
+++ b/ui/puzzle/src/ctrl.js
@@ -253,9 +253,9 @@ module.exports = function(opts, i18n) {
       emit: function(res) {
         tree.updateAt(res.work.path, function(node) {
           if (res.work.threatMode) {
-            if (!node.threat || node.threat.depth < res.eval.depth || node.threat.maxDepth < res.eval.maxDepth)
+            if (!node.threat || node.threat.depth <= res.eval.depth || node.threat.maxDepth < res.eval.maxDepth)
               node.threat = res.eval;
-          } else if (!node.ceval || node.ceval.depth < res.eval.depth || node.ceval.maxDepth < res.eval.maxDepth)
+          } else if (!node.ceval || node.ceval.depth <= res.eval.depth || node.ceval.maxDepth < res.eval.maxDepth)
             node.ceval = res.eval;
           if (res.work.path === vm.path) {
             setAutoShapes();


### PR DESCRIPTION
This fixes a bug where longer PVs are never shown because
stockfish prints the normal PV first.
This will also show the mixed depth PVs stockfishProtocol now
emits (i.e. PV 1 depth 21, PV 2 depth 20). These are categorized
as min(depth of PVs), so would not override the depth 20
emit.

@niklasf