### PR TITLE
Add a styled unauthorized page (403)

### DIFF
--- a/app/controllers/LilaController.scala
+++ b/app/controllers/LilaController.scala
@@ -102,17 +102,17 @@ private[controllers] trait LilaController
 
   protected def Secure[A](p: BodyParser[A])(perm: Permission)(f: Context => UserModel => Fu[Result]): Action[A] =
     Auth(p) { implicit ctx => me =>
-      isGranted(perm).fold(f(ctx)(me), fuccess(authorizationFailed(ctx.req)))
+      isGranted(perm).fold(f(ctx)(me), authorizationFailed(ctx.req))
     }
 
   protected def SecureF(s: UserModel => Boolean)(f: Context => UserModel => Fu[Result]): Action[AnyContent] =
     Auth(BodyParsers.parse.anyContent) { implicit ctx => me =>
-      s(me).fold(f(ctx)(me), fuccess(authorizationFailed(ctx.req)))
+      s(me).fold(f(ctx)(me), authorizationFailed(ctx.req))
     }
 
   protected def SecureBody[A](p: BodyParser[A])(perm: Permission)(f: BodyContext[A] => UserModel => Fu[Result]): Action[A] =
     AuthBody(p) { implicit ctx => me =>
-      isGranted(perm).fold(f(ctx)(me), fuccess(authorizationFailed(ctx.req)))
+      isGranted(perm).fold(f(ctx)(me), authorizationFailed(ctx.req))
     }
 
   protected def SecureBody(perm: Permission.type => Permission)(f: BodyContext[_] => UserModel => Fu[Result]): Action[AnyContent] =
@@ -256,7 +256,8 @@ private[controllers] trait LilaController
 
   protected val unauthorizedApiResult = Unauthorized(jsonError("Login required"))
 
-  protected def authorizationFailed(req: RequestHeader): Result = Forbidden("no permission")
+  protected def authorizationFailed(req: RequestHeader): Fu[Result] =
+    reqToCtx(req) flatMap (x => Main authFailed x.req)
 
   protected def ensureSessionId(req: RequestHeader)(res: Result): Result =
     req.session.data.contains(LilaCookie.sessionId).fold(

--- a/app/controllers/Main.scala
+++ b/app/controllers/Main.scala
@@ -132,6 +132,11 @@ object Main extends LilaController {
       NotFound(html.base.notFound())
     }
 
+  def authFailed(req: RequestHeader): Fu[Result] =
+    reqToCtx(req) map { implicit ctx =>
+      Forbidden(html.base.authFailed())
+    }
+
   def fpmenu = Open { implicit ctx =>
     Ok(html.base.fpmenu()).fuccess
   }

--- a/app/controllers/Main.scala
+++ b/app/controllers/Main.scala
@@ -134,6 +134,7 @@ object Main extends LilaController {
 
   def authFailed(req: RequestHeader): Fu[Result] =
     reqToCtx(req) map { implicit ctx =>
+      lila.mon.http.response.code403()
       Forbidden(html.base.authFailed())
     }
 

--- a/app/views/base/authFailed.scala.html
+++ b/app/views/base/authFailed.scala.html
@@ -1,0 +1,14 @@
+@()(implicit ctx: Context)
+
+@base.layout(
+title = "Access denied",
+moreCss = cssTag("authFailed.css")) {
+
+<div class="content_box small_box">
+  <header>
+    <h1>403</h1>
+    <strong>Access denied!</strong>
+    <p>You tried to visit a page you're not authorized to access. Return to <a class="underline" href="@routes.Lobby.home">the homepage</a>.<p>
+  </header>
+</div>
+}

--- a/modules/common/src/main/mon.scala
+++ b/modules/common/src/main/mon.scala
@@ -15,6 +15,7 @@ object mon {
     }
     object response {
       val code400 = inc("http.response.4.00")
+      val code403 = inc("http.response.4.03")
       val code404 = inc("http.response.4.04")
       val code500 = inc("http.response.5.00")
       val home = rec("http.response.home")

--- a/public/stylesheets/authFailed.css
+++ b/public/stylesheets/authFailed.css
@@ -1,0 +1,26 @@
+div.content_box header {
+  overflow: hidden;
+}
+div.content_box header h1 {
+  font-size: 110px;
+  float: left;
+  font-weight: bold;
+  margin: -30px 30px 0 0;
+  opacity: 0.3;
+}
+div.content_box header strong {
+  text-transform: uppercase;
+  opacity: 0.5;
+  font-size: 31px;
+  margin: 10px 0 10px 0;
+  display: block;
+}
+div.content_box a.underline {
+  text-decoration: underline;
+}
+div.content_box div.game {
+  text-align: center;
+}
+div.content_box .credits {
+  margin-top: 2em;
+}


### PR DESCRIPTION
The current 403 page returns a plain "no permission" text, this change adds a
styled 403 page to match the 404 page. Related to #2225

![screenshot-l org-2017-06-14-23-14-59](https://user-images.githubusercontent.com/3677497/27154638-752c2424-515e-11e7-9c80-e8c28c8a145a.jpeg)

I tried to emulate the `notFound` function, but have a feeling it came out wrong? 😅

```scala
def notFound(implicit ctx: Context): Fu[Result] = negotiate(
    html =
    if (HTTPRequest isSynchronousHttp ctx.req) Main notFound ctx.req
    else fuccess(Results.NotFound("Resource not found")),
    api = _ => notFoundJson("Resource not found")
  )
```

* There's no mini-game embedded on this.