### PR TITLE
Fix lag estimate code

### DIFF
--- a/modules/game/src/main/Event.scala
+++ b/modules/game/src/main/Event.scala
@@ -242,7 +242,7 @@ object Event {
     def data = Json.obj(
       "white" -> truncateAt(white, 2),
       "black" -> truncateAt(black, 2),
-      "lagEst" -> nextLagComp.map { _.roundTenths }
+      "lagEst" -> nextLagComp.collect { case Centis(c) if c > 0 => c }
     ).noNull
   }
   object Clock {

--- a/ui/round/src/clock/ctrl.js
+++ b/ui/round/src/clock/ctrl.js
@@ -22,7 +22,7 @@ module.exports = function(data, opts) {
   var times;
 
   function update(white, black, delayCentis) {
-    if (delayCentis === undefined) delayCentis = 0;
+    if (delayCentis === undefined) delayCentis = 1;
     times = {
       white: white * 1000,
       black: black * 1000,


### PR DESCRIPTION
- change server value to centis, which is what js was expecting and
  the accuracy is useful.
- filter lagEst key if it's 0.
- js lag default of .01s.