### PR TITLE
Correct translation of Welsh

### DIFF
--- a/modules/i18n/src/main/LangList.scala
+++ b/modules/i18n/src/main/LangList.scala
@@ -182,7 +182,7 @@ object LangList {
     "vi" -> "Tiếng Việt",
     "vo" -> "Volapük",
     "wa" -> "Walon",
-    "cy" -> "Cymrae",
+    "cy" -> "Cymraeg",
     "wo" -> "Wolof",
     "fy" -> "Frysk",
     "xh" -> "isiXhosa",


### PR DESCRIPTION
"Cymraeg" is the correct translation of Welsh.