### PR TITLE
highlight titles in sidebar and round (fixes #2864)

### DIFF
--- a/modules/game/src/main/Namer.scala
+++ b/modules/game/src/main/Namer.scala
@@ -1,6 +1,7 @@
 package lila.game
 
 import lila.common.LightUser
+import lila.user.User
 import play.twirl.api.Html
 
 object Namer {
@@ -11,8 +12,11 @@ object Namer {
   def player(p: Player, withRating: Boolean = true, withTitle: Boolean = true)(implicit lightUser: LightUser.GetterSync) = Html {
     p.aiLevel.fold(
       p.userId.flatMap(lightUser).fold(lila.user.User.anonymous) { user =>
-        if (withRating) s"${withTitle.fold(user.titleNameHtml, user.name)}&nbsp;(${ratingString(p)})"
-        else withTitle.fold(user.titleName, user.name)
+        val title = (user.title ifTrue withTitle) ?? { t =>
+          s"""<span class="title" title="${User titleName t}">$t</span>&nbsp;"""
+        }
+        if (withRating) s"$title${user.name}&nbsp;(${ratingString(p)})"
+        else s"$title${user.name}"
       }
     ) { level => s"A.I. level $level" }
   }

--- a/ui/round/src/view/user.ts
+++ b/ui/round/src/view/user.ts
@@ -19,13 +19,12 @@ export function userHtml(ctrl, player) {
   var perf = user ? user.perfs[d.game.perf] : null;
   var rating = player.rating ? player.rating : (perf && perf.rating);
   if (user) {
-    var fullName = (user.title ? user.title + ' ' : '') + user.username;
     var connecting = !player.onGame && ctrl.vm.firstSeconds && user.online;
     return h('div.username.user_link.' + player.color, {
       class: {
         online: player.onGame,
         offline: !player.onGame,
-        long: fullName.length > 20,
+        long: user.username.length > 16,
         connecting: connecting
       }
     }, [
@@ -40,7 +39,7 @@ export function userHtml(ctrl, player) {
           href: '/@/' + user.username,
           target: game.isPlayerPlaying(d) ? '_blank' : '_self'
         }
-      }, fullName),
+      }, user.title ? [h('span.title', user.title), ' ', user.username] : user.username),
       rating ? h('rating', rating + (player.provisional ? '?' : '')) : null,
       ratingDiff(player),
       player.engine ? h('span', {


### PR DESCRIPTION
Consistent title highlighting for ui/round. I had skipped this in #3188. You can check if it's too bright or good on stage.