### PR TITLE
Blurriness and duplication of fpmenu

### DIFF
--- a/public/stylesheets/fpmenu.css
+++ b/public/stylesheets/fpmenu.css
@@ -116,7 +116,7 @@ body.fpmenu #fpmenu {
 }
 #fpmenu .forgot {
   font-size: 0.8em;
-  margin-top: 5px;
+  margin-top: 4px;
   text-align: center;
 }
 #fpmenu .forgot a {

--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -612,9 +612,10 @@ lichess.topMenuIntent = function() {
         return false;
       });
 
-      $('#ham-plate').one('mouseover click', function() {
-        $('body').append($('<div id=fpmenu>').load('/fpmenu'));
+      $('#ham-plate').one('mouseover', function() {
         lichess.loadCss('/assets/stylesheets/fpmenu.css');
+      }).one('click', function() {
+        $('body').append($('<div id=fpmenu>').load('/fpmenu'));
       }).click(function() {
         document.body.classList.toggle('fpmenu');
       });


### PR DESCRIPTION
- Remove blurriness from anon sign in fpmenu
- Load fpmenu only once - this avoids duplication of dom generated by mouseover and click. Duplicate dom is visible with current  styles when you have browser size less than 970px