### PR TITLE
Give all non-game moves made in the analysis editor a different styling.

### DIFF
--- a/public/stylesheets/analyse.css
+++ b/public/stylesheets/analyse.css
@@ -1173,6 +1173,9 @@ body.piece_letter .tview2 move {
 .tview2 move.current {
   border: 1px solid #d85000!important;
 }
+.tview2 move.nongame {
+  font-style: italic;
+}
 .tview2 move.active {
   color: #d85000;
 }

--- a/ui/analyse/src/ctrl.js
+++ b/ui/analyse/src/ctrl.js
@@ -41,7 +41,8 @@ module.exports = function(opts) {
   var initialize = function(data) {
     this.data = data;
     if (!data.game.moveTimes) this.data.game.moveTimes = [];
-    this.ongoing = !util.synthetic(this.data) && game.playable(this.data);
+    this.synthetic = util.synthetic(this.data);
+    this.ongoing = !this.synthetic && game.playable(this.data);
     this.tree = tree.build(tree.ops.reconstruct(this.data.treeParts));
     this.actionMenu = new actionMenu();
     this.autoplay = new autoplay(this);
@@ -52,6 +53,7 @@ module.exports = function(opts) {
   initialize(opts.data);
 
   var initialPath = tree.path.root;
+  var gamePath = '';
   if (opts.initialPly) {
     var locationHash = location.hash;
     var plyStr = opts.initialPly === 'url' ? (locationHash || '').replace(/#/, '') : opts.initialPly;
@@ -65,10 +67,16 @@ module.exports = function(opts) {
         return n.ply <= ply;
       });
     }
+    if (!this.synthetic && !this.ongoing) gamePath = tree.ops.takePathWhile(mainline, function(n) {
+      return n.ply <= mainline.length - 1;
+    });
   }
 
   this.vm = {
+    synthetic: this.synthetic,
+    ongoing: this.ongoing,
     initialPath: initialPath,
+    gamePath: gamePath,
     cgConfig: null,
     comments: true,
     flip: false,

--- a/ui/analyse/src/treeView.js
+++ b/ui/analyse/src/treeView.js
@@ -139,6 +139,7 @@ function renderMainlineMoveOf(ctx, node, opts) {
   if (path === ctx.ctrl.vm.path) classes.push('active');
   if (path === ctx.ctrl.vm.contextMenuPath) classes.push('context_menu');
   if (path === ctx.ctrl.vm.initialPath && game.playable(ctx.ctrl.data)) classes.push('current');
+  if (path.length > ctx.ctrl.vm.gamePath.length && !ctx.ctrl.vm.synthetic && !ctx.ctrl.vm.ongoing) classes.push('nongame');
   else if (ctx.ctrl.retro && ctx.ctrl.retro.current() && ctx.ctrl.retro.current().prev.path === path) classes.push('current');
   if (opts.conceal) classes.push(opts.conceal);
   if (classes.length) attrs.class = classes.join(' ');


### PR DESCRIPTION
Currently italics. Implements #2627.

<img width="862" alt="screen shot 2017-02-15 at 10 20 44 pm" src="https://cloud.githubusercontent.com/assets/542245/23007722/137f88d8-f3d0-11e6-9d68-7aabd1818235.png">