### PR TITLE
Fixing an incorrect URL example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ $.ajax({
 ### `POST /api/users` fetch many users by ID
 
 ```
-> curl --data "legend,lovlas" 'https://en.lichess.org/users'
+> curl --data "legend,lovlas" 'https://en.lichess.org/api/users'
 ```
 
 Users are returned in the order same order as the ids.


### PR DESCRIPTION
Adding the missing `/api` to `curl --data "legend,lovlas" 'https://en.lichess.org/users'`