### PR TITLE
Highlight Patron link in the /account preferences menu

### DIFF
--- a/app/views/account/layout.scala.html
+++ b/app/views/account/layout.scala.html
@@ -35,7 +35,7 @@
 <a class="@active.active("security")" href="@routes.Account.security()">
   @trans.security()
 </a>
-<a href="@routes.Plan.index">Patron</a>
+<a href="@routes.Plan.index" style="color: #d59120; font-weight: bold;">Patron</a>
 <div class="sep"></div>
 <a class="@active.active("close")" href="@routes.Account.close()">
   @trans.closeAccount()


### PR DESCRIPTION
Makes sure the Patron link is more visible in the /account menu