### PR TITLE
Use less of Project.apply

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -37,12 +37,14 @@ object BuildSettings {
   def project(name: String, deps: Seq[sbt.ClasspathDep[sbt.ProjectReference]] = Seq.empty) =
     Project(
       name,
-      file("modules/" + name),
-      dependencies = deps,
-      settings = Seq(
-        version := "2.0",
-        libraryDependencies := defaultDeps
-      ) ++ buildSettings ++ srcMain
+      file("modules/" + name)
+    )
+    .dependsOn(deps: _*)
+    .settings(
+      version := "2.0",
+      libraryDependencies := defaultDeps,
+      buildSettings,
+      srcMain
     )
 
   val compilerOptions = Seq(


### PR DESCRIPTION
In sbt 1 Project.apply will only take 2 parameters.