### PR TITLE
add webassembly support for ceval

### DIFF
--- a/ui/analyse/src/ctrl.js
+++ b/ui/analyse/src/ctrl.js
@@ -490,7 +490,7 @@ module.exports = function(opts) {
         var env = this.ceval.env();
         var desc = [
           'ceval crash',
-          env.pnacl ? 'native' : 'asmjs',
+          env.pnacl ? 'pnacl' : (env.wasm ? 'wasm' : 'asmjs'),
           'multiPv:' + env.multiPv,
           'threads:' + env.threads,
           'hashSize:' + env.hashSize,

--- a/ui/ceval/src/ctrl.js
+++ b/ui/ceval/src/ctrl.js
@@ -12,6 +12,7 @@ module.exports = function(opts) {
   };
 
   var pnaclSupported = !opts.failsafe && navigator.mimeTypes['application/x-pnacl'];
+  var wasmSupported = !opts.failsafe && typeof WebAssembly === 'object' && WebAssembly.validate(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00));
   var minDepth = 6;
   var maxDepth = storedProp(storageKey('ceval.max-depth'), 18);
   var multiPv = storedProp(storageKey('ceval.multipv'), opts.multiPvDefault || 1);
@@ -28,8 +29,9 @@ module.exports = function(opts) {
   var isDeeper = m.prop(false);
 
   var pool = makePool(stockfishProtocol, {
-    asmjs: '/assets/vendor/stockfish.js/stockfish.js?v=16',
+    asmjs: '/assets/vendor/stockfish.js/stockfish.js?v=17',
     pnacl: pnaclSupported && '/assets/vendor/stockfish.pexe/nacl/stockfish.nmf?v=16',
+    wasm: wasmSupported && '/assets/vendor/stockfish.js/stockfish.wasm.js?v=17',
     onCrash: opts.onCrash
   }, {
     minDepth: minDepth,
@@ -152,6 +154,7 @@ module.exports = function(opts) {
 
   return {
     pnaclSupported: pnaclSupported,
+    wasmSupported: wasmSupported,
     start: start,
     stop: stop,
     allowed: allowed,
@@ -193,6 +196,7 @@ module.exports = function(opts) {
     env: function() {
       return {
         pnacl: !!pnaclSupported,
+        wasm: !!wasmSupported,
         multiPv: multiPv(),
         threads: threads(),
         hashSize: hashSize(),

--- a/ui/ceval/src/pool.js
+++ b/ui/ceval/src/pool.js
@@ -43,7 +43,7 @@ function makeHelper(makeWorker, terminateWorker, poolOpts, makeProtocol, protoco
 
 function makeWebWorker(makeProtocol, poolOpts, protocolOpts) {
   return makeHelper(function() {
-    return new Worker(poolOpts.asmjs);
+    return new Worker(poolOpts.wasm || poolOpts.asmjs);
   }, function(worker) {
     worker.terminate();
   }, poolOpts, makeProtocol, protocolOpts);

--- a/ui/ceval/src/view.js
+++ b/ui/ceval/src/view.js
@@ -70,7 +70,7 @@ function threatButton(ctrl) {
 function engineName(ctrl) {
   return [
     lichess.engineName,
-    ctrl.pnaclSupported ? m('span.native', 'native') : m('span.asmjs', 'asmjs')
+    ctrl.pnaclSupported ? m('span.native', 'pnacl') : (ctrl.wasmSupported ? m('span.native', 'wasm') : m('span.asmjs', 'asmjs'))
   ];
 }
 


### PR DESCRIPTION
The binary format for WebAssembly `0x1` has been frozen. [Support will arrive in mainline browsers soon](https://lists.w3.org/Archives/Public/public-webassembly/2017Feb/0002.html). Until then it can be seen in nightlies of Firefox and Chromium.

The build only differs in flags and a small wrapper, otherwise it uses the same code adjustments as stockfish.js.

&nbsp; | ASMJS | WASM | PNacl
--- | --- | --- | ---
file sizes | 1140K | 476K + 164K [1] | **484K**
gzipped | 260K | **144K + 44K** | 412K

[1] The wrapper script will become smaller in the future.

In terms of speed WASM beats ASMJS several times over. PNaCl is still 5-10% faster. More importantly WebAssembly does not yet support threading, so if available PNaCl will be preferred for a while. This also means WASM requires the same hack for stopping search, the pool, and (probably) can not support "Go deeper".

---

Update: I deployed this to stage.