### PR TITLE
Add Monaco to countries list

### DIFF
--- a/modules/user/src/main/Countries.scala
+++ b/modules/user/src/main/Countries.scala
@@ -153,6 +153,7 @@ object Countries {
     C("MW", "Malawi"),
     C("MX", "Mexico"),
     C("MY", "Malaysia"),
+    C("MC", "Monaco"),
     C("MZ", "Mozambique"),
     C("NA", "Namibia"),
     C("NE", "Niger"),


### PR DESCRIPTION
Also note that Monaco's ISO 3166 two-letter code is "MC", which is included in the pull request.