### PR TITLE
Manually install yarn rc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,9 @@ jobs:
         apt:
           packages:
            - parallel
-      before_install: yarn global add gulp-cli
+      before_install:
+       - npm install -g yarn@0.25.2
+       - yarn global add gulp-cli
       script: ./ui/build prod
       after_success:
        - git log -n 1 --pretty=oneline > commit.txt


### PR DESCRIPTION
This silences the annoying 'waiting' messages, after next
yarn release we can remove this.