### PR TITLE
Improve blur detection

### DIFF
--- a/ui/round/src/blur.js
+++ b/ui/round/src/blur.js
@@ -2,27 +2,26 @@ var game = require('game').game;
 
 // Register blur events to be sent as move metadata
 
-var blur = false;
+var lastFocus;
+var lastMove;
 
 var init = function(ctrl) {
   if (game.isPlayerPlaying(ctrl.data) && !ctrl.data.simul)
-    window.addEventListener('blur', function() {
-      blur = true;
+    window.addEventListener('focus', function() {
+      lastFocus = Date.now();
     });
 }
 
 var get = function() {
-  var value = blur;
-  blur = false;
-  return value;
+  return lastFocus - lastMove > 1000;
 };
 
-var reset = function() {
-  blur = false;
+var onMove = function() {
+  lastMove = Date.now();
 };
 
 module.exports = {
   init: init,
   get: get,
-  reset: reset
+  onMove: onMove
 };

--- a/ui/round/src/ctrl.js
+++ b/ui/round/src/ctrl.js
@@ -195,6 +195,7 @@ module.exports = function(opts) {
       role: role,
       pos: key
     };
+    if (blur.get()) drop.b = 1;
     this.resign(false);
     if (this.userId && this.data.pref.submitMove && !isPredrop) {
       this.vm.dropToSubmit = drop;
@@ -288,6 +289,7 @@ module.exports = function(opts) {
         check: !!o.check
       });
       if (o.check) lichess.sound.check();
+      blur.onMove();
     }
     if (o.clock)(this.clock || this.correspondenceClock).update(o.clock.white, o.clock.black);
     d.game.threefold = !!o.threefold;


### PR DESCRIPTION
Track 'focus' event instead of blur, and only count
blurs which include a focus at least 1s after
opponent moves.