### PR TITLE
fix ui/site gulp build without ab file

### DIFF
--- a/ui/site/gulpfile.js
+++ b/ui/site/gulpfile.js
@@ -13,17 +13,22 @@ var onError = function(error) {
 var standalone = 'Lichess';
 
 var abFile = process.env.LILA_AB_FILE;
-if (!process.env.LILA_AB_FILE) gutil.log('Building without AB file');
 
 gulp.task('jquery-fill', function() {
   return gulp.src('src/jquery.fill.js')
     .pipe(streamify(uglify()))
     .pipe(gulp.dest('./dist'));
 });
+
 gulp.task('ab', function() {
-  return gulp.src(process.env.LILA_AB_FILE)
-    .pipe(streamify(uglify()))
-    .pipe(gulp.dest('./dist'));
+  if (abFile) {
+    return gulp.src(abFile)
+      .pipe(streamify(uglify()))
+      .pipe(gulp.dest('./dist'));
+  } else {
+    gutil.log(gutil.colors.yellow('Building without AB file'));
+    return gutil.noop();
+  }
 });
 
 gulp.task('prod-source', function() {


### PR DESCRIPTION
Previously the build was failing with:

```
[13:24:11] Building without AB file
[13:24:11] Using gulpfile ~/Projekte/lila/ui/site/gulpfile.js
[13:24:11] Starting 'jquery-fill'...
[13:24:11] Starting 'ab'...
[13:24:11] 'ab' errored after 160 μs
[13:24:11] Error: Invalid glob argument: undefined
    at Gulp.src (/home/niklas/Projekte/lila/ui/site/node_modules/vinyl-fs/lib/src/index.js:20:11)
    at Gulp.<anonymous> (/home/niklas/Projekte/lila/ui/site/gulpfile.js:24:15)
    at module.exports (/home/niklas/Projekte/lila/ui/site/node_modules/orchestrator/lib/runTask.js:34:7)
    at Gulp.Orchestrator._runTask (/home/niklas/Projekte/lila/ui/site/node_modules/orchestrator/index.js:273:3)
    at Gulp.Orchestrator._runStep (/home/niklas/Projekte/lila/ui/site/node_modules/orchestrator/index.js:214:10)
    at Gulp.Orchestrator.start (/home/niklas/Projekte/lila/ui/site/node_modules/orchestrator/index.js:134:8)
    at /usr/lib/node_modules/gulp/bin/gulp.js:129:20
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
    at Function.Module.runMain (module.js:449:11)
[13:24:11] Finished 'jquery-fill' after 75 ms
```