### PR TITLE
Send lag est in some circumstances

### DIFF
--- a/ui/round/src/clock/clockCtrl.ts
+++ b/ui/round/src/clock/clockCtrl.ts
@@ -147,4 +147,6 @@ export class ClockController {
      Math.max(0, this.times[color] - this.elapsed()) :
      this.times[color]
   );
+
+  isRunning = () => this.times.activeColor !== undefined;
 }

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -229,6 +229,7 @@ export default class RoundController {
       ackable: true
     };
     if (this.clock) {
+      socketOpts.withLag = !this.shouldSendMoveTime || !this.clock.isRunning;
       const moveMillis = this.clock.stopClock();
       if (this.shouldSendMoveTime) {
         if (meta.premove) socketOpts.millis = 0;

--- a/ui/round/src/interfaces.ts
+++ b/ui/round/src/interfaces.ts
@@ -17,6 +17,7 @@ export interface Untyped {
 
 export interface SocketOpts {
   ackable: boolean;
+  withLag?: boolean;
   millis?: number;
 }
 

--- a/ui/site/src/socket.js
+++ b/ui/site/src/socket.js
@@ -68,6 +68,7 @@ lichess.StrongSocket = function(url, version, settings) {
     o = o || {};
     var msg = { t: t };
     if (d !== undefined) {
+      if (o.withLag) d.l = Math.round(averageLag);
       if (o.millis >= 0) d.s = Math.round(o.millis * 0.1).toString(36);
       msg.d = d;
     }


### PR DESCRIPTION
Send lag when clock is not running to
improve lag estimates for move 1.

Send lag position when move timer isn't
trusted to still given user a bit of comp.