### PR TITLE
reload to apply 3d (fixes #3049)

### DIFF
--- a/ui/dasher/src/board.ts
+++ b/ui/dasher/src/board.ts
@@ -31,9 +31,7 @@ export function ctrl(data: BoardData, trans: Trans, publishZoom: PublishZoom, re
     trans,
     setIs3d(v: boolean) {
       data.is3d = v;
-      $.post('/pref/is3d', { is3d: v }, window.lichess.reloadOtherTabs);
-      applyDimension(v);
-      publishZoom(data.zoom / 100);
+      $.post('/pref/is3d', { is3d: v }, window.lichess.reload);
       redraw();
     },
     setZoom(v: number) {
@@ -82,15 +80,4 @@ function makeSlider(ctrl: BoardCtrl, el: HTMLElement) {
       slide: (_: any, ui: any) => ctrl.setZoom(ui.value)
     });
   });
-}
-
-function applyDimension(is3d: boolean) {
-
-  $('body').children('.content').removeClass('is2d is3d').addClass(is3d ? 'is3d' : 'is2d');
-
-  if (is3d && !$('link[href*="board-3d.css"]').length) {
-    $('link[href*="board.css"]').clone().each(function(this: HTMLElement) {
-      $(this).attr('href', $(this).attr('href').replace(/board\.css/, 'board-3d.css')).appendTo('head');
-    });
-  }
 }

--- a/ui/dasher/src/board.ts
+++ b/ui/dasher/src/board.ts
@@ -31,7 +31,10 @@ export function ctrl(data: BoardData, trans: Trans, publishZoom: PublishZoom, re
     trans,
     setIs3d(v: boolean) {
       data.is3d = v;
-      $.post('/pref/is3d', { is3d: v }, window.lichess.reload);
+      $.post('/pref/is3d', { is3d: v }, () => {
+        window.lichess.reloadOtherTabs();
+        window.lichess.reload();
+      });
       redraw();
     },
     setZoom(v: number) {


### PR DESCRIPTION
I think changing 2d/3d is rare enough to warrant a page reload. Alternative ideas:

* Add an event to globally upgrade chessgrounds to `addPieceZIndex`.
* Try and optimize `addPieceZIndex` so that it can be always on. But there's probably some unavoidable cost.