### PR TITLE
Created years ago and useless

### DIFF
--- a/doc/sf-benchs
+++ b/doc/sf-benchs
@@ -1,6 +1,0 @@
-Stockfish 5:
-Y70: 2 190 000
-
-Stockfish 6:
-Y70: 2 200 000
-


### PR DESCRIPTION
From a benchmark install upgrade from stockfish 5 to 6. Obviously not still being used if we're on stockfish 8