### PR TITLE
fix double decoding of 3check fens

### DIFF
--- a/app/controllers/Editor.scala
+++ b/app/controllers/Editor.scala
@@ -26,7 +26,9 @@ object Editor extends LilaController {
   def index = load("")
 
   def load(urlFen: String) = Open { implicit ctx =>
-    val fenStr = Some(urlFen.trim.replace("_", " ")).filter(_.nonEmpty) orElse get("fen")
+    val fenStr = lila.common.String.decodeUriPath(urlFen)
+      .map(_.replace("_", " ").trim).filter(_.nonEmpty)
+      .orElse(get("fen"))
     fuccess {
       val situation = readFen(fenStr)
       Ok(html.board.editor(
@@ -50,10 +52,7 @@ object Editor extends LilaController {
   }
 
   private def readFen(fen: Option[String]): Situation =
-    fen.map {
-      java.net.URLDecoder.decode(_, "UTF-8").trim
-    }.filter(_.nonEmpty)
-      .flatMap(Forsyth.<<<).map(_.situation) | Situation(chess.variant.Standard)
+    fen.map(_.trim).filter(_.nonEmpty).flatMap(Forsyth.<<<).map(_.situation) | Situation(chess.variant.Standard)
 
   def game(id: String) = Open { implicit ctx =>
     OptionResult(GameRepo game id) { game =>

--- a/app/controllers/UserAnalysis.scala
+++ b/app/controllers/UserAnalysis.scala
@@ -30,8 +30,9 @@ object UserAnalysis extends LilaController with TheftPrevention {
   }
 
   def load(urlFen: String, variant: Variant) = Open { implicit ctx =>
-    val fenStr = Some(urlFen.trim.replace("_", " ")).filter(_.nonEmpty) orElse get("fen")
-    val decodedFen = fenStr.map { java.net.URLDecoder.decode(_, "UTF-8").trim }
+    val decodedFen = lila.common.String.decodeUriPath(urlFen)
+      .map(_.replace("_", " ").trim).filter(_.nonEmpty)
+      .orElse(get("fen"))
     val pov = makePov(decodedFen, variant)
     val orientation = get("color").flatMap(chess.Color.apply) | pov.color
     Env.api.roundApi.userAnalysisJson(pov, ctx.pref, decodedFen, orientation, owner = false, me = ctx.me) map { data =>

--- a/modules/common/src/main/String.scala
+++ b/modules/common/src/main/String.scala
@@ -14,6 +14,15 @@ object String {
     slug.toLowerCase
   }
 
+  def decodeUriPath(input: String): Option[String] = {
+    try {
+      play.utils.UriEncoding.decodePath(input, "UTF-8").some
+    }
+    catch {
+      case e: play.utils.InvalidUriEncodingException => None
+    }
+  }
+
   final class Delocalizer(netDomain: String) {
 
     private val regex = ("""\w{2}\.""" + quoteReplacement(netDomain)).r


### PR DESCRIPTION
1. open a three-check analysis board: https://lichess.org/analysis/threeCheck
2. try to edit the check counts in the fen input field
3. press enter

`java.net.UrlDecoder.decode` decodes the `+`-signs to spaces, parsing fails and the check counts are reset to `+0+0`.

` play.utils.UriEncoding.decodePath` is the right decoder.