### PR TITLE
fix playUci for underpromotions (closes #2822)

### DIFF
--- a/ui/analyse/src/crazy/crazyView.js
+++ b/ui/analyse/src/crazy/crazyView.js
@@ -1,5 +1,4 @@
 var crazyDrag = require('./crazyDrag');
-var defined = require('common').defined;
 var m = require('mithril');
 
 var eventNames = ['mousedown', 'touchstart'];

--- a/ui/analyse/src/ctrl.js
+++ b/ui/analyse/src/ctrl.js
@@ -1,6 +1,5 @@
 var opposite = require('chessground/util').opposite;
 var tree = require('tree');
-var ground = require('./ground');
 var keyboard = require('./keyboard');
 var actionMenu = require('./actionMenu').controller;
 var autoplay = require('./autoplay');
@@ -661,10 +660,12 @@ module.exports = function(opts) {
     if (uci[1] === '@') this.chessground.newPiece({
       color: this.chessground.state.movable.color,
       role: chessUtil.sanToRole[uci[0]]
-    },
-    move[1])
-    else if (!move[2]) sendMove(move[0], move[1])
-    else sendMove(move[0], move[1], chessUtil.sanToRole[move[2].toUpperCase()]);
+    }, move[1]);
+    else {
+      var capture = this.chessground.state.pieces[move[1]];
+      var promotion = move[2] && chessUtil.sanToRole[move[2].toUpperCase()];
+      sendMove(move[0], move[1], capture, promotion);
+    }
   }.bind(this);
 
   this.explorerMove = function(uci) {


### PR DESCRIPTION
The signature of sendMove recently changed and now takes a captured
piece as the third argument. Call it accordingly.