### PR TITLE
consistently highlight player titles (#2864)

### DIFF
--- a/app/templating/UserHelper.scala
+++ b/app/templating/UserHelper.scala
@@ -127,7 +127,7 @@ trait UserHelper { self: I18nHelper with StringHelper with NumberHelper =>
 
   private def titleTag(title: Option[String]) = title match {
     case None => ""
-    case Some(t) => s"""<span class="title" title="${User titleName t}">$t</span> """
+    case Some(t) => s"""<span class="title" title="${User titleName t}">$t</span>&nbsp;"""
   }
 
   private def userIdNameLink(
@@ -206,15 +206,15 @@ trait UserHelper { self: I18nHelper with StringHelper with NumberHelper =>
     s"""<span $klass $href>$icon$titleS$content$rating</span>"""
   }
 
-  def userIdSpanMini(userId: String, withOnline: Boolean = false, rating: Option[Int] = None) = Html {
+  def userIdSpanMini(userId: String, withOnline: Boolean = false) = Html {
     val user = lightUser(userId)
     val name = user.fold(userId)(_.name)
-    val content = user.fold(userId)(_.titleNameHtml)
+    val content = user.fold(userId)(_.name)
+    val titleS = user.??(u => titleTag(u.title))
     val klass = userClass(userId, none, withOnline)
     val href = s"data-${userHref(name)}"
     val icon = withOnline ?? lineIcon(user)
-    val ra = rating.??(r => s" ($r)")
-    s"""<span $klass $href>$icon$content$ra</span>"""
+    s"""<span $klass $href>$icon$titleS$content</span>"""
   }
 
   private def renderRating(perf: Perf) =

--- a/app/views/game/widgets.scala.html
+++ b/app/views/game/widgets.scala.html
@@ -3,9 +3,7 @@
 @gamePlayer(variant: chess.variant.Variant, player: Player) = {
 <div class="player @player.color.name">
   @player.playerUser.map { playerUser =>
-  <a href="@routes.User.show(playerUser.id)" class="user_link ulpt">
-    @usernameOrId(playerUser.id)
-  </a>
+  @userIdLink(playerUser.id.some, withOnline = false)
   <br />
   @if(player.berserk) { @berserkIconSpanHtml }
   @playerUser.rating@if(player.provisional) {?}

--- a/app/views/user/show.scala.html
+++ b/app/views/user/show.scala.html
@@ -27,9 +27,9 @@ description = describeUser(u)).some) {
   <div class="content_box_top">
     <h1 class="lichess_title user_link @if(isOnline(u.id)){online}else{offline}">
       @if(u.isPatron) {
-      <a href="@routes.Plan.index">@Html(patronIcon)</a>@u.titleUsername
+      <a href="@routes.Plan.index">@Html(patronIcon)</a>@userSpan(u, withPowerTip = false, withOnline = false)
       } else {
-      @Html(lineIcon)@u.titleUsername
+      @userSpan(u, withPowerTip = false)
       }
     </h1>
     <div class="trophies@if(info.countTrophiesAndPerfCups > 7){ packed}">


### PR DESCRIPTION
Everywhere except ui/round and left sidebar. (These can also be done, but might be more controversial since the titles are quite bright, especially in the dark theme.)