### PR TITLE
fix pasting of variant pgns with fen tag

### DIFF
--- a/app/controllers/Practice.scala
+++ b/app/controllers/Practice.scala
@@ -70,8 +70,9 @@ object Practice extends LilaController {
 
   private def analysisJson(us: UserStudy)(implicit ctx: Context): Fu[(JsObject, JsObject)] = us match {
     case UserStudy(_, _, chapters, WithChapter(study, chapter), _) =>
-      val pov = UserAnalysis.makePov(chapter.root.fen.value.some, chapter.setup.variant)
-      Env.round.jsonView.userAnalysisJson(pov, ctx.pref, chapter.setup.orientation, owner = false, me = ctx.me) zip
+      val initialFen = chapter.root.fen.value.some
+      val pov = UserAnalysis.makePov(initialFen, chapter.setup.variant)
+      Env.round.jsonView.userAnalysisJson(pov, ctx.pref, initialFen, chapter.setup.orientation, owner = false, me = ctx.me) zip
         studyEnv.jsonView(study, chapters, chapter, ctx.me) map {
           case (baseData, studyJson) =>
             val analysis = baseData ++ Json.obj(

--- a/app/controllers/Study.scala
+++ b/app/controllers/Study.scala
@@ -92,8 +92,9 @@ object Study extends LilaController {
           study <- env.api.resetIfOld(s, chapters)
           _ <- Env.user.lightUserApi preloadMany study.members.ids.toList
           _ = if (HTTPRequest isSynchronousHttp ctx.req) env.studyRepo.incViews(study)
-          pov = UserAnalysis.makePov(chapter.root.fen.value.some, chapter.setup.variant)
-          baseData <- Env.round.jsonView.userAnalysisJson(pov, ctx.pref, chapter.setup.orientation, owner = false, me = ctx.me)
+          initialFen = chapter.root.fen.value.some
+          pov = UserAnalysis.makePov(initialFen, chapter.setup.variant)
+          baseData <- Env.round.jsonView.userAnalysisJson(pov, ctx.pref, initialFen, chapter.setup.orientation, owner = false, me = ctx.me)
           studyJson <- env.jsonView(study, chapters, chapter, ctx.me)
           data = lila.study.JsonView.JsData(
             study = studyJson,
@@ -196,8 +197,9 @@ object Study extends LilaController {
       _.fold(embedNotFound) {
         case WithChapter(study, chapter) => CanViewResult(study) {
           val setup = chapter.setup
-          val pov = UserAnalysis.makePov(chapter.root.fen.value.some, setup.variant)
-          Env.round.jsonView.userAnalysisJson(pov, ctx.pref, setup.orientation, owner = false, me = ctx.me) zip
+          val initialFen = chapter.root.fen.value.some
+          val pov = UserAnalysis.makePov(initialFen, setup.variant)
+          Env.round.jsonView.userAnalysisJson(pov, ctx.pref, initialFen, setup.orientation, owner = false, me = ctx.me) zip
             env.jsonView(study.copy(
               members = lila.study.StudyMembers(Map.empty) // don't need no members
             ), List(chapter.metadata), chapter, ctx.me) flatMap {

--- a/modules/api/src/main/RoundApi.scala
+++ b/modules/api/src/main/RoundApi.scala
@@ -94,13 +94,13 @@ private[api] final class RoundApi(
 
   def userAnalysisJson(pov: Pov, pref: Pref, initialFen: Option[String], orientation: chess.Color, owner: Boolean, me: Option[User]) =
     owner.??(forecastApi loadForDisplay pov).flatMap { fco =>
-      jsonView.userAnalysisJson(pov, pref, orientation, owner = owner, me = me) map
+      jsonView.userAnalysisJson(pov, pref, initialFen, orientation, owner = owner, me = me) map
         withTree(pov, analysis = none, initialFen, WithFlags(opening = true))_ map
         withForecast(pov, owner, fco)_
     }
 
   def freeStudyJson(pov: Pov, pref: Pref, initialFen: Option[String], orientation: chess.Color, me: Option[User]) =
-    jsonView.userAnalysisJson(pov, pref, orientation, owner = false, me = me) map
+    jsonView.userAnalysisJson(pov, pref, initialFen, orientation, owner = false, me = me) map
       withTree(pov, analysis = none, initialFen, WithFlags(opening = true))_
 
   private def withTree(pov: Pov, analysis: Option[Analysis], initialFen: Option[String], withFlags: WithFlags)(obj: JsObject) =

--- a/modules/round/src/main/JsonView.scala
+++ b/modules/round/src/main/JsonView.scala
@@ -217,11 +217,12 @@ final class JsonView(
   def userAnalysisJson(
     pov: Pov,
     pref: Pref,
+    initialFen: Option[String],
     orientation: chess.Color,
     owner: Boolean,
     me: Option[User]
   ) =
-    (pov.game.pgnMoves.nonEmpty ?? GameRepo.initialFen(pov.game)) map { initialFen =>
+    fuccess {
       import pov._
       val fen = Forsyth >> game.toChess
       Json.obj(
@@ -229,10 +230,7 @@ final class JsonView(
           "id" -> gameId,
           "variant" -> game.variant,
           "opening" -> game.opening,
-          "initialFen" -> {
-            if (pov.game.pgnMoves.isEmpty) fen
-            else (initialFen | chess.format.Forsyth.initial)
-          },
+          "initialFen" -> (initialFen | game.variant.initialFen),
           "fen" -> fen,
           "turns" -> game.turns,
           "player" -> game.turnColor.name,


### PR DESCRIPTION
Fixes the following issue: On the analysis board paste a PGN like:

```
[Variant "Crazyhouse"]
[FEN "rnbqkbnr/ppp1pppp/8/3P4/8/8/PPPP1PPP/RNBQKBNR/P b KQkq - 3 3"]

3. e6
```
It mostly works, but the `initialFen` in the analysis JSON is sent as the standard starting FEN.

The PGN is then incorrectly displayed as:

```
[Variant "Crazyhouse"]

3... e6
```

---

There is also an opportunity to refactor things, because `userAnalysisJson` no longer has to be a future. But it's probably best to keep this PR small.