### PR TITLE
fix transpositions in watkins explorer

### DIFF
--- a/ui/analyse/src/explorer/openingXhr.js
+++ b/ui/analyse/src/explorer/openingXhr.js
@@ -47,7 +47,7 @@ module.exports = {
       method: 'POST',
       url: endpoint + '/watkins',
       data: {
-        moves: moves.join(' ')
+        moves: moves
       },
       serialize: function(data) {
         return data.moves;


### PR DESCRIPTION
Watkins proof trees do not support transpositions, so do not use the FEN as the cache key there.