### PR TITLE
Fix inaccurate "user(s) on these IPs"

### DIFF
--- a/app/views/user/mod.scala.html
+++ b/app/views/user/mod.scala.html
@@ -265,7 +265,7 @@
   <table class="others slist">
     <thead>
       <tr>
-        <th>@spy.otherUsers.size user(s) on these IPs</th>
+        <th>@spy.otherUsers.size similar user(s)</th>
         <th>Same</th>
         <th data-sort-method="number">Games</th>
         <th>Status</th>


### PR DESCRIPTION
Because it's both IP and Print. Putting both in there would make it a bit long though, so "similar user(s)" is shorter but accurate