### PR TITLE
remove unused _referrer fields

### DIFF
--- a/app/views/auth/login.scala.html
+++ b/app/views/auth/login.scala.html
@@ -14,7 +14,6 @@
           <button type="submit" class="submit button" data-icon="F"> @trans.signIn()</button>
         </li>
       </ul>
-      <input type="hidden" class="referrer" name="_referrer" value="@referrer.getOrElse(currentUrl)" />
     </form>
   </div>
   <div class="alternative">

--- a/app/views/auth/signup.scala.html
+++ b/app/views/auth/signup.scala.html
@@ -37,7 +37,6 @@ zen = true) {
           <button type="submit" class="submit button" data-icon="F"> @trans.signUp()</button>
         </li>
       </ul>
-      <input type="hidden" class="referrer" name="_referrer" value="@currentUrl" />
     </form>
   </div>
 </div>


### PR DESCRIPTION
It seems the GET parameter `referrer` is used instead.