### PR TITLE
[RFC] Use tournament score to improve pairings quality

### DIFF
--- a/modules/tournament/src/main/arena/AntmaPairing.scala
+++ b/modules/tournament/src/main/arena/AntmaPairing.scala
@@ -10,6 +10,7 @@ private object AntmaPairing {
     import data._
 
     def rankFactor = PairingSystem.rankFactorFor(players)
+    def scoreFactor = PairingSystem.scoreFactorFor(players)
 
     def justPlayedTogether(u1: String, u2: String) =
       lastOpponents.hash.get(u1).contains(u2) ||
@@ -19,6 +20,7 @@ private object AntmaPairing {
       if (justPlayedTogether(a.player.userId, b.player.userId)) None
       else Some {
         Math.abs(a.rank - b.rank) * rankFactor(a, b) +
+          Math.abs(a.player.score - b.player.score) * scoreFactor(a, b) +
           Math.abs(a.player.rating - b.player.rating)
       }
 

--- a/modules/tournament/src/main/arena/PairingSystem.scala
+++ b/modules/tournament/src/main/arena/PairingSystem.scala
@@ -111,6 +111,9 @@ private[tournament] object PairingSystem extends AbstractPairingSystem {
      * This should increase leader vs leader pairing chances.
      */
   private[arena] def scoreFactorFor(players: RankedPlayers): (RankedPlayer, RankedPlayer) => Int = {
-    players.map(_.player.score).max
+    val maxScore = players.map(_.player.score).max
+    (a, b) => {
+      maxScore
+    }
   }
 }

--- a/modules/tournament/src/main/arena/PairingSystem.scala
+++ b/modules/tournament/src/main/arena/PairingSystem.scala
@@ -92,8 +92,8 @@ private[tournament] object PairingSystem extends AbstractPairingSystem {
      * we increase pairing quality for them.
      * The higher ranked, and the more ranking is relevant.
      * For instance rank 1 vs rank 5
-     * is better thank 300 vs rank 310
-     * This should increase leader vs leader pairing chances
+     * is better than rank 300 vs rank 310
+     * This should increase leader vs leader pairing chances.
      *
      * top rank factor = 2000
      * bottom rank factor = 300
@@ -104,5 +104,13 @@ private[tournament] object PairingSystem extends AbstractPairingSystem {
       val rank = Math.min(a.rank, b.rank)
       300 + 1700 * (maxRank - rank) / maxRank
     }
+  }
+
+  /* By increasing the factor for high scoring players,
+     * we increase pairing quality for them.
+     * This should increase leader vs leader pairing chances.
+     */
+  private[arena] def scoreFactorFor(players: RankedPlayers): (RankedPlayer, RankedPlayer) => Int = {
+    players.map(_.player.score).max
   }
 }

--- a/modules/tournament/src/main/arena/PairingSystem.scala
+++ b/modules/tournament/src/main/arena/PairingSystem.scala
@@ -109,11 +109,15 @@ private[tournament] object PairingSystem extends AbstractPairingSystem {
   /* By increasing the factor for high scoring players,
      * we increase pairing quality for them.
      * This should increase leader vs leader pairing chances.
+     *
+     * top score factor = 2000
+     * bottom score factor = 300
      */
   private[arena] def scoreFactorFor(players: RankedPlayers): (RankedPlayer, RankedPlayer) => Int = {
     val maxScore = players.map(_.player.score).max
     (a, b) => {
-      maxScore
+      val score = Math.max(a.player.score, b.player.score)
+      300 + 1700 * (score + 1) / (maxScore + 1)
     }
   }
 }


### PR DESCRIPTION
I think that if players have many tournament points, they should be paired against other players who have many tournament points.  This becomes more important toward the end of an event.

I'm unsure how to test this and open to feedback in general!  Maybe being on a hot streak should affect this factor?

(I am surprised to find that player ratings are part of the fitness function.)