### PR TITLE
Allow mods to kick a user from rankings

### DIFF
--- a/app/controllers/Mod.scala
+++ b/app/controllers/Mod.scala
@@ -61,6 +61,10 @@ object Mod extends LilaController {
     modApi.reopenAccount(me.id, username) inject redirect(username)
   }
 
+  def kickFromRankings(username: String) = Secure(_.RemoveRanking) { implicit ctx => me =>
+    modApi.kickFromRankings(me.id, username) inject redirect(username)
+  }
+
   private case class Irwin(result: Boolean, reason: String)
   private implicit val IrwinReads = Json.reads[Irwin]
 

--- a/app/views/user/mod.scala.html
+++ b/app/views/user/mod.scala.html
@@ -49,6 +49,11 @@
   </form>
   }
   }
+  @if(isGranted(_.RemoveRanking)) {
+  <form method="post" action="@routes.Mod.kickFromRankings(u.username)" data-hint="Excludes this user from the rankings during the next calculation." class="hint--bottom-left">
+    <input class="button" type="submit" value="Kick from ranking" />
+  </form>
+  }
   @if(isGranted(_.SetTitle)) {
   <br />
   <br />

--- a/conf/routes
+++ b/conf/routes
@@ -353,6 +353,7 @@ POST  /mod/:username/reopen            controllers.Mod.reopenAccount(username: S
 POST  /mod/:username/title             controllers.Mod.setTitle(username: String)
 GET   /mod/:username/communication     controllers.Mod.communication(username: String)
 POST  /mod/:ip/ipban                   controllers.Mod.ipban(ip: String)
+POST  /mod/:username/kickFromRankings  controllers.Mod.kickFromRankings(username: String)
 GET   /mod/log                         controllers.Mod.log
 POST  /mod/:username/refreshUserAssess controllers.Mod.refreshUserAssess(username: String)
 POST  /mod/:username/email             controllers.Mod.setEmail(username: String)

--- a/modules/hub/src/main/actorApi.scala
+++ b/modules/hub/src/main/actorApi.scala
@@ -60,6 +60,7 @@ package mod {
   case class MarkCheater(userId: String)
   case class MarkBooster(userId: String)
   case class ChatTimeout(mod: String, user: String, reason: String)
+  case class KickFromRankings(userId: String)
 }
 
 package captcha {

--- a/modules/mod/src/main/ModApi.scala
+++ b/modules/mod/src/main/ModApi.scala
@@ -119,6 +119,11 @@ final class ModApi(
   def ipban(mod: String, ip: String): Funit =
     (firewall blockIp IpAddress(ip)) >> logApi.ipban(mod, ip)
 
+  def kickFromRankings(mod: String, username: String): Funit = withUser(username) { user =>
+    lilaBus.publish(lila.hub.actorApi.mod.KickFromRankings(user.id), 'kickFromRankings)
+    logApi.kickFromRankings(mod, user.id)
+  }
+
   private def withUser[A](username: String)(op: User => Fu[A]): Fu[A] =
     UserRepo named username flatten "[mod] missing user " + username flatMap op
 

--- a/modules/mod/src/main/Modlog.scala
+++ b/modules/mod/src/main/Modlog.scala
@@ -39,6 +39,7 @@ case class Modlog(
     case Modlog.troll => "shadowban"
     case Modlog.untroll => "un-shadowban"
     case Modlog.permissions => "set permissions"
+    case Modlog.kickFromRankings => "kick from rankings"
     case a => a
   }
 
@@ -75,4 +76,5 @@ object Modlog {
   val deleteTeam = "deleteTeam"
   val terminateTournament = "terminateTournament "
   val chatTimeout = "chatTimeout "
+  val kickFromRankings = "kickFromRankings"
 }

--- a/modules/mod/src/main/ModlogApi.scala
+++ b/modules/mod/src/main/ModlogApi.scala
@@ -99,6 +99,10 @@ final class ModlogApi(coll: Coll) {
     Modlog(mod, user.some, Modlog.permissions, details = permissions.mkString(", ").some)
   }
 
+  def kickFromRankings(mod: String, user: String) = add {
+    Modlog(mod, user.some, Modlog.kickFromRankings)
+  }
+
   def recent = coll.find($empty).sort($sort naturalDesc).cursor[Modlog]().gather[List](100)
 
   def wasUnengined(userId: String) = coll.exists($doc(

--- a/modules/security/src/main/Permission.scala
+++ b/modules/security/src/main/Permission.scala
@@ -42,18 +42,19 @@ object Permission {
   case object Coach extends Permission("ROLE_COACH")
   case object PreviewCoach extends Permission("ROLE_PREVIEW_COACH")
   case object ModNote extends Permission("ROLE_MOD_NOTE")
+  case object RemoveRanking extends Permission("ROLE_REMOVE_RANKING")
 
   case object Hunter extends Permission("ROLE_HUNTER", List(
     ViewBlurs, MarkEngine, MarkBooster, StaffForum,
     UserSpy, UserEvaluate, SeeReport, Beta, SeeInsight,
-    UserSearch, ModNote
+    UserSearch, ModNote, RemoveRanking
   ))
 
   case object Admin extends Permission("ROLE_ADMIN", List(
     Hunter, ModerateForum, IpBan, CloseAccount, ReopenAccount,
     ChatTimeout, MarkTroll, SetTitle, SetEmail, ModerateQa, StreamConfig,
     MessageAnyone, CloseTeam, TerminateTournament, ManageTournament, ManageEvent,
-    PreviewCoach, PracticeConfig
+    PreviewCoach, PracticeConfig, RemoveRanking
   ))
 
   case object SuperAdmin extends Permission("ROLE_SUPER_ADMIN", List(

--- a/modules/user/src/main/Env.scala
+++ b/modules/user/src/main/Env.scala
@@ -60,6 +60,7 @@ final class Env(
     def receive = {
       case lila.hub.actorApi.mod.MarkCheater(userId) => rankingApi remove userId
       case lila.hub.actorApi.mod.MarkBooster(userId) => rankingApi remove userId
+      case lila.hub.actorApi.mod.KickFromRankings(userId) => rankingApi remove userId
       case User.Active(user) =>
         if (!user.seenRecently) UserRepo setSeenAt user.id
         onlineUserIdMemo put user.id


### PR DESCRIPTION
Use case: yesterday I wanted to kick opperwezen's second account from the Top 10 because he had two accounts there. I had no proper way to do this, so I had to mark as booster and immediately as un-booster to trigger rankingApi.remove.

This new 'Kick from ranking' button will trigger rankingApi.remove to exclude a user from the next ranking calculation (because by my observation, .remove does not invalidate the cache, and I suppose that's by design).