### PR TITLE
Make material dark theme <option>s more readable on FireFox

### DIFF
--- a/public/stylesheets/material.form.css
+++ b/public/stylesheets/material.form.css
@@ -168,6 +168,7 @@ body.dark .material.form .form-group * {
 }
 body.dark .material.form .form-group select option {
   color: #bbb;
+  background-color: #2b2b2b;
 }
 .material.form .form-group select ~ .control-label,
 .material.form .form-group input:focus ~ .control-label,

--- a/public/stylesheets/material.form.css
+++ b/public/stylesheets/material.form.css
@@ -167,7 +167,7 @@ body.dark .material.form .form-group * {
   color: #3893E8;
 }
 body.dark .material.form .form-group select option {
-  color: #333;
+  color: #bbb;
 }
 .material.form .form-group select ~ .control-label,
 .material.form .form-group input:focus ~ .control-label,


### PR DESCRIPTION
Fixes (i hope):

![screen shot 2017-08-21 at 2 39 08 pm](https://user-images.githubusercontent.com/24863887/29531585-8ef5c2ce-867f-11e7-97df-b1c1c7400251.png)
