### PR TITLE
Add mod action 'reportban'

### DIFF
--- a/app/controllers/Mod.scala
+++ b/app/controllers/Mod.scala
@@ -81,6 +81,10 @@ object Mod extends LilaController {
     modApi.kickFromRankings(me.id, username) inject redirect(username)
   }
 
+  def reportban(username: String) = Secure(_.ReportBan) { implicit ctx => me =>
+    modApi.toggleReportban(me.id, username) inject redirect(username)
+  }
+
   def setTitle(username: String) = SecureBody(_.SetTitle) { implicit ctx => me =>
     implicit def req = ctx.body
     lila.user.DataForm.title.bindFromRequest.fold(

--- a/app/views/user/mod.scala.html
+++ b/app/views/user/mod.scala.html
@@ -59,6 +59,11 @@
     <input class="button" type="submit" value="Kick from ranking" />
   </form>
   }
+  @if(isGranted(_.ReportBan)) {
+  <form method="post" action="@routes.Mod.reportban(u.username)" data-hint="@if(u.reportban){En}else{Dis}able the report feature for this user." class="hint--bottom left">
+    <input class="button@when(u.reportban, " active")" type="submit" value="Reportban" />
+  </form>
+  }
   @if(isGranted(_.SetTitle)) {
   <br />
   <br />

--- a/app/views/user/mod.scala.html
+++ b/app/views/user/mod.scala.html
@@ -282,6 +282,7 @@
           @if(o.engine){<i title="Engine" data-icon="n"></i>}
           @if(o.ipBan){<i title="IP ban" data-icon="2" class="is-red"></i>}
           @if(o.disabled){<i title="Closed" data-icon="k"></i>}
+          @if(o.reportban){<i title="Reportban" data-icon="!"></i>}
         </td>
         <td data-sort="@o.createdAt.getMillis">@momentFromNow(o.createdAt)</td>
         <td data-sort="@o.seenAt.map(_.getMillis)">@o.seenAt.map(momentFromNow)</td>

--- a/app/views/user/mod.scala.html
+++ b/app/views/user/mod.scala.html
@@ -54,6 +54,7 @@
   </form>
   }
   }
+  <div class="second_mod_button_row">
   @if(isGranted(_.RemoveRanking)) {
   <form method="post" action="@routes.Mod.kickFromRankings(u.username)" data-hint="Excludes this user from the rankings during the next calculation." class="hint--bottom-left">
     <input class="button" type="submit" value="Kick from ranking" />
@@ -64,6 +65,7 @@
     <input class="button@when(u.reportban, " active")" type="submit" value="Reportban" />
   </form>
   }
+  </div>
   @if(isGranted(_.SetTitle)) {
   <br />
   <br />

--- a/conf/routes
+++ b/conf/routes
@@ -356,6 +356,7 @@ POST  /mod/:username/inquiry           controllers.Mod.spontaneousInquiry(userna
 GET   /mod/:username/communication     controllers.Mod.communication(username: String)
 POST  /mod/:ip/ipban                   controllers.Mod.ipban(ip: String)
 POST  /mod/:username/kickFromRankings  controllers.Mod.kickFromRankings(username: String)
+POST  /mod/:username/reportban         controllers.Mod.reportban(username: String)
 GET   /mod/log                         controllers.Mod.log
 POST  /mod/:username/refreshUserAssess controllers.Mod.refreshUserAssess(username: String)
 POST  /mod/:username/email             controllers.Mod.setEmail(username: String)

--- a/modules/mod/src/main/ModApi.scala
+++ b/modules/mod/src/main/ModApi.scala
@@ -124,6 +124,16 @@ final class ModApi(
     logApi.kickFromRankings(mod, user.id)
   }
 
+  def toggleReportban(mod: String, username: String): Funit = withUser(username) { user =>
+    setReportban(mod, username, !user.reportban)
+  }
+
+  def setReportban(mod: String, username: String, v: Boolean): Funit = withUser(username) { user =>
+    (user.reportban != v) ?? {
+      UserRepo.setReportban(user.id, v) >>- logApi.reportban(mod, user.id, v)
+    }
+  }
+
   private def withUser[A](username: String)(op: User => Fu[A]): Fu[A] =
     UserRepo named username flatten "[mod] missing user " + username flatMap op
 

--- a/modules/mod/src/main/Modlog.scala
+++ b/modules/mod/src/main/Modlog.scala
@@ -40,6 +40,8 @@ case class Modlog(
     case Modlog.untroll => "un-shadowban"
     case Modlog.permissions => "set permissions"
     case Modlog.kickFromRankings => "kick from rankings"
+    case Modlog.reportban => "reportban"
+    case Modlog.unreportban => "un-reportban"
     case Modlog.modMessage => "send message"
     case a => a
   }
@@ -78,5 +80,7 @@ object Modlog {
   val terminateTournament = "terminateTournament "
   val chatTimeout = "chatTimeout "
   val kickFromRankings = "kickFromRankings"
+  val reportban = "reportban"
+  val unreportban = "unreportban"
   val modMessage = "modMessage"
 }

--- a/modules/mod/src/main/ModlogApi.scala
+++ b/modules/mod/src/main/ModlogApi.scala
@@ -103,6 +103,10 @@ final class ModlogApi(coll: Coll) {
     Modlog(mod, user.some, Modlog.kickFromRankings)
   }
 
+  def reportban(mod: String, user: String, v: Boolean) = add {
+    Modlog(mod, user.some, v.fold(Modlog.reportban, Modlog.unreportban))
+  }
+
   def modMessage(mod: String, user: String, subject: String) = add {
     Modlog(mod, user.some, Modlog.modMessage, details = subject.some)
   }

--- a/modules/report/src/main/ReportApi.scala
+++ b/modules/report/src/main/ReportApi.scala
@@ -31,7 +31,7 @@ final class ReportApi(
     createdBy = by
   ), setup.user, by)
 
-  def create(report: Report, reported: User, by: User): Funit = !by.troll ?? {
+  def create(report: Report, reported: User, by: User): Funit = !by.reportban ?? {
     !isAlreadySlain(report, reported) ?? {
 
       lila.mon.mod.report.create(report.reason.key)()

--- a/modules/security/src/main/Permission.scala
+++ b/modules/security/src/main/Permission.scala
@@ -43,6 +43,7 @@ object Permission {
   case object PreviewCoach extends Permission("ROLE_PREVIEW_COACH")
   case object ModNote extends Permission("ROLE_MOD_NOTE")
   case object RemoveRanking extends Permission("ROLE_REMOVE_RANKING")
+  case object ReportBan extends Permission("ROLE_REPORT_BAN")
   case object ModMessage extends Permission("ROLE_MOD_MESSAGE")
 
   case object Hunter extends Permission("ROLE_HUNTER", List(
@@ -55,7 +56,7 @@ object Permission {
     Hunter, ModerateForum, IpBan, CloseAccount, ReopenAccount,
     ChatTimeout, MarkTroll, SetTitle, SetEmail, ModerateQa, StreamConfig,
     MessageAnyone, CloseTeam, TerminateTournament, ManageTournament, ManageEvent,
-    PreviewCoach, PracticeConfig, RemoveRanking
+    PreviewCoach, PracticeConfig, RemoveRanking, ReportBan
   ))
 
   case object SuperAdmin extends Permission("ROLE_SUPER_ADMIN", List(
@@ -66,7 +67,7 @@ object Permission {
     Admin, Hunter, MarkTroll, ChatTimeout, ChangePermission, ViewBlurs, StaffForum, ModerateForum,
     UserSpy, MarkEngine, MarkBooster, IpBan, ModerateQa, StreamConfig, PracticeConfig,
     Beta, MessageAnyone, UserSearch, CloseTeam, TerminateTournament, ManageTournament, ManageEvent,
-    PublicMod, Developer, Coach, PreviewCoach, GuineaPig, ModNote
+    PublicMod, Developer, Coach, PreviewCoach, GuineaPig, ModNote, RemoveRanking, ReportBan
   )
 
   lazy private val all: List[Permission] = SuperAdmin :: allButSuperAdmin

--- a/modules/user/src/main/User.scala
+++ b/modules/user/src/main/User.scala
@@ -26,7 +26,8 @@ case class User(
     seenAt: Option[DateTime],
     kid: Boolean,
     lang: Option[String],
-    plan: Plan
+    plan: Plan,
+    reportban: Boolean = false
 ) extends Ordered[User] {
 
   override def equals(other: Any) = other match {
@@ -188,6 +189,7 @@ object User {
     val prevEmail = "prevEmail"
     val colorIt = "colorIt"
     val plan = "plan"
+    val reportban = "reportban"
   }
 
   import lila.db.BSON
@@ -221,7 +223,8 @@ object User {
       kid = r boolD kid,
       lang = r strO lang,
       title = r strO title,
-      plan = r.getO[Plan](plan) | Plan.empty
+      plan = r.getO[Plan](plan) | Plan.empty,
+      reportban = r boolD reportban
     )
 
     def writes(w: BSON.Writer, o: User) = BSONDocument(
@@ -243,7 +246,8 @@ object User {
       kid -> w.boolO(o.kid),
       lang -> o.lang,
       title -> o.title,
-      plan -> o.plan.nonEmpty
+      plan -> o.plan.nonEmpty,
+      reportban -> w.boolO(o.reportban)
     )
   }
 }

--- a/modules/user/src/main/UserRepo.scala
+++ b/modules/user/src/main/UserRepo.scala
@@ -303,6 +303,8 @@ object UserRepo {
 
   def setBooster(id: ID, v: Boolean): Funit = coll.updateField($id(id), "booster", v).void
 
+  def setReportban(id: ID, v: Boolean): Funit = coll.updateField($id(id), "reportban", v).void
+
   def toggleIpBan(id: ID) = coll.fetchUpdate[User]($id(id)) { u => $set("ipBan" -> !u.ipBan) }
 
   def toggleKid(user: User) = coll.updateField($id(user.id), "kid", !user.kid)

--- a/public/stylesheets/user-mod.css
+++ b/public/stylesheets/user-mod.css
@@ -16,6 +16,9 @@
   border: 0;
   vertical-align: top;
 }
+.mod_zone .second_mod_button_row {
+  margin-top: 5px;
+}
 .mod_zone .neural,
 .mod_zone .mod_roles {
   padding: 10px 0;


### PR DESCRIPTION
Based on recent discussion in #tavern. Paranoid members aren't always abusive, and abusive strong players may still make good reports. A 'reportban' is like a shadowban except it only affects reporting, and with this pull request, shadowbans no longer affect someone's ability to report.

This pull request consists of 3 commits: please see their full commit messages to see what they do exactly.