### PR TITLE
Improve text wrapping of team description in team search

### DIFF
--- a/public/stylesheets/team.css
+++ b/public/stylesheets/team.css
@@ -43,7 +43,8 @@
 #team table.slist td {
   padding-top: 1em;
   padding-bottom: 1em;
-  word-break: break-all;
+  overflow-wrap: break-word;
+  max-width: 674px;
 }
 #team table.slist a.team-name {
   font-size: 1.3em;


### PR DESCRIPTION
Works in my Chrome 60.0 browser.  Hat tip: [Stack Overflow](https://stackoverflow.com/a/7410812).