### PR TITLE
workaround initial antichess fen bug for watkins

### DIFF
--- a/ui/analyse/src/explorer/explorerConfig.js
+++ b/ui/analyse/src/explorer/explorerConfig.js
@@ -9,7 +9,7 @@ module.exports = {
 
     var available = ['lichess'];
     if (variant === 'standard') available.push('masters');
-    else if (variant === 'antichess' && withGames && game.initialFen === 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1') {
+    else if (variant === 'antichess' && withGames && game.initialFen.indexOf('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w ') === 0) {
         available.push('watkins');
     }
 


### PR DESCRIPTION
Just saw on @ddugovic's stream that the antichess solution is not available for analysis of games. This is because `game.initialFen` (incorrectly) has castling rights.

This PR does not fix the [root cause](https://github.com/ornicar/scalachess/blob/master/src/main/scala/variant/Antichess.scala#L10), but should be a reasonable workaround for existing games.