### PR TITLE
[RFC] avoid global translations using trans_me

### DIFF
--- a/app/views/tournament/enterableTable.scala.html
+++ b/app/views/tournament/enterableTable.scala.html
@@ -11,12 +11,9 @@
   @tour.schedule.map { s =>
   <td>@momentFromNowNoCtx(s.at)</td>
   }.getOrElse {
-  <td class="small">
+  <td class="small@if(tour.mode.rated) { rated}">
     <span class="text" data-icon="p">@tour.clock.show</span>
     @if(tour.variant.exotic) { @tour.variant.shortName }
-    @if(tour.mode.rated) {
-    <span class="trans_me">@trans.rated.literalTxtTo(lila.i18n.enLang)</span>
-    }
   </td>
   }
   <td>@tour.durationString</td>

--- a/public/stylesheets/home.css
+++ b/public/stylesheets/home.css
@@ -548,6 +548,9 @@ div.blog.undertable time {
 #lichess .enterable_list td:last-child {
   width: 20px;
 }
+#lichess .enterable_list .rated {
+  color: #d59120;
+}
 div.new_posts li {
   margin: 0.6em 0;
   padding-left: 9px;

--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -529,16 +529,6 @@ lichess.topMenuIntent = function() {
         });
       })();
 
-      function translateTexts() {
-        $('.trans_me').each(function() {
-          var t = $(this).removeClass('trans_me');
-          if (t.val()) t.val(lichess.globalTrans(t.val()));
-          else t.text(lichess.globalTrans(t.text()));
-        });
-      }
-      translateTexts();
-      lichess.pubsub.on('content_loaded', translateTexts);
-
       $('input.user-autocomplete').each(function() {
         var opts = {
           focus: 1,


### PR DESCRIPTION
A step towards #3218. Idea: Use color to encode tournament ratedness (which seems to be the only usage of the `trans_me` hack).

![image](https://user-images.githubusercontent.com/402777/28171285-31c64d68-67e8-11e7-8279-e6e4e313fccd.png)
