### PR TITLE
Improve ceval emit throttling

### DIFF
--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -69,7 +69,7 @@ export default function(opts: CevalOpts): CevalController {
     };
   })();
 
-  const onEmit = throttle(800, false, (ev: Tree.ClientEval, work: Work) => {
+  const onEmit = throttle(500, false, (ev: Tree.ClientEval, work: Work) => {
     sortPvsInPlace(ev.pvs, (work.ply % 2 === (work.threatMode ? 1 : 0)) ? 'white' : 'black');
     npsRecorder(ev);
     curEval = ev;

--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -69,12 +69,17 @@ export default function(opts: CevalOpts): CevalController {
     };
   })();
 
+  let lastEmitFen: string | null = null;
+
   const onEmit = throttle(500, false, (ev: Tree.ClientEval, work: Work) => {
     sortPvsInPlace(ev.pvs, (work.ply % 2 === (work.threatMode ? 1 : 0)) ? 'white' : 'black');
     npsRecorder(ev);
     curEval = ev;
     opts.emit(ev, work);
-    if (ev.millis > 1000 && ev.millis < 5000) window.lichess.storage.set('ceval.fen', ev.fen);
+    if (ev.fen !== lastEmitFen) {
+      lastEmitFen = ev.fen;
+      window.lichess.storage.set('ceval.fen', ev.fen);
+    }
   });
 
   const effectiveMaxDepth = function(): number {

--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -69,19 +69,13 @@ export default function(opts: CevalOpts): CevalController {
     };
   })();
 
-  const throttledEmit = throttle(150, false, opts.emit);
-
-  const onEmit = function(ev: Tree.ClientEval, work: Work) {
+  const onEmit = throttle(800, false, (ev: Tree.ClientEval, work: Work) => {
     sortPvsInPlace(ev.pvs, (work.ply % 2 === (work.threatMode ? 1 : 0)) ? 'white' : 'black');
     npsRecorder(ev);
     curEval = ev;
-    throttledEmit(ev, work);
-    publish(ev);
-  };
-
-  const publish = function(ev: Tree.ClientEval) {
-    if (ev.depth === 12) window.lichess.storage.set('ceval.fen', ev.fen);
-  };
+    opts.emit(ev, work);
+    if (ev.millis > 1000 && ev.millis < 5000) window.lichess.storage.set('ceval.fen', ev.fen);
+  });
 
   const effectiveMaxDepth = function(): number {
     return (isDeeper() || infinite()) ? 99 : parseInt(maxDepth());

--- a/ui/site/src/util.js
+++ b/ui/site/src/util.js
@@ -5,12 +5,15 @@ lichess.engineName = 'Stockfish 8';
 lichess.raf = (window.requestAnimationFrame || window.setTimeout).bind(window);
 lichess.requestIdleCallback = (window.requestIdleCallback || window.setTimeout).bind(window);
 lichess.storage = (function() {
-  var withStorage = function(f) {
-    // can throw an exception when storage is full
-    try {
-      if (window.localStorage !== undefined) return f(window.localStorage);
-    } catch (e) {}
-  }
+  try {
+    // just accessing localStorage can throw an exception...
+    var storage = window.localStorage;
+  } catch (e) {}
+  var withStorage = storage ? function(f) {
+    // this can throw exceptions as well.
+    try { return f(storage); }
+    catch (e) {}
+  } : function() {};
   return {
     get: function(k) {
       return withStorage(function(s) {

--- a/ui/site/src/util.js
+++ b/ui/site/src/util.js
@@ -8,7 +8,7 @@ lichess.storage = (function() {
   var withStorage = function(f) {
     // can throw an exception when storage is full
     try {
-      return !!window.localStorage ? f(window.localStorage) : null;
+      if (window.localStorage !== undefined) return f(window.localStorage);
     } catch (e) {}
   }
   return {
@@ -18,10 +18,14 @@ lichess.storage = (function() {
       });
     },
     set: function(k, v) {
-      // removing first may help http://stackoverflow.com/questions/2603682/is-anyone-else-receiving-a-quota-exceeded-err-on-their-ipad-when-accessing-local
       withStorage(function(s) {
-        s.removeItem(k);
-        s.setItem(k, v);
+        try {
+          s.setItem(k, v);
+        } catch (e) {
+          // removing first may help http://stackoverflow.com/questions/2603682/is-anyone-else-receiving-a-quota-exceeded-err-on-their-ipad-when-accessing-local
+          s.removeItem(k);
+          s.setItem(k, v);
+        }
       });
     },
     remove: function(k) {
@@ -42,7 +46,7 @@ lichess.storage = (function() {
         },
         listen: function(f) {
           window.addEventListener('storage', function(e) {
-            if (e.key === k && e.newValue !== null) f(e);
+            if (e.key === k && e.newValue !== null && e.newValue !== e.oldValue) f(e);
           });
         }
       };

--- a/ui/site/src/util.js
+++ b/ui/site/src/util.js
@@ -49,7 +49,7 @@ lichess.storage = (function() {
         },
         listen: function(f) {
           window.addEventListener('storage', function(e) {
-            if (e.key === k && e.newValue !== null && e.newValue !== e.oldValue) f(e);
+            if (e.key === k && e.newValue !== null) f(e);
           });
         }
       };


### PR DESCRIPTION
Reduce processing and arrow draw rate to 500ms, using leading edge throttling.

This throttling reduces redraw during piece animation (when navigating analyze with arrows, for example), and ensures evals stay visible for at least 500ms to make the display feel more solid.