### PR TITLE
Report players with lots of unclear games

### DIFF
--- a/modules/evaluation/src/main/PlayerAggregateAssessment.scala
+++ b/modules/evaluation/src/main/PlayerAggregateAssessment.scala
@@ -39,14 +39,19 @@ case class PlayerAggregateAssessment(
 
     def percentLikelyCheatingGames(x: Double) =
       (cheatingSum + likelyCheatingSum).toDouble / assessmentsCount >= (x / 100) - relationModifier
+      
+    def percentUnclearGames(x: Double) =
+      (cheatingSum + likelyCheatingSum + unclearSum).toDouble / assessmentsCount >= (x / 100) - relationModifier
 
     val markable: Boolean = !isGreatUser && isWorthLookingAt &&
       (cheatingSum >= 3 || cheatingSum + likelyCheatingSum >= 6) &&
       (percentCheatingGames(10) || percentLikelyCheatingGames(20))
 
     val reportable: Boolean = isWorthLookingAt &&
-      (cheatingSum >= 2 || cheatingSum + likelyCheatingSum >= (isNewRatedUser.fold(2, 4))) &&
-      (percentCheatingGames(5) || percentLikelyCheatingGames(10))
+      (cheatingSum >= 2
+       || cheatingSum + likelyCheatingSum >= isNewRatedUser.fold(2, 4)
+       || cheatingSum + likelyCheatingSum + unclearSum >= isNewRatedUser.fold(4, 8)) &&
+      (percentCheatingGames(5) || percentLikelyCheatingGames(10) || percentUnclearGames(15))
 
     val bannable: Boolean = (relatedCheatersCount == relatedUsersCount) && relatedUsersCount >= 1
 
@@ -92,6 +97,7 @@ case class PlayerAggregateAssessment(
   val relationModifier = if (relatedUsersCount >= 1) 0.02 else 0
   val cheatingSum = countAssessmentValue(Cheating)
   val likelyCheatingSum = countAssessmentValue(LikelyCheating)
+  val unclearSum = countAssessmentValue(Unclear)
 
   // Some statistics
   def sfAvgGiven(predicate: PlayerAssessment => Boolean): Option[Int] = {


### PR DESCRIPTION
I've noticed that a lot of players who get reported from the community have a high proportion of unclear games. These players are commonly then automatically marked by Irwin. With Irwin spending a lot of time idle at the moment, I think it's a good idea to broaden the search for cheaters in this field.