### PR TITLE
Remove 'negro' from shutup dictionary

### DIFF
--- a/modules/shutup/src/main/Dictionary.scala
+++ b/modules/shutup/src/main/Dictionary.scala
@@ -93,7 +93,6 @@ motherfuc?k(er|)
 mthrfckr
 muff
 nazi
-negro
 nigg?(er|a|ah)
 nonce
 nutsac?k


### PR DESCRIPTION
"negro" is Spanish for "black", causing at least one false positive I've seen appear a few times in the report queue, in the context of black pieces.

I don't remember seeing a true positive for this keyword, so we can consider removing it.