### PR TITLE
remove date from trans dump

### DIFF
--- a/bin/trans-dump.js
+++ b/bin/trans-dump.js
@@ -9,7 +9,7 @@ fs.readFile('translation/source/site.xml', { encoding: 'utf8' }).then(txt => {
 
     const keyList = keys.map(k => 'val `' + k + '` = new Translated("' + k + '")');
 
-    const code = `// Generated with bin/trans-dump.js ${new Date()}
+    const code = `// Generated with bin/trans-dump.js
 package lila.i18n
 
 // format: OFF

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1,4 +1,4 @@
-// Generated with bin/trans-dump.js Mon May 29 2017 11:38:58 GMT+0200 (CEST)
+// Generated with bin/trans-dump.js
 package lila.i18n
 
 // format: OFF


### PR DESCRIPTION
Having this date will cause merge conflicts every time. We should use Git to look it up, if needed.