### PR TITLE
mobile.css: fix list style for long bullet points

### DIFF
--- a/public/stylesheets/mobile.css
+++ b/public/stylesheets/mobile.css
@@ -33,6 +33,8 @@
 .mobile .left-side li {
   list-style-type: none;
   line-height: 1.5em;
+  padding-left: 2em;
+  text-indent: -1em;
 }
 .mobile .left-side li:before {
   vertical-align: middle;


### PR DESCRIPTION
Before:

![2017-03-14-153930_833x620_scrot](https://cloud.githubusercontent.com/assets/402777/23905956/f131e2aa-08cc-11e7-9d9a-18538126be0f.png)


After:

![2017-03-14-153919_833x620_scrot](https://cloud.githubusercontent.com/assets/402777/23905930/e43bab76-08cc-11e7-878c-5d0e6ffd4649.png)
