### PR TITLE
Update material.form.css

### DIFF
--- a/public/stylesheets/material.form.css
+++ b/public/stylesheets/material.form.css
@@ -39,6 +39,7 @@
 .material.form .form-group.half .form-group.half {
   width: 46.5%;
   margin-bottom: 0;
+  vertical-align: top;
 }
 .material.form .form-group.half:nth-child(odd) {
   margin-right: 5%;


### PR DESCRIPTION
Using the latest version on FireFox, on two different types of computers (mac & windows) the https://en.lichess.org/account/profile page's .form-group.half are uneven. Before: https://snag.gy/suol63.jpg and with my one line CSS added: https://snag.gy/7ifGuL.jpg .