### PR TITLE
Restore AI lag comp

### DIFF
--- a/modules/round/src/main/Player.scala
+++ b/modules/round/src/main/Player.scala
@@ -74,7 +74,7 @@ private[round] final class Player(
     else fuccess(round ! actorApi.round.ResignAi)
   }
 
-  private val fishnetLag = MoveMetrics()
+  private val fishnetLag = MoveMetrics(clientLag = Centis(5).some)
 
   private def applyUci(game: Game, uci: Uci, blur: Boolean, metrics: MoveMetrics): Valid[MoveResult] =
     (uci match {


### PR DESCRIPTION
During lag comp rewrite the AI lost its hard coded lag
adjustment, making it easier to flag. Give it back some
lag comp, hard coded to .05s per move.