### PR TITLE
Better fix for ceval multitab toggle

### DIFF
--- a/ui/ceval/src/pool.ts
+++ b/ui/ceval/src/pool.ts
@@ -163,7 +163,7 @@ export default class Pool {
   }
 
   start(work: Work) {
-    window.lichess.storage.set('ceval.pool.start', '1');
+    window.lichess.storage.set('ceval.pool.start', Date.now().toString());
     this.getWorker().then(function(worker) {
       worker.start(work);
     });

--- a/ui/site/src/util.js
+++ b/ui/site/src/util.js
@@ -22,9 +22,13 @@ lichess.storage = (function() {
     },
     set: function(k, v) {
       withStorage(function(s) {
-        // must remove first, or else listeners won't be triggered if old == new
-        s.removeItem(k);
-        s.setItem(k, v);
+        try {
+          s.setItem(k, v);
+        } catch (e) {
+          // removing first may help http://stackoverflow.com/questions/2603682/is-anyone-else-receiving-a-quota-exceeded-err-on-their-ipad-when-accessing-local
+          s.removeItem(k);
+          s.setItem(k, v);
+        }
       });
     },
     remove: function(k) {


### PR DESCRIPTION
Keep the storage perf fix, use a new value to ensure
listener gets triggered. The only other listener is
for ceval.fen and the same fen getting published twice
is unlikely to occur and might be a false flag anyway,
so the behavior of only triggering listener when value
changes is acceptable.