### PR TITLE
Hard code premoves to 0s client time.

### DIFF
--- a/ui/round/src/ctrl.js
+++ b/ui/round/src/ctrl.js
@@ -172,8 +172,11 @@ module.exports = function(opts, redraw) {
       ackable: true,
       // withLag: !!this.clock
     }
-    var startTime = this.vm.lastMoveMillis;
-    if (startTime !== null) socketOpts.millis = timer.now() - startTime;
+    if (meta.premove) {
+      socketOpts.millis = 0;
+    } else if (this.vm.lastMoveMillis !== null) {
+      socketOpts.millis = timer.now() - this.vm.lastMoveMillis;
+    }
     this.socket.send(type, action, socketOpts);
 
     this.vm.justDropped = meta.justDropped;
@@ -192,7 +195,12 @@ module.exports = function(opts, redraw) {
     if (this.data.pref.submitMove && !meta.premove) {
       this.vm.moveToSubmit = move;
       redraw();
-    } else this.actualSendMove('move', move, {justCaptured: meta.captured});
+    } else {
+      this.actualSendMove('move', move, {
+        justCaptured: meta.captured,
+        premove: meta.premove
+      })
+    };
 
   }.bind(this);
 
@@ -207,7 +215,10 @@ module.exports = function(opts, redraw) {
       this.vm.dropToSubmit = drop;
       redraw();
     } else {
-      this.actualSendMove('drop', drop, {justDropped: role});
+      this.actualSendMove('drop', drop, {
+        justDropped: role,
+        premove: isPredrop
+      });
     }
   }.bind(this);
 

--- a/ui/site/src/socket.js
+++ b/ui/site/src/socket.js
@@ -69,7 +69,7 @@ lichess.StrongSocket = function(url, version, settings) {
     var msg = { t: t };
     if (d !== undefined) {
       if (o.withLag) d.l = Math.round(averageLag);
-      if ('millis' in o) d.s = Math.floor(o.millis * 0.1).toString(36);
+      if (o.millis !== undefined) d.s = Math.round(o.millis * 0.1).toString(36);
       msg.d = d;
     }
     if (o.ackable) ackable.register(t, d);


### PR DESCRIPTION
Previously they were usually 0s unless a player was
on a slow computer.

We were using Math.floor to ensure premoves were usually
0 time, but now that they're special cased, use Math.round
for conversion instead.