### PR TITLE
HippoBullet, the 2+0 time control

### DIFF
--- a/modules/tournament/src/main/Schedule.scala
+++ b/modules/tournament/src/main/Schedule.scala
@@ -93,22 +93,18 @@ object Schedule {
     case object UltraBullet extends Speed(5)
     case object HyperBullet extends Speed(10)
     case object Bullet extends Speed(20)
-    // TODO: come up with a better name to display.
-    case object SlowBullet extends Speed(25) {
-      override def toString = "Bullet"
-      override def name = "slowbullet"
-    }
+    case object HippoBullet extends Speed(25)
     case object SuperBlitz extends Speed(30)
     case object Blitz extends Speed(40)
     case object Classical extends Speed(50)
-    val all: List[Speed] = List(UltraBullet, HyperBullet, Bullet, SlowBullet, SuperBlitz, Blitz, Classical)
+    val all: List[Speed] = List(UltraBullet, HyperBullet, Bullet, HippoBullet, SuperBlitz, Blitz, Classical)
     val mostPopular: List[Speed] = List(Bullet, Blitz, Classical)
     def apply(name: String) = all find (_.name == name)
     def byId(id: Int) = all find (_.id == id)
     def similar(s1: Speed, s2: Speed) = (s1, s2) match {
       case (a, b) if a == b => true
       case (HyperBullet, Bullet) | (Bullet, HyperBullet) => true
-      case (Bullet, SlowBullet) | (SlowBullet, Bullet) => true
+      case (Bullet, HippoBullet) | (HippoBullet, Bullet) => true
       case _ => false
     }
     def fromClock(clock: chess.Clock.Config) = {
@@ -116,13 +112,13 @@ object Schedule {
       if (time < 30) UltraBullet
       else if (time < 60) HyperBullet
       else if (time < 120) Bullet
-      else if (time < 180) SlowBullet
+      else if (time < 180) HippoBullet
       else if (time < 480) Blitz
       else Classical
     }
     def toPerfType(speed: Speed) = speed match {
       case UltraBullet => PerfType.UltraBullet
-      case HyperBullet | Bullet | SlowBullet => PerfType.Bullet
+      case HyperBullet | Bullet | HippoBullet => PerfType.Bullet
       case SuperBlitz | Blitz => PerfType.Blitz
       case Classical => PerfType.Classical
     }
@@ -142,12 +138,12 @@ object Schedule {
     Some((s.freq, s.variant, s.speed) match {
 
       case (Hourly, _, UltraBullet | HyperBullet | Bullet) => 27
-      case (Hourly, _, SlowBullet | SuperBlitz | Blitz) => 57
+      case (Hourly, _, HippoBullet | SuperBlitz | Blitz) => 57
       case (Hourly, _, Classical) if s.hasMaxRating => 57
       case (Hourly, _, Classical) => 117
 
       case (Daily | Eastern, _, UltraBullet | HyperBullet | Bullet) => 60
-      case (Daily | Eastern, _, SlowBullet | SuperBlitz) => 90
+      case (Daily | Eastern, _, HippoBullet | SuperBlitz) => 90
       case (Daily | Eastern, Standard, Blitz) => 120
       case (Daily | Eastern, _, Classical) => 150
 
@@ -155,22 +151,22 @@ object Schedule {
       case (Daily | Eastern, _, Blitz) => 60 // variant daily is shorter
 
       case (Weekly, _, UltraBullet | HyperBullet | Bullet) => 60 * 2
-      case (Weekly, _, SlowBullet | SuperBlitz) => 60 * 3
+      case (Weekly, _, HippoBullet | SuperBlitz) => 60 * 3
       case (Weekly, _, Blitz) => 60 * 3
       case (Weekly, _, Classical) => 60 * 4
 
       case (Weekend, _, UltraBullet | HyperBullet | Bullet) => 90
-      case (Weekend, _, SlowBullet | SuperBlitz) => 60 * 2
+      case (Weekend, _, HippoBullet | SuperBlitz) => 60 * 2
       case (Weekend, _, Blitz) => 60 * 3
       case (Weekend, _, Classical) => 60 * 4
 
       case (Monthly, _, UltraBullet | HyperBullet | Bullet) => 60 * 3
-      case (Monthly, _, SlowBullet | SuperBlitz) => 60 * 3 + 30
+      case (Monthly, _, HippoBullet | SuperBlitz) => 60 * 3 + 30
       case (Monthly, _, Blitz) => 60 * 4
       case (Monthly, _, Classical) => 60 * 5
 
       case (Yearly, _, UltraBullet | HyperBullet | Bullet) => 60 * 4
-      case (Yearly, _, SlowBullet | SuperBlitz) => 60 * 5
+      case (Yearly, _, HippoBullet | SuperBlitz) => 60 * 5
       case (Yearly, _, Blitz) => 60 * 6
       case (Yearly, _, Classical) => 60 * 8
 
@@ -201,7 +197,7 @@ object Schedule {
       case (_, _, UltraBullet) => TC(15, 0)
       case (_, _, HyperBullet) => TC(30, 0)
       case (_, _, Bullet) => TC(60, 0)
-      case (_, _, SlowBullet) => TC(2 * 60, 0)
+      case (_, _, HippoBullet) => TC(2 * 60, 0)
       case (_, _, SuperBlitz) => TC(3 * 60, 0)
       case (_, _, Blitz) => TC(5 * 60, 0)
       case (_, _, Classical) => TC(10 * 60, 0)
@@ -218,19 +214,19 @@ object Schedule {
         case (_, UltraBullet) => 0
 
         case (Hourly, UltraBullet | HyperBullet | Bullet) => 20
-        case (Hourly, SlowBullet | SuperBlitz | Blitz) => 15
+        case (Hourly, HippoBullet | SuperBlitz | Blitz) => 15
         case (Hourly, Classical) => 10
 
         case (Daily | Eastern, UltraBullet | HyperBullet | Bullet) => 20
-        case (Daily | Eastern, SlowBullet | SuperBlitz | Blitz) => 15
+        case (Daily | Eastern, HippoBullet | SuperBlitz | Blitz) => 15
         case (Daily | Eastern, Classical) => 10
 
         case (Weekly | Monthly, UltraBullet | HyperBullet | Bullet) => 30
-        case (Weekly | Monthly, SlowBullet | SuperBlitz | Blitz) => 20
+        case (Weekly | Monthly, HippoBullet | SuperBlitz | Blitz) => 20
         case (Weekly | Monthly, Classical) => 15
 
         case (Weekend, UltraBullet | HyperBullet | Bullet) => 30
-        case (Weekend, SlowBullet | SuperBlitz | Blitz) => 20
+        case (Weekend, HippoBullet | SuperBlitz | Blitz) => 20
 
         case _ => 0
       }

--- a/modules/tournament/src/main/TournamentScheduler.scala
+++ b/modules/tournament/src/main/TournamentScheduler.scala
@@ -254,7 +254,7 @@ private final class TournamentScheduler private (api: TournamentApi) extends Act
           val speed = hour % 6 match {
             case 0 | 3 => Bullet
             case 1 | 4 => SuperBlitz
-            case 5 => SlowBullet
+            case 5 => HippoBullet
             case _ => Blitz
           }
           List(


### PR DESCRIPTION
Because Hippos are large, or as a more memorable
misspelling of the hypo prefix.

Thanks to lightsss for thinking up this cute name.