### PR TITLE
Fix/update simul rating display. Fixes #3185

### DIFF
--- a/modules/simul/src/main/SimulPlayer.scala
+++ b/modules/simul/src/main/SimulPlayer.scala
@@ -1,6 +1,7 @@
 package lila.simul
 
 import chess.variant.Variant
+import lila.rating.Perf
 import lila.user.{ User, Perfs }
 
 private[simul] case class SimulPlayer(
@@ -16,16 +17,7 @@ private[simul] case class SimulPlayer(
 
 private[simul] object SimulPlayer {
 
-  private[simul] def make(user: User, variant: Variant): SimulPlayer = {
-
-    val perf =
-      if (variant == chess.variant.Standard) {
-        if (user.perfs.classical.nb >= 20 ||
-          user.perfs.classical.nb > user.perfs.blitz.nb)
-          user.perfs.classical
-        else user.perfs.blitz
-      } else Perfs.variantLens(variant).fold(user.perfs.standard)(_(user.perfs))
-
+  private[simul] def make(user: User, variant: Variant, perf: Perf): SimulPlayer = {
     new SimulPlayer(
       user = user.id,
       variant = variant,


### PR DESCRIPTION
In simuls, the displayed ratings for blitz or classical controls can be inaccurate. [For example](https://lichess.org/simul/f6MLFfr7) the game widgets show classical ratings (which are often 100-200 points higher than blitz ratings), even though it is a blitz simul. In the candidates list, it [displays blitz fire icons](https://youtu.be/aNdwh1FbHw0?t=6474) instead of the classical hourglass icons.

So in blitz simuls, classical ratings are displayed, and also in some instances blitz ratings are shown in classical simuls. I think both of these cases can be misleading/confusing to the host and players, so I attempted a code fix to separate blitz and classical cases from each other.

Apologize ahead of time for inexperience with lila and scala, but very happy to contribute to this amazing project :)