### PR TITLE
movetime chart: translate to improve 1s moves

### DIFF
--- a/public/javascripts/chart/movetime.js
+++ b/public/javascripts/chart/movetime.js
@@ -1,6 +1,4 @@
 lichess.movetimeChart = function(data) {
-  var log1p = Math.log1p || function(x) { return Math.log(x + 1); };
-
   lichess.loadScript('/assets/javascripts/chart/common.js').done(function() {
     lichess.loadScript('/assets/javascripts/chart/division.js').done(function() {
       lichess.chartCommon('highchart').done(function() {
@@ -19,6 +17,8 @@ lichess.movetimeChart = function(data) {
             var ply = 0;
             var max = 0;
 
+            var logC = Math.pow(Math.log(3), 2);
+
             moveCentis.forEach(function(time, i) {
               var node = tree[i + 1];
               ply = node ? node.ply : ply + 1;
@@ -26,7 +26,8 @@ lichess.movetimeChart = function(data) {
 
               var turn = (ply + 1) >> 1;
               var color = ply & 1;
-              var y = Math.pow(log1p(.005 * Math.min(time, 12e4)), 2);
+
+              var y = Math.pow(Math.log(.005 * Math.min(time, 12e4) + 3), 2) - logC;
               max = Math.max(y, max);
 
               series[color ? 'white' : 'black'].push({


### PR DESCRIPTION
This change moves the plot, avoiding the concave
section of the curve. There's a bunch of free params
so it's hard to find the right balance but I think
this is an improvement...

blue = current, red = new.

![image](https://cloud.githubusercontent.com/assets/1027886/24687257/dc81b0fe-1986-11e7-8cbf-3b1b35832a4c.png)
