### PR TITLE
fix pgn line breaks in firefox (#2989)

### DIFF
--- a/app/views/analyse/replay.scala.html
+++ b/app/views/analyse/replay.scala.html
@@ -78,7 +78,7 @@ atom = atom.some) {
           <a data-icon="=" class="text embed_howto" target="_blank">Embed in your website</a>
         </div>
       </div>
-      <div class="pgn">@Html(nl2br(escapeHtml(pgn)))</div>
+      <div class="pgn">@pgn</div>
     </div>
     <div class="panel move_times">
       @if(game.turns > 1) {

--- a/app/views/analyse/replayBot.scala.html
+++ b/app/views/analyse/replayBot.scala.html
@@ -64,7 +64,7 @@ chessground = false) {
         <a data-icon="x" rel="nofollow" href="@routes.Export.pgn(game.id)?as=imported"> @trans.downloadImported()</a>
         }
       </p>
-      <div class="pgn">@Html(nl2br(escapeHtml(pgn)))</div>
+      <div class="pgn">@pgn</div>
     </div>
     @cross.map { c =>
     <div class="panel crosstable">

--- a/app/views/round/watcherBot.scala.html
+++ b/app/views/round/watcherBot.scala.html
@@ -14,7 +14,7 @@ openGraph = povOpenGraph(pov).some) {
   <div class="lichess_ground for_bot">
     <h1>@titleGame(pov.game)</h1>
     <p>@describePov(pov)</p>
-    <div class="pgn">@Html(nl2br(escapeHtml(pgn.toString)))</div>
+    <div class="pgn">@pgn.render</div>
   </div>
 </div>
 }

--- a/public/stylesheets/analyse.css
+++ b/public/stylesheets/analyse.css
@@ -73,6 +73,7 @@ div.fen_pgn a {
   color: #3893E8;
 }
 div.fen_pgn .pgn {
+  white-space: pre-wrap;
   font-family: monospace;
 }
 div.fen_pgn strong {


### PR DESCRIPTION
For some reason FF was ignoring the double `<br>` between headers and movetext: https://github.com/ornicar/lila/issues/2989#issuecomment-298311623