### PR TITLE
Move up Daily Bullet and Superblitz 1hr

### DIFF
--- a/modules/tournament/src/main/TournamentScheduler.scala
+++ b/modules/tournament/src/main/TournamentScheduler.scala
@@ -160,8 +160,9 @@ private final class TournamentScheduler private (api: TournamentApi) extends Act
           },
 
         List( // daily tournaments!
-          at(today, 16) map { date => Schedule(Daily, Bullet, Standard, std, date |> orTomorrow) },
-          at(today, 17) map { date => Schedule(Daily, SuperBlitz, Standard, std, date |> orTomorrow) },
+          // avoid conflict with hourly hyperbullet
+          at(today, 15) map { date => Schedule(Daily, Bullet, Standard, std, date |> orTomorrow) },
+          at(today, 16) map { date => Schedule(Daily, SuperBlitz, Standard, std, date |> orTomorrow) },
           at(today, 18) map { date => Schedule(Daily, Blitz, Standard, std, date |> orTomorrow) },
           at(today, 19) map { date => Schedule(Daily, Classical, Standard, std, date |> orTomorrow) },
           at(today, 20) map { date => Schedule(Daily, HyperBullet, Standard, std, date |> orTomorrow) },


### PR DESCRIPTION
- avoid conflict of bullet with hourly hyperbullet
- avoid superblitz daily (90m) & blitz daily overlap