### PR TITLE
Do not generate leaderboard assessments for offline users [RFC]

### DIFF
--- a/modules/irwin/src/main/Env.scala
+++ b/modules/irwin/src/main/Env.scala
@@ -33,7 +33,7 @@ final class Env(
     tournamentApi.allCurrentLeadersInStandard flatMap api.requests.fromTournamentLeaders
   }
   scheduler.future(15 minutes, "irwin leaderboards") {
-    userCache.top50OnlineIds.get flatMap api.requests.fromLeaderboard
+    userCache.top50Online.get flatMap api.requests.fromLeaderboard
   }
 
   system.lilaBus.subscribe(system.actorOf(Props(new Actor {

--- a/modules/irwin/src/main/Env.scala
+++ b/modules/irwin/src/main/Env.scala
@@ -33,7 +33,7 @@ final class Env(
     tournamentApi.allCurrentLeadersInStandard flatMap api.requests.fromTournamentLeaders
   }
   scheduler.future(15 minutes, "irwin leaderboards") {
-    userCache.top50Online.get >>- api.requests.fromLeaderboard(_)
+    userCache.top50OnlineIds.get flatMap api.requests.fromLeaderboard
   }
 
   system.lilaBus.subscribe(system.actorOf(Props(new Actor {

--- a/modules/irwin/src/main/Env.scala
+++ b/modules/irwin/src/main/Env.scala
@@ -33,11 +33,7 @@ final class Env(
     tournamentApi.allCurrentLeadersInStandard flatMap api.requests.fromTournamentLeaders
   }
   scheduler.future(15 minutes, "irwin leaderboards") {
-    lila.common.Future.applySequentially(lila.rating.PerfType.standard) { pt =>
-      userCache.top200Perf(pt.id) flatMap { users =>
-        api.requests.fromLeaderboard(users.map(_.user.id))
-      }
-    }
+    userCache.top50Online.get >>- api.requests.fromLeaderboard(_)
   }
 
   system.lilaBus.subscribe(system.actorOf(Props(new Actor {

--- a/modules/irwin/src/main/IrwinApi.scala
+++ b/modules/irwin/src/main/IrwinApi.scala
@@ -100,9 +100,9 @@ final class IrwinApi(
           }
       }
 
-    private[irwin] def fromLeaderboard(leaders: List[User.ID]): Funit =
-      lila.common.Future.applySequentially(leaders) { userId =>
-        insert(userId, _.Leaderboard, none)
+    private[irwin] def fromLeaderboard(leaders: List[User]): Funit =
+      lila.common.Future.applySequentially(leaders) { user =>
+        insert(user.id, _.Leaderboard, none)
       }
   }
 

--- a/modules/user/src/main/Cached.scala
+++ b/modules/user/src/main/Cached.scala
@@ -85,9 +85,9 @@ final class Cached(
     keyToString = _.toString
   )
 
-  val top50Online = asyncCache.single[List[User]](
+  val top50Online = asyncCache.single[List[User.ID]](
     name = "user.top50online",
-    f = UserRepo.byIdsSortRating(onlineUserIdMemo.keys, 50),
+    f = UserRepo.idsByIdsSortRating(onlineUserIdMemo.keys, 50),
     expireAfter = _.ExpireAfterWrite(10 seconds)
   )
 

--- a/modules/user/src/main/Cached.scala
+++ b/modules/user/src/main/Cached.scala
@@ -85,8 +85,14 @@ final class Cached(
     keyToString = _.toString
   )
 
-  val top50Online = asyncCache.single[List[User.ID]](
+  val top50Online = asyncCache.single[List[User]](
     name = "user.top50online",
+    f = UserRepo.byIdsSortRating(onlineUserIdMemo.keys, 50),
+    expireAfter = _.ExpireAfterWrite(10 seconds)
+  )
+
+  val top50OnlineIds = asyncCache.single[List[User.ID]](
+    name = "user.top50onlineid",
     f = UserRepo.idsByIdsSortRating(onlineUserIdMemo.keys, 50),
     expireAfter = _.ExpireAfterWrite(10 seconds)
   )

--- a/modules/user/src/main/Cached.scala
+++ b/modules/user/src/main/Cached.scala
@@ -91,12 +91,6 @@ final class Cached(
     expireAfter = _.ExpireAfterWrite(10 seconds)
   )
 
-  val top50OnlineIds = asyncCache.single[List[User.ID]](
-    name = "user.top50onlineid",
-    f = UserRepo.idsByIdsSortRating(onlineUserIdMemo.keys, 50),
-    expireAfter = _.ExpireAfterWrite(10 seconds)
-  )
-
   object ranking {
 
     def getAll(userId: User.ID): Fu[Map[Perf.Key, Int]] =


### PR DESCRIPTION
Since [we no longer prioritize tournament requests over leaderboard requests](6b5247bafdbde96052194d7defb91470becab3ba), for performance reasons let's consider filtering leaderboard requests based upon online players rather than based upon all leaderboard players.