### PR TITLE
Add more English profane plural and -d/-ed suffixes

### DIFF
--- a/modules/shutup/src/main/Analyser.scala
+++ b/modules/shutup/src/main/Analyser.scala
@@ -8,8 +8,7 @@ object Analyser {
   )
 
   private def wordsRegexes =
-    Dictionary.en.map { word =>
-      if (word endsWith "s") word else word + "s?"
+    Dictionary.en.map { word => word + "e?[ds]?"
     } ++
       Dictionary.ru
 

--- a/modules/shutup/src/main/Dictionary.scala
+++ b/modules/shutup/src/main/Dictionary.scala
@@ -25,7 +25,7 @@ ball
 bastard?
 bewb
 bimbo
-bitche?
+bitch
 blow
 blowjob
 blumpkin
@@ -74,12 +74,11 @@ hitler+
 homm?o(sexual|)
 honkey
 hooker
-hore
 horny
 humping
 idiot
 incest
-jerk
+jerks?
 jizz?(um|)
 kaffir
 kike
@@ -89,7 +88,7 @@ masturbat(e|ion|ing)
 milf
 molest
 moron
-mother
+mothers?
 motherfuc?k(er|)
 mthrfckr
 muff
@@ -105,7 +104,7 @@ pecker
 pederast
 pen(1|i)s
 pig
-pimp
+pimps?
 piss
 poof
 poon
@@ -119,13 +118,13 @@ puss(i|y|ie|)
 queef
 queer
 quim
-raped?
+rape
 rapist
 rect(al|um)
-retard(ed|)
+retard
 rimjob
 schlong
-screw(d|ed|)
+screw
 scrotum
 scum(bag|)
 semen
@@ -160,7 +159,7 @@ vibrator
 vulva
 wanc?k(er|)
 wetback
-whore?
+w?hore?
 wog
 """)
 

--- a/modules/shutup/src/test/AnalyserTest.scala
+++ b/modules/shutup/src/test/AnalyserTest.scala
@@ -14,7 +14,7 @@ class DetectTest extends Specification {
       find("well fuck me") must_== List("fuck")
     }
     "find many bad words" in {
-      find("fuck that shit") must_== List("fuck", "shit")
+      find("fucked that shit") must_== List("fucked", "shit")
       find("Beat them cunting nigger faggots with a communist dick") must_==
         List("cunting", "nigger", "faggots", "dick")
     }
@@ -34,7 +34,7 @@ class DetectTest extends Specification {
       find("ass as ashole") must_== List("ass", "ashole")
     }
     "find plurals" in {
-      find("cunts kunts cuntings kawas kuntings") must_== List("cunts", "kunts", "cuntings", "kuntings")
+      find("asses cunts kunts cuntings kawas kuntings") must_== List("asses", "cunts", "kunts", "cuntings", "kuntings")
     }
     "50 shades of fuck" in {
       find("fuck fffuuk fektard feak fak phuk") must_== List("fuck", "fffuuk", "fektard", "fak", "phuk")


### PR DESCRIPTION
English suffixes -s, -d, -es, -ed, and -e (typo of -es/-ed) are common.
Code golfed dictionary a little bit.