### PR TITLE
simplify csrf handler

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -255,7 +255,6 @@ security {
   mailgun = ${mailgun}
   net.domain = ${net.domain}
   net.base_url = ${net.base_url}
-  csrf.enabled = true
 }
 recaptcha {
   endpoint = "https://www.google.com/recaptcha/api/siteverify"

--- a/modules/security/src/main/Env.scala
+++ b/modules/security/src/main/Env.scala
@@ -42,7 +42,6 @@ final class Env(
     val RecaptchaEndpoint = config getString "recaptcha.endpoint"
     val RecaptchaEnabled = config getBoolean "recaptcha.enabled"
     val NetDomain = config getString "net.domain"
-    val CsrfEnabled = config getBoolean "csrf.enabled"
   }
   import settings._
 
@@ -132,7 +131,7 @@ final class Env(
 
   lazy val api = new SecurityApi(storeColl, firewall, geoIP, emailAddressValidator)
 
-  lazy val csrfRequestHandler = new CSRFRequestHandler(NetDomain, enabled = CsrfEnabled)
+  lazy val csrfRequestHandler = new CSRFRequestHandler(NetDomain)
 
   def cli = new Cli
 


### PR DESCRIPTION
Reviewing the CSRF handler after months and months of monitoring:

* There should be no need to disable CSRF protection *ever*.
* `isXhr` beeing safe gave me a break for a moment until I remembered the reason. Put a comment.
* Referer to Origin conversion is somewhat tricky and the regex has a performance problem due to backtracking found by @isaacl. It turns out we can just drop it anyway.

Once this is deployed and we got some more monitoring data, we can potentially flip the decision on missing Origin headers to a safer default.