### PR TITLE
Include time control in variant tourney names

### DIFF
--- a/modules/tournament/src/main/Schedule.scala
+++ b/modules/tournament/src/main/Schedule.scala
@@ -24,6 +24,7 @@ case class Schedule(
         case (_, Some(max)) => s"U${max.rating} ${speed.toString}"
       }
     case _ if variant.standard => s"${position.shortName} ${speed.toString}"
+    case m @ Schedule.Freq.Hourly => s"${variant.name} ${speed.toString}"
     case _ => s"${freq.toString} ${variant.name}"
   }
 


### PR DESCRIPTION
For Hourly Variant tourneys, drop the word 'Hourly'
and instead include the time control.