### PR TITLE
Option for public mods to display icon in forum/qa

### DIFF
--- a/app/templating/ForumHelper.scala
+++ b/app/templating/ForumHelper.scala
@@ -31,8 +31,9 @@ trait ForumHelper { self: UserHelper with StringHelper =>
   def authorLink(
     post: Post,
     cssClass: Option[String] = None,
-    withOnline: Boolean = true
+    withOnline: Boolean = true,
+    modIcon: Boolean = false
   ) = post.userId.fold(Html(lila.user.User.anonymous)) { userId =>
-    userIdLink(userId.some, cssClass = cssClass, withOnline = withOnline)
+    userIdLink(userId.some, cssClass = cssClass, withOnline = withOnline, modIcon = modIcon)
   }
 }

--- a/app/templating/UserHelper.scala
+++ b/app/templating/UserHelper.scala
@@ -82,7 +82,8 @@ trait UserHelper { self: I18nHelper with StringHelper with NumberHelper =>
     withOnline: Boolean = true,
     withTitle: Boolean = true,
     truncate: Option[Int] = None,
-    params: String = ""
+    params: String = "",
+    modIcon: Boolean = false
   ): Html = Html {
     userIdOption.flatMap(lightUser).fold(User.anonymous) { user =>
       userIdNameLink(
@@ -94,7 +95,8 @@ trait UserHelper { self: I18nHelper with StringHelper with NumberHelper =>
         withOnline = withOnline,
         withTitle = withTitle,
         truncate = truncate,
-        params = params
+        params = params,
+        modIcon = modIcon
       )
     }
   }
@@ -116,7 +118,8 @@ trait UserHelper { self: I18nHelper with StringHelper with NumberHelper =>
       withOnline = withOnline,
       withTitle = withTitle,
       truncate = truncate,
-      params = params
+      params = params,
+      modIcon = false
     )
   }
 
@@ -139,13 +142,14 @@ trait UserHelper { self: I18nHelper with StringHelper with NumberHelper =>
     withTitle: Boolean,
     truncate: Option[Int],
     title: Option[String],
-    params: String
+    params: String,
+    modIcon: Boolean
   ): String = {
     val klass = userClass(userId, cssClass, withOnline)
     val href = userHref(username, params = params)
     val content = truncate.fold(username)(username.take)
     val titleS = if (withTitle) titleTag(title) else ""
-    val icon = withOnline ?? lineIcon(isPatron)
+    val icon = withOnline ?? (if (modIcon) moderatorIcon else lineIcon(isPatron))
     s"""<a $klass $href>$icon$titleS$content</a>"""
   }
 
@@ -276,6 +280,7 @@ trait UserHelper { self: I18nHelper with StringHelper with NumberHelper =>
 
   val lineIcon: String = """<i class="line"></i>"""
   val patronIcon: String = """<i class="line patron" title="lichess Patron"></i>"""
+  val moderatorIcon: String = """<i class="line moderator" title="lichess Moderator"></i>"""
   private def lineIcon(patron: Boolean): String = if (patron) patronIcon else lineIcon
   private def lineIcon(user: Option[LightUser]): String = lineIcon(user.??(_.isPatron))
   def lineIcon(user: User): String = lineIcon(user.isPatron)

--- a/app/views/forum/topic/form.scala.html
+++ b/app/views/forum/topic/form.scala.html
@@ -26,6 +26,9 @@
   @forum.post.formFields(form("post")("text"), form("post")("author"), None)
   @base.captcha(form("post")("move"), form("post")("gameId"), captcha)
   @errMsg(form("post"))
+  @if(isGranted(_.PublicMod)){
+    <div class="submit"><input type="checkbox" name="post.modIcon" value="true" /> Show moderator icon next to my name</div>
+  }
   <button class="submit button" type="submit" data-icon="E"> @trans.createTheTopic()</button>
   <a href="@routes.ForumCateg.show(categ.slug)" style="margin-left:20px">@trans.cancel()</a>
 </form>

--- a/app/views/forum/topic/show.scala.html
+++ b/app/views/forum/topic/show.scala.html
@@ -40,7 +40,7 @@ description = shorten(posts.currentPageResults.headOption.??(_.text).replace("\n
     @posts.currentPageResults.map { post =>
     <div class="post" id="@post.number">
       <div class="metas clearfix">
-        @authorLink(post, "author".some)
+        @authorLink(post=post, cssClass="author".some, modIcon=post.displayModIcon)
 
         @post.updatedAt.map { updatedAt =>
           <span class="post-edited">edited</span>
@@ -104,6 +104,9 @@ description = shorten(posts.currentPageResults.headOption.??(_.text).replace("\n
       @forum.post.formFields(form("text"), form("author"), topic.some)
       @base.captcha(form("move"), form("gameId"), captcha)
       @globalError(form)
+      @if(isGranted(_.PublicMod)){
+      <div class="submit"><input type="checkbox" name="modIcon" value="true" /> Show moderator icon next to my name</div>
+      }
       <button type="submit" class="submit button" data-icon="E"> @trans.reply()</button>
       <a href="@routes.ForumCateg.show(categ.slug)" style="margin-left:20px">@trans.cancel()</a>
     </form>

--- a/app/views/qa/answerList.scala.html
+++ b/app/views/qa/answerList.scala.html
@@ -33,7 +33,7 @@
     <div class="content">
       <div class="answer">
         <div class="meta">
-          <span class="light">Answered @momentFromNow(a.createdAt) by @userIdLink(a.userId.some)</span>
+          <span class="light">Answered @momentFromNow(a.createdAt) by @userIdLink(userIdOption=a.userId.some, modIcon=a.displayModIcon)</span>
           @if(lila.qa.QaAuth canEdit a) {
           <a class="thin button toggle-edit-answer" data-icon="m"> Edit</a>
           }

--- a/app/views/qa/questionShow.scala.html
+++ b/app/views/qa/questionShow.scala.html
@@ -75,6 +75,9 @@ description = shorten(q.body.replace("\n", ""), 152).body).some) {
         <textarea class="answer-body" name="@form("body").name">@form("body").value</textarea>
         @errMsg(form("body"))
         @base.captcha(form("move"), form("gameId"), captcha)
+        @if(isGranted(_.PublicMod)){
+          <div class="submit"><input type="checkbox" name="modIcon" value="true" /> Show moderator icon next to my name</div>
+        }
         <button class="pure submit button" type="submit">Post your answer</button>
       </form>
     </div>

--- a/modules/forum/src/main/CategApi.scala
+++ b/modules/forum/src/main/CategApi.scala
@@ -54,7 +54,8 @@ private[forum] final class CategApi(env: Env) {
         troll = false,
         hidden = topic.hidden,
         lang = "en".some,
-        categId = categ.id
+        categId = categ.id,
+        modIcon = None
       )
       env.categColl.insert(categ).void >>
         env.postColl.insert(post).void >>

--- a/modules/forum/src/main/DataForm.scala
+++ b/modules/forum/src/main/DataForm.scala
@@ -6,12 +6,14 @@ import play.api.data.Forms._
 private[forum] final class DataForm(val captcher: akka.actor.ActorSelection) extends lila.hub.CaptchedForm {
 
   import DataForm._
+  import lila.security.Granter
 
   val postMapping = mapping(
     "text" -> text(minLength = 3),
     "author" -> optional(text),
     "gameId" -> text,
-    "move" -> text
+    "move" -> text,
+    "modIcon" -> optional(boolean)
   )(PostData.apply)(PostData.unapply)
     .verifying(captchaFailMessage, validateCaptcha _)
 
@@ -33,7 +35,8 @@ object DataForm {
     text: String,
     author: Option[String],
     gameId: String,
-    move: String
+    move: String,
+    modIcon: Option[Boolean]
   )
 
   case class TopicData(

--- a/modules/forum/src/main/DataForm.scala
+++ b/modules/forum/src/main/DataForm.scala
@@ -6,7 +6,6 @@ import play.api.data.Forms._
 private[forum] final class DataForm(val captcher: akka.actor.ActorSelection) extends lila.hub.CaptchedForm {
 
   import DataForm._
-  import lila.security.Granter
 
   val postMapping = mapping(
     "text" -> text(minLength = 3),

--- a/modules/forum/src/main/Post.scala
+++ b/modules/forum/src/main/Post.scala
@@ -21,7 +21,8 @@ case class Post(
     lang: Option[String],
     editHistory: Option[List[OldVersion]] = None,
     createdAt: DateTime,
-    updatedAt: Option[DateTime] = None
+    updatedAt: Option[DateTime] = None,
+    modIcon: Option[Boolean]
 ) {
 
   private val permitEditsFor = 4 hours
@@ -59,6 +60,8 @@ case class Post(
   }
 
   def hasEdits = editHistory.isDefined
+
+  def displayModIcon = ~modIcon
 }
 
 object Post {
@@ -77,7 +80,8 @@ object Post {
     number: Int,
     lang: Option[String],
     troll: Boolean,
-    hidden: Boolean
+    hidden: Boolean,
+    modIcon: Option[Boolean]
   ): Post = {
 
     Post(
@@ -92,7 +96,8 @@ object Post {
       troll = troll,
       hidden = hidden,
       createdAt = DateTime.now,
-      categId = categId
+      categId = categId,
+      modIcon = modIcon
     )
   }
 }

--- a/modules/forum/src/main/PostApi.scala
+++ b/modules/forum/src/main/PostApi.scala
@@ -41,7 +41,8 @@ final class PostApi(
           lang = lang map (_.language),
           troll = ctx.troll,
           hidden = topic.hidden,
-          categId = categ.id
+          categId = categ.id,
+          modIcon = (data.modIcon.getOrElse(false) && ctx.me.map(MasterGranter(_.PublicMod)).getOrElse(false)).fold(Some(true), None)
         )
         PostRepo findDuplicate post flatMap {
           case Some(dup) => fuccess(dup)

--- a/modules/forum/src/main/PostApi.scala
+++ b/modules/forum/src/main/PostApi.scala
@@ -42,7 +42,7 @@ final class PostApi(
           troll = ctx.troll,
           hidden = topic.hidden,
           categId = categ.id,
-          modIcon = (data.modIcon.getOrElse(false) && ctx.me.map(MasterGranter(_.PublicMod)).getOrElse(false)).fold(Some(true), None)
+          modIcon = (~data.modIcon && ~ctx.me.map(MasterGranter(_.PublicMod))).option(true)
         )
         PostRepo findDuplicate post flatMap {
           case Some(dup) => fuccess(dup)

--- a/modules/forum/src/main/TopicApi.scala
+++ b/modules/forum/src/main/TopicApi.scala
@@ -60,7 +60,8 @@ private[forum] final class TopicApi(
           text = lila.security.Spam.replace(data.post.text),
           lang = lang map (_.language),
           number = 1,
-          categId = categ.id
+          categId = categ.id,
+          modIcon = (data.post.modIcon.pp.getOrElse(false) && ctx.me.map(MasterGranter(_.PublicMod)).getOrElse(false)).fold(Some(true), None)
         )
         env.postColl.insert(post) >>
           env.topicColl.insert(topic withPost post) >>

--- a/modules/forum/src/main/TopicApi.scala
+++ b/modules/forum/src/main/TopicApi.scala
@@ -61,7 +61,7 @@ private[forum] final class TopicApi(
           lang = lang map (_.language),
           number = 1,
           categId = categ.id,
-          modIcon = (data.post.modIcon.pp.getOrElse(false) && ctx.me.map(MasterGranter(_.PublicMod)).getOrElse(false)).fold(Some(true), None)
+          modIcon = (data.post.modIcon.getOrElse(false) && ctx.me.map(MasterGranter(_.PublicMod)).getOrElse(false)).fold(Some(true), None)
         )
         env.postColl.insert(post) >>
           env.topicColl.insert(topic withPost post) >>

--- a/modules/forum/src/main/TopicApi.scala
+++ b/modules/forum/src/main/TopicApi.scala
@@ -61,7 +61,7 @@ private[forum] final class TopicApi(
           lang = lang map (_.language),
           number = 1,
           categId = categ.id,
-          modIcon = (data.post.modIcon.getOrElse(false) && ctx.me.map(MasterGranter(_.PublicMod)).getOrElse(false)).fold(Some(true), None)
+          modIcon = (~data.post.modIcon && ~ctx.me.map(MasterGranter(_.PublicMod))).option(true)
         )
         env.postColl.insert(post) >>
           env.topicColl.insert(topic withPost post) >>

--- a/modules/qa/src/main/DataForm.scala
+++ b/modules/qa/src/main/DataForm.scala
@@ -35,7 +35,8 @@ private[qa] final class DataForm(
       "body" -> nonEmptyText(minLength = 30)
         .verifying(languageMessage, validateLanguage _),
       "gameId" -> text,
-      "move" -> text
+      "move" -> text,
+      "modIcon" -> optional(boolean)
     )(AnswerData.apply)(AnswerData.unapply)
       .verifying(captchaFailMessage, validateCaptcha _)
   )
@@ -82,7 +83,8 @@ private[qa] case class QuestionData(
 private[qa] case class AnswerData(
   body: String,
   gameId: String,
-  move: String
+  move: String,
+  modIcon: Option[Boolean]
 )
 
 private[qa] case class CommentData(body: String)

--- a/modules/qa/src/main/QaApi.scala
+++ b/modules/qa/src/main/QaApi.scala
@@ -162,7 +162,7 @@ final class QaApi(
     private implicit val voteBSONHandler = Macros.handler[Vote]
     private implicit val answerBSONHandler = Macros.handler[Answer]
 
-    def create(data: AnswerData, q: Question, user: User)(implicit ctx: UserContext): Fu[Answer] =
+    def create(data: AnswerData, q: Question, user: User): Fu[Answer] =
       lila.db.Util findNextId answerColl flatMap { id =>
         val a = Answer(
           _id = id,
@@ -174,7 +174,7 @@ final class QaApi(
           acceptedAt = None,
           createdAt = DateTime.now,
           editedAt = None,
-          modIcon = (data.modIcon.getOrElse(false) && ctx.me.map(Granter(_.PublicMod)).getOrElse(false)).fold(Some(true), None)
+          modIcon = (~data.modIcon && Granter.apply(_.PublicMod)(user)).option(true)
         )
 
         (answerColl insert a) >>

--- a/modules/qa/src/main/model.scala
+++ b/modules/qa/src/main/model.scala
@@ -46,7 +46,8 @@ case class Answer(
     comments: List[Comment],
     acceptedAt: Option[DateTime],
     createdAt: DateTime,
-    editedAt: Option[DateTime]
+    editedAt: Option[DateTime],
+    modIcon: Option[Boolean]
 ) {
 
   def id = _id
@@ -60,6 +61,8 @@ case class Answer(
   def editNow = copy(editedAt = Some(DateTime.now))
 
   def userIds = userId :: comments.map(_.userId)
+
+  def displayModIcon = ~modIcon
 }
 
 case class AnswerWithQuestion(answer: Answer, question: Question)

--- a/public/stylesheets/common.css
+++ b/public/stylesheets/common.css
@@ -127,6 +127,9 @@ time {
 .user_link .line.patron::before {
   content: '';
 }
+.user_link .line.moderator::before {
+  content: '';
+}
 
 body.blind_mode .is::before,
 body.blind_mode .is::after,


### PR DESCRIPTION
Closes #754. Closes #1092. Partial #931.

This is possible for forum posts (also the first post of a topic) and Q&A
answers (not questions, because that doesn't seem useful at all).

Above the 'Submit' button, there is a checkbox to tell if you want to
display a moderator icon next to your name.

If a non-PublicMod tries to add this checkbox himself, the `modIcon`
Option[Boolean] is still set to None and no icon will appear.