### PR TITLE
avoid using e.which in board editor (fixes #3135)

### DIFF
--- a/ui/editor/src/chessground.js
+++ b/ui/editor/src/chessground.js
@@ -20,7 +20,7 @@ function bindEvents(el, ctrl) {
 }
 
 function isLeftButton(e) {
-  return e.buttons === 1 || e.button === 1 || e.which === 1;
+  return e.buttons === 1 || e.button === 1;
 }
 
 function isLeftClick(e) {


### PR DESCRIPTION
It seems to be `1` in Firefox, even for `mousemove` events.