### PR TITLE
Allow SAN moves to be case-sensitive or case-insensitive. Fix #3035

### DIFF
--- a/public/javascripts/keyboardMove.js
+++ b/public/javascripts/keyboardMove.js
@@ -54,6 +54,8 @@ function makeBindings(opts, submit, clear) {
 }
 
 function sanToUci(san, sans) {
+  for (var i in sans)
+    if (i === san) return sans[i];
   var lowered = san.toLowerCase();
   for (var i in sans)
     if (i.toLowerCase() === lowered) return sans[i];

--- a/public/javascripts/keyboardMove.js
+++ b/public/javascripts/keyboardMove.js
@@ -54,7 +54,7 @@ function makeBindings(opts, submit, clear) {
 }
 
 function sanToUci(san, sans) {
-  if (sans[san] !== undefined) return sans[san];
+  if (san in sans) return sans[san];
   var lowered = san.toLowerCase();
   for (var i in sans)
     if (i.toLowerCase() === lowered) return sans[i];

--- a/public/javascripts/keyboardMove.js
+++ b/public/javascripts/keyboardMove.js
@@ -54,8 +54,7 @@ function makeBindings(opts, submit, clear) {
 }
 
 function sanToUci(san, sans) {
-  for (var i in sans)
-    if (i === san) return sans[i];
+  if (sans[san] !== undefined) return sans[san];
   var lowered = san.toLowerCase();
   for (var i in sans)
     if (i.toLowerCase() === lowered) return sans[i];


### PR DESCRIPTION
This change works on my lila instance, allowing `Bxc4` to be different from `bxc4`.