### PR TITLE
Slightly lower the study overboard in order to prevent it from overflowing

### DIFF
--- a/public/stylesheets/study.css
+++ b/public/stylesheets/study.css
@@ -366,6 +366,9 @@ div.underboard .notif.error {
   margin: 6px 0 0 0;
   display: inline-block;
 }
+.study_overboard.lichess_overboard {
+  top: 60%;
+}
 .study_overboard .material.form {
   margin: 0;
   padding: 20px;


### PR DESCRIPTION
<img width="1133" alt="screen shot 2017-02-22 at 10 15 37 pm" src="https://cloud.githubusercontent.com/assets/542245/23244708/d4056736-f94c-11e6-8847-32b43264e1df.png">
<img width="1126" alt="screen shot 2017-02-22 at 10 15 47 pm" src="https://cloud.githubusercontent.com/assets/542245/23244710/d40b96a6-f94c-11e6-8de2-899b35213c79.png">
<img width="1136" alt="screen shot 2017-02-22 at 10 15 58 pm" src="https://cloud.githubusercontent.com/assets/542245/23244709/d40ac0b4-f94c-11e6-996b-8e9ab5726811.png">
<img width="1115" alt="screen shot 2017-02-22 at 10 16 06 pm" src="https://cloud.githubusercontent.com/assets/542245/23244711/d420af5a-f94c-11e6-9180-2829c300ba23.png">
<img width="1117" alt="screen shot 2017-02-22 at 10 16 13 pm" src="https://cloud.githubusercontent.com/assets/542245/23244712/d421bea4-f94c-11e6-803b-767310ff55f1.png">