### PR TITLE
Replace 'new Date()' with 'Date.now()'

### DIFF
--- a/bin/prod/wsmon-away.js
+++ b/bin/prod/wsmon-away.js
@@ -33,7 +33,7 @@ var runCommand = function(cmd) {
 var lastRestarted = 0;
 
 var doRestartLichess = function() {
-  lastRestarted = new Date().getTime();
+  lastRestarted = Date.now();
   logger('error', 'Restart lichess now');
   runCommand('/home/lichess/bin/prod/restart-now');
 }
@@ -41,7 +41,7 @@ var doRestartLichess = function() {
 var restartLichess = function(msg) {
   logger('error', msg);
   logger('error', "Asking to restart");
-  if (new Date().getTime() < lastRestarted + 5 * 60 * 1000) logger('error', "Too early!");
+  if (Date.now() < lastRestarted + 5 * 60 * 1000) logger('error', "Too early!");
   else doRestartLichess();
   // runCommand('jstack -F `cat /home/lichess/RUNNING_PID` > /root/lichess-auto-jstack');
   // setTimeout(function() {

--- a/ui/analyse/src/study/studyForm.js
+++ b/ui/analyse/src/study/studyForm.js
@@ -30,11 +30,11 @@ var select = function(s) {
 module.exports = {
   ctrl: function(save, getData) {
 
-    var initAt = new Date();
+    var initAt = Date.now();
 
     function isNew() {
       var d = getData();
-      return d.from === 'scratch' && d.isNew && new Date() - initAt < 5000;
+      return d.from === 'scratch' && d.isNew && Date.now() - initAt < 5000;
     }
 
     var open = m.prop(false);

--- a/ui/ceval/src/stockfishProtocol.ts
+++ b/ui/ceval/src/stockfishProtocol.ts
@@ -59,7 +59,7 @@ export default class Protocol {
     if (this.expectedPvs < multiPv) this.expectedPvs = multiPv;
 
     // Work around negative times on Safari.
-    if (!elapsedMs || elapsedMs < 0) elapsedMs = Math.max(0, new Date().getTime() - this.work.startedAt!.getTime());
+    if (!elapsedMs || elapsedMs < 0) elapsedMs = Math.max(0, Date.now() - this.work.startedAt));
 
     if (depth < this.opts.minDepth) return;
 
@@ -104,7 +104,7 @@ export default class Protocol {
 
   start(w: Work) {
     this.work = w;
-    this.work.startedAt = new Date();
+    this.work.startedAt = Date.now();
     this.curEval = null;
     this.stopped = null;
     this.expectedPvs = 1;

--- a/ui/ceval/src/stockfishProtocol.ts
+++ b/ui/ceval/src/stockfishProtocol.ts
@@ -58,9 +58,6 @@ export default class Protocol {
     // Track max pv index to determine when pv prints are done.
     if (this.expectedPvs < multiPv) this.expectedPvs = multiPv;
 
-    // Work around negative times on Safari.
-    if (!elapsedMs || elapsedMs < 0) elapsedMs = Math.max(0, Date.now() - this.work.startedAt));
-
     if (depth < this.opts.minDepth) return;
 
     let pivot = this.work.threatMode ? 0 : 1;
@@ -104,7 +101,6 @@ export default class Protocol {
 
   start(w: Work) {
     this.work = w;
-    this.work.startedAt = Date.now();
     this.curEval = null;
     this.stopped = null;
     this.expectedPvs = 1;

--- a/ui/ceval/src/types.ts
+++ b/ui/ceval/src/types.ts
@@ -21,7 +21,6 @@ export interface Work {
   initialFen: string;
   currentFen: string;
   moves: string[];
-  startedAt?: Date;
   emit: (ev: Tree.ClientEval) => void;
 }
 

--- a/ui/chat2/src/moderation.ts
+++ b/ui/chat2/src/moderation.ts
@@ -5,7 +5,7 @@ import { userModInfo } from './xhr'
 import { userLink, spinner } from './util';
 
 function isToday(timestamp: number) {
-  return window.moment(timestamp).isSame(new Date(), 'day');
+  return window.moment(timestamp).isSame(Date.now(), 'day');
 }
 
 export function moderationCtrl(opts: ModerationOpts): ModerationCtrl {

--- a/ui/common/src/throttle.ts
+++ b/ui/common/src/throttle.ts
@@ -41,11 +41,11 @@ export default function(delay: number, noTrailing: any, callback: any, debounceM
   return function(this: any, ...args: any[]): void {
 
     const self: any = this;
-    const elapsed = Number(new Date()) - lastExec;
+    const elapsed = Date.now() - lastExec;
 
     // Execute `callback` and update the `lastExec` timestamp.
     function exec() {
-      lastExec = Number(new Date());
+      lastExec = Date.now();
       callback.apply(self, args);
     }
 

--- a/ui/site/src/ackable.js
+++ b/ui/site/src/ackable.js
@@ -4,7 +4,7 @@ module.exports = function(send) {
 
   function resend() {
     messages.forEach(function(m) {
-      if (new Date() - m.at > 2500) send(m.t, m.d);
+      if (Date.now() - m.at > 2500) send(m.t, m.d);
     });
   }
 
@@ -16,7 +16,7 @@ module.exports = function(send) {
       messages.push({
         t: t,
         d: d,
-        at: new Date()
+        at: Date.now()
       });
     },
     gotAck: function() {

--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -1,5 +1,3 @@
-// var start = new Date(); var millis = 500; while (new Date() - millis < start) {}
-
 lichess.challengeApp = (function() {
   var instance, booted;
   var $toggle = $('#challenge_notifications_tag');
@@ -668,11 +666,11 @@ lichess.notifyApp = (function() {
       });
 
       if (window.Fingerprint2) setTimeout(function() {
-        var t = +new Date();
+        var t = Date.now()
         new Fingerprint2({
           excludeJsFonts: true
         }).get(function(res) {
-          var time = (+new Date()) - t;
+          var time = Date.now() - t;
           $.post('/set-fingerprint/' + res + '/' + time);
         });
       }, 500);

--- a/ui/site/src/socket.js
+++ b/ui/site/src/socket.js
@@ -4,7 +4,7 @@ var makeAckable = require('./ackable');
 lichess.StrongSocket = function(url, version, settings) {
 
   var now = function() {
-    return new Date().getTime();
+    return Date.now();
   };
 
   var settings = $.extend(true, {}, lichess.StrongSocket.defaults, settings);

--- a/ui/site/src/util.js
+++ b/ui/site/src/util.js
@@ -276,14 +276,14 @@ lichess.idleTimer = function(delay, onIdle, onWakeUp) {
   var events = ['mousemove', 'touchstart'];
   var listening = false;
   var active = true;
-  var lastSeenActive = new Date();
+  var lastSeenActive = Date.now();
   var onActivity = function() {
     if (!active) {
       // console.log('Wake up');
       onWakeUp();
     }
     active = true;
-    lastSeenActive = new Date();
+    lastSeenActive = Date.now();
     stopListening();
   };
   var startListening = function() {
@@ -303,7 +303,7 @@ lichess.idleTimer = function(delay, onIdle, onWakeUp) {
     }
   };
   setInterval(function() {
-    if (active && new Date() - lastSeenActive > delay) {
+    if (active && Date.now() - lastSeenActive > delay) {
       // console.log('Idle mode');
       onIdle();
       active = false;

--- a/ui/tournament/src/xhr.js
+++ b/ui/tournament/src/xhr.js
@@ -7,7 +7,7 @@ var xhrConfig = function(xhr) {
 }
 
 function uncache(url) {
-  return url + '?_=' + new Date().getTime();
+  return url + '?_=' + Date.now();
 }
 
 // when the tournament no longer exists

--- a/ui/tournamentSchedule/src/view.js
+++ b/ui/tournamentSchedule/src/view.js
@@ -190,7 +190,7 @@ function isSystemTournament(t) {
 }
 
 module.exports = function(ctrl) {
-  now = (new Date()).getTime();
+  now = Date.now();
   startTime = now - 3 * 60 * 60 * 1000;
   stopTime = startTime + 10 * 60 * 60 * 1000;
 


### PR DESCRIPTION
Date.now() is faster and more readable when
used in arithmetic. Remove safari workaround fixed by
niklasf/stockfish.js#4