### PR TITLE
Set clock on move

### DIFF
--- a/ui/round/src/clock/view.ts
+++ b/ui/round/src/clock/view.ts
@@ -7,9 +7,7 @@ import { h } from 'snabbdom'
 export function renderClock(ctrl, player, position) {
   const millis = ctrl.clock.millisOf(player.color);
   const isPlayer = ctrl.data.player.color === player.color;
-  let isRunning = false;
-  if (ctrl.vm.justMoved) isRunning = !isPlayer;
-  else if (player.color === ctrl.data.game.player && ctrl.isClockRunning()) isRunning = true;
+  const isRunning = isPlayer && game.playable(ctrl.data) && ctrl.isClockRunning();
   const update = (el: HTMLElement) => {
     ctrl.clock.elements[player.color].time = el;
     el.innerHTML = formatClockTime(ctrl.clock.data, millis, isRunning);

--- a/ui/site/src/socket.js
+++ b/ui/site/src/socket.js
@@ -68,7 +68,7 @@ lichess.StrongSocket = function(url, version, settings) {
     o = o || {};
     var msg = { t: t };
     if (d !== undefined) {
-      if (o.millis >= 0) d.s = Math.round(o.millis * 0.1).toString(36);
+      if (o.centis >= 0) d.s = o.centis.toString(36);
       msg.d = d;
     }
     if (o.ackable) ackable.register(t, d);


### PR DESCRIPTION
Use the centis value sent on wire to set clock
to match server time. Fixes an issue with the clock
either didn't tick fast enough or somehow became out of
sync with the better elapsed calculation and the time
shifted in apiMove()

Some misc cleanup.