### PR TITLE
Slightly lower game config overboard so it doesn’t overflow when setting up a game from a position.

### DIFF
--- a/public/stylesheets/home.css
+++ b/public/stylesheets/home.css
@@ -743,6 +743,9 @@ div.game_config .color_submits button.random i {
   height: 55px;
   padding: 0;
 }
+div.game_config.lichess_overboard {
+  top: 55%;
+}
 #nb_games_in_play {
   margin-bottom: 10px;
 }


### PR DESCRIPTION
Before: <img width="1087" alt="screen shot 2017-02-28 at 12 04 14 am" src="https://cloud.githubusercontent.com/assets/542245/23393617/af2c9dd4-fd49-11e6-8900-05f0d6ab66f5.png">
After: <img width="1075" alt="screen shot 2017-02-28 at 12 04 02 am" src="https://cloud.githubusercontent.com/assets/542245/23393619/b09ceb1a-fd49-11e6-81f7-77ad2f12136b.png">