### PR TITLE
Fix movetime calculations for games with inc

### DIFF
--- a/modules/game/src/main/BSONHandlers.scala
+++ b/modules/game/src/main/BSONHandlers.scala
@@ -166,7 +166,7 @@ object BSONHandlers {
     for {
       clk <- clock
       history <- clockHistory
-      times = history.get(color)
+      times = history(color)
     } yield BinaryFormat.clockHistory.writeSide(Centis(clk.limit * 100), times, flagged has color)
 
   private[game] def clockBSONReader(since: DateTime, whiteBerserk: Boolean, blackBerserk: Boolean) = new BSONReader[BSONBinary, Color => Clock] {

--- a/modules/game/src/main/Game.scala
+++ b/modules/game/src/main/Game.scala
@@ -123,6 +123,15 @@ case class Game(
     } yield Centis(0) :: {
       val pairs = clocks.iterator zip clocks.iterator.drop(1)
 
+      // We need to determine if this color's last clock had inc applied.
+      // if finished and history.size == playedTurns then game was ended
+      // by a players move, such as with mate or autodraw. In this case,
+      // the last move of the game, and the only one without inc, is the
+      // last entry of the clock history for !turnColor.
+      //
+      // On the other hand, if history.size is more than playedTurns,
+      // then the game ended during a players turn by async event, and
+      // the last recorded time is in the history for turnColor.
       val noLastInc = finished && (history.size <= playedTurns) == (color != turnColor)
 
       pairs map {

--- a/modules/game/src/main/GameDiff.scala
+++ b/modules/game/src/main/GameDiff.scala
@@ -47,7 +47,7 @@ private[game] object GameDiff {
         clk <- g.clock
         history <- g.clockHistory
         curColor = g.turnColor
-        times = history.get(color)
+        times = history(color)
       } yield (Centis(clk.limit * 100), times, g.flagged has color)
 
     def clockHistoryToBytes(o: Option[ClockHistorySide]) = o.map {


### PR DESCRIPTION
Properly calculate if the current color's last move
had inc applied, which affects movetime calc.