### PR TITLE
Countdown tweaks

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -919,6 +919,14 @@ lichess.notifyApp = (function() {
       });
     });
 
+    play.warmup = function() {
+      if (enabled()) {
+        // See goldfire/howler.js#715
+        Howler._autoResume();   // This resumes sound if suspended.
+        Howler._autoSuspend();  // This starts the 30s timer to suspend.
+      }
+    };
+
     play.set = function() {
       return soundSet;
     };
@@ -1185,7 +1193,7 @@ lichess.notifyApp = (function() {
     _create: function() {
       var self = this;
       // this.options.time: seconds Integer
-      var target = this.options.time * 1000 + Date.now() - 1;
+      var target = this.options.time * 1000 + Date.now();
       var timeEl = this.element.find('>.time')[0];
       var tick = function() {
         var remaining = target - Date.now();
@@ -1199,11 +1207,11 @@ lichess.notifyApp = (function() {
     _pad: function(x) { return (x < 10 ? '0' : '') + x; },
 
     _formatMs: function(msTime) {
-      var date = new Date(Math.max(0, msTime));
+      var date = new Date(Math.max(0, msTime + 500));
 
       var hours = date.getUTCHours(),
           minutes = date.getUTCMinutes(),
-          seconds = date.getSeconds();
+          seconds = date.getUTCSeconds();
 
       if (hours > 0) {
         return hours + ':' + this._pad(minutes) + ':' + this._pad(seconds);

--- a/ui/tournament/src/sound.js
+++ b/ui/tournament/src/sound.js
@@ -5,7 +5,7 @@ function doCountDown(targetTime) {
   var started = false;
 
   return function curCounter() {
-    var secondsToStart = targetTime - (new Date().getTime() / 1000);
+    var secondsToStart = targetTime - Date.now() / 1000;
 
     // always play the 0 sound before completing.
     var bestTick = Math.max(0, Math.round(secondsToStart));
@@ -47,8 +47,10 @@ module.exports = {
     if (data.secondsToStart > 60 * 60 * 24) return;
 
     countDownTimeout = setTimeout(
-      doCountDown(new Date().getTime() / 1000 + data.secondsToStart - 0.1),
+      doCountDown(Date.now() / 1000 + data.secondsToStart - 0.1),
       900);  // wait 900ms before starting countdown.
+
+    setTimeout(lichess.sound.warmup, (data.secondsToStart - 15) * 1000);
 
     // Preload countdown sounds.
     for (var i = 10; i>=0; i--) {


### PR DESCRIPTION
- Round countdown clock to nearest second instead of truncating millis
  This better aligns with countdown sounds which are also rounded.
- Call Howler functions to resume WebAudio context.
  Use this 'warmup' for tourney countdown to ensure smooth start.
- General cleanup (new Date().getTime()  -->  Date.now())