### PR TITLE
Track page reloads as blurs

### DIFF
--- a/ui/round/src/blur.ts
+++ b/ui/round/src/blur.ts
@@ -1,14 +1,15 @@
 // Register blur events to be sent as move metadata
 
-let lastFocus = -1;
-let focusCutoff = Date.now() + 10000;
+let lastFocus = 0;
+let focusCutoff = 0;
 
-export function init() {
+export function init(withBlur: boolean) {
+  if (!withBlur) focusCutoff = Date.now() + 10000;
   window.addEventListener('focus', () => lastFocus = Date.now());
 }
 
 export function get() {
-  return lastFocus > focusCutoff;
+  return lastFocus >= focusCutoff;
 };
 
 export function onMove() {

--- a/ui/round/src/ctrl.js
+++ b/ui/round/src/ctrl.js
@@ -548,7 +548,7 @@ module.exports = function(opts, redraw) {
     }
     lichess.requestIdleCallback(function idleCallback() {
       if (game.isPlayerPlaying(this.data)) {
-        if (!this.data.simul) blur.init();
+        if (!this.data.simul) blur.init(this.data.steps.length > 2);
 
         title.init(this);
         this.setTitle();


### PR DESCRIPTION
If a user reloads the page during their move after
move 1, count it as a blur.

This fixes #3075.