### PR TITLE
Fixed inconsistencies in cheat detection

### DIFF
--- a/modules/evaluation/src/main/Assessible.scala
+++ b/modules/evaluation/src/main/Assessible.scala
@@ -56,8 +56,7 @@ case class Assessible(analysed: Analysed) {
       case PlayerFlags(T, _, T, _, _, T, _) => Cheating // high accuracy, high blurs, no fast moves
       case PlayerFlags(T, _, _, T, _, _, _) => Cheating // high accuracy, moderate blurs
 
-      case PlayerFlags(_, T, _, T, T, _, _) => LikelyCheating // always has advantage, moderate blurs, highly consistent move times
-      case PlayerFlags(_, _, _, T, T, _, _) => LikelyCheating // high accuracy, moderate blurs => 93% chance cheating
+      case PlayerFlags(_, _, _, T, T, _, _) => LikelyCheating // moderate blurs, highly consistent move times
       case PlayerFlags(T, _, _, _, _, _, T) => LikelyCheating // Holds are bad, hmk?
       case PlayerFlags(_, T, _, _, _, _, T) => LikelyCheating // Holds are bad, hmk?
 


### PR DESCRIPTION
One inline comment incorrectly stated that it was for high accuracy and
moderate blurs. It was changed to moderate blurs and highly consistent
move times

Also, one case was a subset of another case with the same output.
Removing the more specific case results in no change in functionality.