### PR TITLE
make Centis ordered and provide abs

### DIFF
--- a/modules/common/src/main/Centis.scala
+++ b/modules/common/src/main/Centis.scala
@@ -3,7 +3,7 @@ package lila.common
 import scala.concurrent.duration._
 
 // maximum value = Int.MaxValue / 100 / 60 / 60 / 24 = 248 days
-case class Centis(value: Int) extends AnyVal {
+case class Centis(value: Int) extends AnyVal with Ordered[Centis] {
 
   def roundTenths: Int = math.round(value.toFloat / 10)
   def millis: Long = value * 10l
@@ -12,10 +12,11 @@ case class Centis(value: Int) extends AnyVal {
   def +(other: Centis) = Centis(value + other.value)
   def -(other: Centis) = Centis(value - other.value)
   def *(scalar: Int) = Centis(scalar * value)
-  def <(other: Centis) = value < other.value
-  def >(other: Centis) = value > other.value
   def unary_- = Centis(-value)
 
+  def compare(other: Centis) = value compare other.value
+
+  def abs: Centis = Centis(value.abs)
   def atMost(other: Int) = Centis(value atMost other)
   def atLeast(other: Int) = Centis(value atLeast other)
 }


### PR DESCRIPTION
Let's have some more utilities. The clocktimes-v2 tests need them.