### PR TITLE
fix zh game end in fishnet pv

### DIFF
--- a/ui/analyse/src/gameEnd.js
+++ b/ui/analyse/src/gameEnd.js
@@ -1,5 +1,0 @@
-module.exports = function(node) {
-  if (node.dests !== '') return false;
-  if (node.san.indexOf('#')) return 'mate';
-  return 'draw';
-};

--- a/ui/tree/src/tree.js
+++ b/ui/tree/src/tree.js
@@ -107,6 +107,7 @@ module.exports = function(root) {
     var existing = nodeAtPathOrNull(newPath);
     if (existing) {
       if (defined(node.dests) && !defined(existing.dests)) existing.dests = node.dests;
+      if (defined(node.drops) && !defined(existing.drops)) existing.drops = node.drops;
       return newPath;
     }
     if (updateAt(path, function(parent) {


### PR DESCRIPTION
Found by @isaacl:

> analysis board is detecting checkmate even though it's not.  but when I import the position into a study or as a fresh pgn, it calcuates the move as normal
>
> ![image](https://cloud.githubusercontent.com/assets/402777/23201927/13b16c98-f8dc-11e6-8174-85b73f9c264f.png)
> https://en.lichess.org/jXTPa1HQ/black#32 in the computer line

The difference is that there is a fishnet pv in the original game and drop information did not get merged properly with the existing nodes.

Also removes the unused `gameEnd.js`.