### PR TITLE
provide round to complete seven tag roster (#2989)

### DIFF
--- a/modules/game/src/main/PgnDump.scala
+++ b/modules/game/src/main/PgnDump.scala
@@ -65,6 +65,7 @@ final class PgnDump(
       }),
       Tag(_.Site, gameUrl(game.id)),
       Tag(_.Date, imported.flatMap(_ tag "date") | dateFormat.print(game.createdAt)),
+      Tag(_.Round, imported.flatMap(_ tag "round") | "-"),
       Tag(_.White, player(game.whitePlayer, wu)),
       Tag(_.Black, player(game.blackPlayer, bu)),
       Tag(_.Result, result(game)),


### PR DESCRIPTION
`Round` is one of the seven mandatory PGN tags. Let's provide it for imported games (including games from the opening explorer).