### PR TITLE
remove chessli

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "public/vendor/tagmanager"]
 	path = public/vendor/tagmanager
 	url = https://github.com/max-favilli/tagmanager
-[submodule "ui/chessli"]
-	path = ui/chessli
-	url = https://github.com/ornicar/chess.js
 [submodule "public/vendor/moment"]
 	path = public/vendor/moment
 	url = https://github.com/moment/moment


### PR DESCRIPTION
I cant find any module that uses this now. For example in learn it is installed from `github:ornicar/chess.js#learn` instead.