### PR TITLE
remember crazyhouse pockets when pasting fens

### DIFF
--- a/modules/game/src/main/Game.scala
+++ b/modules/game/src/main/Game.scala
@@ -648,7 +648,7 @@ object Game {
       daysPerTurn = daysPerTurn,
       mode = mode,
       variant = variant,
-      crazyData = (variant == Crazyhouse) option Crazyhouse.Data.init,
+      crazyData = game.board.crazyData,
       metadata = Metadata(
         source = source.some,
         pgnImport = pgnImport,


### PR DESCRIPTION
Fixes this issue: On the crazyhouse analysis board, paste a fen with a pocket like

```
rnbqkbnr/pppp1ppp/8/4N3/8/8/PPPPPPPP/RNBQKB1R/P b KQkq - 3 2
```

The import works but the PGN is displayed as:

```
[Variant "Crazyhouse"]
[FEN "rnbqkbnr/pppp1ppp/8/4N3/8/8/PPPPPPPP/RNBQKB1R/ b KQkq - 0 2"]
```

(i.e. without the pocket)