### PR TITLE
use safe string indexing in SubdomainKiller

### DIFF
--- a/modules/i18n/src/main/SubdomainKiller.scala
+++ b/modules/i18n/src/main/SubdomainKiller.scala
@@ -17,7 +17,7 @@ final class SubdomainKiller(domain: String) {
     else None
 
   private def appliesTo(req: RequestHeader) =
-    req.host(2) == '.' &&
+    req.host.lift(2).has('.') &&
       req.host.drop(3) == domain &&
       HTTPRequest.isRedirectable(req) &&
       !excludePath(req.path)


### PR DESCRIPTION
Does not matter a lot, but I saw some exceptions when `Host` was empty in my dev env.