### PR TITLE
[RFC] yarn 0.26 supports linking modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,15 +68,12 @@ jobs:
           packages:
            - parallel
       before_install:
-       - npm install -g yarn@0.25.3
+       - npm install -g yarn@0.26.1
        - yarn global add gulp-cli
       script: ./ui/build prod
       after_success:
        - git log -n 1 --pretty=oneline > commit.txt
        - tar -zcf "lila-assets-${TRAVIS_BRANCH}.tar.gz" public LICENSE COPYING.md README.md commit.txt
-      before_cache:
-       - yarn cache dir
-       - rm -rf $HOME/.cache/yarn/v1/npm-{types,common,chess,game,tree,ceval}-*
       cache:
         directories:
           - $HOME/.cache/yarn

--- a/ui/analyse/package.json
+++ b/ui/analyse/package.json
@@ -35,13 +35,13 @@
   },
   "dependencies": {
     "autolink-js": "^1.0.2",
-    "ceval": "file:../ceval",
-    "chess": "file:../chess",
+    "ceval": "link:../ceval",
+    "chess": "link:../chess",
     "chessground": "^6.4",
-    "common": "file:../common",
-    "game": "file:../game",
+    "common": "link:../common",
+    "game": "link:../game",
     "mithril": "github:ornicar/mithril.js#lila-vdom-only-2",
-    "tree": "file:../tree",
-    "types": "file:../types"
+    "tree": "link:../tree",
+    "types": "link:../types"
   }
 }

--- a/ui/analyse/yarn.lock
+++ b/ui/analyse/yarn.lock
@@ -380,13 +380,9 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-"ceval@file:../ceval":
-  version "1.0.0"
-  dependencies:
-    chess "file:../chess"
-    common "file:../common"
-    defer-promise "^1.0.1"
-    mithril "github:ornicar/mithril.js#lila-vdom-only-2"
+"ceval@link:../ceval":
+  version "0.0.0"
+  uid ""
 
 chalk@^1.0.0, chalk@^1.1.1:
   version "1.1.3"
@@ -398,8 +394,9 @@ chalk@^1.0.0, chalk@^1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-"chess@file:../chess":
-  version "1.0.0"
+"chess@link:../chess":
+  version "0.0.0"
+  uid ""
 
 chessground@^6.4:
   version "6.4.23"
@@ -469,8 +466,9 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-"common@file:../common":
-  version "1.0.0"
+"common@link:../common":
+  version "0.0.0"
+  uid ""
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -853,8 +851,9 @@ function-bind@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
-"game@file:../game":
-  version "1.0.0"
+"game@link:../game":
+  version "0.0.0"
+  uid ""
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -2299,10 +2298,9 @@ tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
-"tree@file:../tree":
-  version "1.0.0"
-  dependencies:
-    common "file:../common"
+"tree@link:../tree":
+  version "0.0.0"
+  uid ""
 
 tsconfig@^5.0.3:
   version "5.0.3"
@@ -2342,8 +2340,9 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-"types@file:../types":
-  version "1.0.0"
+"types@link:../types":
+  version "0.0.0"
+  uid ""
 
 typescript@^2:
   version "2.3.2"

--- a/ui/build
+++ b/ui/build
@@ -14,10 +14,8 @@ build_ts() {
   echo "build_ts" "$@"
   set -ev
   cd ui/$1
-  grep ': "file:' package.json | cut -d'"' -f2 | xargs -t yarn link
   yarn install --mutex file:$YARN_MUTEX
   yarn run compile
-  yarn link
 }
 
 build() {
@@ -25,12 +23,9 @@ build() {
   set -ev
   app=$1
   cd ui/$app
-  grep ': "file:' package.json | cut -d'"' -f2 | xargs -t yarn link
   yarn install --mutex file:$YARN_MUTEX
   gulp $target
 }
-
-(cd ui/types && yarn link)
 
 if type -p parallel; then # parallel execution!
   if [ -z "$P_OPTS" -a ! -e ~/.parallel/config ]; then

--- a/ui/ceval/package.json
+++ b/ui/ceval/package.json
@@ -29,12 +29,12 @@
     "@types/jquery": "^2.0",
     "@types/nodeunit": "0.0.30",
     "nodeunit": "^0.11.0",
-    "types": "file:../types",
+    "types": "link:../types",
     "typescript": "^2"
   },
   "dependencies": {
-    "chess": "file:../chess",
-    "common": "file:../common",
+    "chess": "link:../chess",
+    "common": "link:../common",
     "defer-promise": "^1.0.1",
     "mithril": "github:ornicar/mithril.js#lila-vdom-only-2"
   }

--- a/ui/ceval/yarn.lock
+++ b/ui/ceval/yarn.lock
@@ -247,8 +247,9 @@ chalk@^1.1.0, chalk@^1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-"chess@file:../chess":
-  version "1.0.0"
+"chess@link:../chess":
+  version "0.0.0"
+  uid ""
 
 clean-yaml-object@^0.1.0:
   version "0.1.0"
@@ -290,8 +291,9 @@ commander@^2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-"common@file:../common":
-  version "1.0.0"
+"common@link:../common":
+  version "0.0.0"
+  uid ""
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -1516,8 +1518,9 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
-"types@file:../types":
-  version "1.0.0"
+"types@link:../types":
+  version "0.0.0"
+  uid ""
 
 typescript@^2:
   version "2.3.2"

--- a/ui/challenge/package.json
+++ b/ui/challenge/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jquery": "^2.0",
-    "types": "file:../types",
+    "types": "link:../types",
     "browserify": "^14",
     "gulp": "^3",
     "gulp-sourcemaps": "^2",

--- a/ui/challenge/yarn.lock
+++ b/ui/challenge/yarn.lock
@@ -2544,8 +2544,9 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-"types@file:../types":
-  version "1.0.0"
+"types@link:../types":
+  version "0.0.0"
+  uid ""
 
 typescript@^2:
   version "2.3.2"

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jquery": "^2.0",
-    "types": "file:../types",
+    "types": "link:../types",
     "browserify": "^14",
     "gulp": "^3",
     "gulp-sourcemaps": "^2",

--- a/ui/chat/yarn.lock
+++ b/ui/chat/yarn.lock
@@ -2544,8 +2544,9 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-"types@file:../types":
-  version "1.0.0"
+"types@link:../types":
+  version "0.0.0"
+  uid ""
 
 typescript@^2:
   version "2.3.2"

--- a/ui/common/package.json
+++ b/ui/common/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "typescript": "^2",
-    "types": "file:../types"
+    "types": "link:../types"
   },
   "dependencies": {
   }

--- a/ui/common/yarn.lock
+++ b/ui/common/yarn.lock
@@ -2,8 +2,9 @@
 # yarn lockfile v1
 
 
-"types@file:../types":
-  version "1.0.0"
+"types@link:../types":
+  version "0.0.0"
+  uid ""
 
 typescript@^2:
   version "2.3.2"

--- a/ui/dasher/package.json
+++ b/ui/dasher/package.json
@@ -15,7 +15,7 @@
     "gulp-uglify": "^2",
     "gulp-util": "^3",
     "tsify": "^3",
-    "types": "file:../types",
+    "types": "link:../types",
     "typescript": "^2",
     "vinyl-buffer": "^1",
     "vinyl-source-stream": "^1",

--- a/ui/dasher/yarn.lock
+++ b/ui/dasher/yarn.lock
@@ -2314,8 +2314,9 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-"types@file:../types":
-  version "1.0.0"
+"types@link:../types":
+  version "0.0.0"
+  uid ""
 
 typescript@^2:
   version "2.3.2"

--- a/ui/game/package.json
+++ b/ui/game/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "typescript": "^2",
-    "types": "file:../types"
+    "types": "link:../types"
   },
   "dependencies": {
   }

--- a/ui/game/yarn.lock
+++ b/ui/game/yarn.lock
@@ -2,8 +2,9 @@
 # yarn lockfile v1
 
 
-"types@file:../types":
-  version "1.0.0"
+"types@link:../types":
+  version "0.0.0"
+  uid ""
 
 typescript@^2:
   version "2.3.2"

--- a/ui/insight/package.json
+++ b/ui/insight/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "mithril": "github:ornicar/mithril.js#lila-1",
-    "common": "file:../common",
+    "common": "link:../common",
     "numeral": "^1.5"
   }
 }

--- a/ui/insight/yarn.lock
+++ b/ui/insight/yarn.lock
@@ -436,8 +436,9 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-"common@file:../common":
-  version "1.0.0"
+"common@link:../common":
+  version "0.0.0"
+  uid ""
 
 concat-map@0.0.1:
   version "0.0.1"

--- a/ui/learn/package.json
+++ b/ui/learn/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "chess.js": "github:ornicar/chess.js#learn",
     "chessground": "github:ornicar/chessground#v4.4.0",
-    "common": "file:../common",
+    "common": "link:../common",
     "mithril": "github:ornicar/mithril.js#lila-1"
   }
 }

--- a/ui/learn/yarn.lock
+++ b/ui/learn/yarn.lock
@@ -447,8 +447,9 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-"common@file:../common":
-  version "1.0.0"
+"common@link:../common":
+  version "0.0.0"
+  uid ""
 
 concat-map@0.0.1:
   version "0.0.1"

--- a/ui/lobby/package.json
+++ b/ui/lobby/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "chessground": "^6.4",
-    "common": "file:../common",
+    "common": "link:../common",
     "mithril": "github:ornicar/mithril.js#lila-vdom-only-2"
   }
 }

--- a/ui/lobby/yarn.lock
+++ b/ui/lobby/yarn.lock
@@ -440,8 +440,9 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-"common@file:../common":
-  version "1.0.0"
+"common@link:../common":
+  version "0.0.0"
+  uid ""
 
 concat-map@0.0.1:
   version "0.0.1"

--- a/ui/notify/package.json
+++ b/ui/notify/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jquery": "^2.0",
-    "types": "file:../types",
+    "types": "link:../types",
     "browserify": "^14",
     "gulp": "^3",
     "gulp-sourcemaps": "^2",

--- a/ui/notify/yarn.lock
+++ b/ui/notify/yarn.lock
@@ -2544,8 +2544,9 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-"types@file:../types":
-  version "1.0.0"
+"types@link:../types":
+  version "0.0.0"
+  uid ""
 
 typescript@^2:
   version "2.3.2"

--- a/ui/puzzle/package.json
+++ b/ui/puzzle/package.json
@@ -31,10 +31,10 @@
   },
   "dependencies": {
     "chessground": "^6.4",
-    "common": "file:../common",
-    "chess": "file:../chess",
-    "tree": "file:../tree",
-    "ceval": "file:../ceval",
+    "common": "link:../common",
+    "chess": "link:../chess",
+    "tree": "link:../tree",
+    "ceval": "link:../ceval",
     "mithril": "github:ornicar/mithril.js#lila-vdom-only-2"
   }
 }

--- a/ui/puzzle/yarn.lock
+++ b/ui/puzzle/yarn.lock
@@ -362,13 +362,9 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-"ceval@file:../ceval":
-  version "1.0.0"
-  dependencies:
-    chess "file:../chess"
-    common "file:../common"
-    defer-promise "^1.0.1"
-    mithril "github:ornicar/mithril.js#lila-vdom-only-2"
+"ceval@link:../ceval":
+  version "0.0.0"
+  uid ""
 
 chalk@^1.0.0, chalk@^1.1.1:
   version "1.1.3"
@@ -380,8 +376,9 @@ chalk@^1.0.0, chalk@^1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-"chess@file:../chess":
-  version "1.0.0"
+"chess@link:../chess":
+  version "0.0.0"
+  uid ""
 
 chessground@^6.4:
   version "6.4.23"
@@ -451,8 +448,9 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-"common@file:../common":
-  version "1.0.0"
+"common@link:../common":
+  version "0.0.0"
+  uid ""
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -2265,10 +2263,9 @@ tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
-"tree@file:../tree":
-  version "1.0.0"
-  dependencies:
-    common "file:../common"
+"tree@link:../tree":
+  version "0.0.0"
+  uid ""
 
 tty-browserify@~0.0.0:
   version "0.0.0"

--- a/ui/round/package.json
+++ b/ui/round/package.json
@@ -33,9 +33,9 @@
   },
   "dependencies": {
     "chessground": "^6.4",
-    "common": "file:../common",
-    "game": "file:../game",
+    "common": "link:../common",
+    "game": "link:../game",
     "snabbdom": "^0.6",
-    "types": "file:../types"
+    "types": "link:../types"
   }
 }

--- a/ui/round/yarn.lock
+++ b/ui/round/yarn.lock
@@ -454,8 +454,9 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-"common@file:../common":
-  version "1.0.0"
+"common@link:../common":
+  version "0.0.0"
+  uid ""
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -834,8 +835,9 @@ function-bind@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
-"game@file:../game":
-  version "1.0.0"
+"game@link:../game":
+  version "0.0.0"
+  uid ""
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -2312,8 +2314,9 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-"types@file:../types":
-  version "1.0.0"
+"types@link:../types":
+  version "0.0.0"
+  uid ""
 
 typescript@^2:
   version "2.3.2"

--- a/ui/simul/package.json
+++ b/ui/simul/package.json
@@ -29,7 +29,7 @@
     "watchify": "^3"
   },
   "dependencies": {
-    "game": "file:../game",
+    "game": "link:../game",
     "mithril": "github:ornicar/mithril.js#lila-1"
   }
 }

--- a/ui/simul/yarn.lock
+++ b/ui/simul/yarn.lock
@@ -803,8 +803,9 @@ function-bind@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
-"game@file:../game":
-  version "1.0.0"
+"game@link:../game":
+  version "0.0.0"
+  uid ""
 
 gauge@~2.7.3:
   version "2.7.4"

--- a/ui/tournament/package.json
+++ b/ui/tournament/package.json
@@ -30,8 +30,8 @@
   },
   "dependencies": {
     "chessground": "^v6.4",
-    "common": "file:../common",
-    "game": "file:../game",
+    "common": "link:../common",
+    "game": "link:../game",
     "mithril": "github:ornicar/mithril.js#lila-1"
   }
 }

--- a/ui/tournament/yarn.lock
+++ b/ui/tournament/yarn.lock
@@ -440,8 +440,9 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-"common@file:../common":
-  version "1.0.0"
+"common@link:../common":
+  version "0.0.0"
+  uid ""
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -810,8 +811,9 @@ function-bind@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
-"game@file:../game":
-  version "1.0.0"
+"game@link:../game":
+  version "0.0.0"
+  uid ""
 
 gauge@~2.7.3:
   version "2.7.4"

--- a/ui/tournamentSchedule/package.json
+++ b/ui/tournamentSchedule/package.json
@@ -33,6 +33,6 @@
   },
   "dependencies": {
     "snabbdom": "^0.6",
-    "types": "file:../types"
+    "types": "link:../types"
   }
 }

--- a/ui/tournamentSchedule/yarn.lock
+++ b/ui/tournamentSchedule/yarn.lock
@@ -2302,8 +2302,9 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-"types@file:../types":
-  version "1.0.0"
+"types@link:../types":
+  version "0.0.0"
+  uid ""
 
 typescript@^2:
   version "2.3.2"

--- a/ui/tree/package.json
+++ b/ui/tree/package.json
@@ -23,9 +23,9 @@
   },
   "devDependencies": {
     "typescript": "^2",
-    "types": "file:../types"
+    "types": "link:../types"
   },
   "dependencies": {
-    "common": "file:../common"
+    "common": "link:../common"
   }
 }

--- a/ui/tree/yarn.lock
+++ b/ui/tree/yarn.lock
@@ -2,11 +2,13 @@
 # yarn lockfile v1
 
 
-"common@file:../common":
-  version "1.0.0"
+"common@link:../common":
+  version "0.0.0"
+  uid ""
 
-"types@file:../types":
-  version "1.0.0"
+"types@link:../types":
+  version "0.0.0"
+  uid ""
 
 typescript@^2:
   version "2.3.2"


### PR DESCRIPTION
yarn 0.26 supports `link:` urls, that could replace our symlink and caching hack. It's only a release candidate so far: https://github.com/yarnpkg/yarn/releases/tag/v0.26.1.

/cc @isaacl, @pukhrajbal