### PR TITLE
Adjust playban cutoffs

### DIFF
--- a/modules/playban/src/main/PlaybanApi.scala
+++ b/modules/playban/src/main/PlaybanApi.scala
@@ -52,7 +52,7 @@ final class PlaybanApi(
   def flag(game: Game, flaggerColor: Color): Funit = {
 
     def unreasonableTime = game.clock map { c =>
-      (c.estimateTotalSeconds / 8) atLeast 15 atMost (3 * 60)
+      (c.estimateTotalSeconds / 12) atLeast 15 atMost (3 * 60)
     }
 
     // flagged after waiting a long time
@@ -142,7 +142,7 @@ final class PlaybanApi(
       update = $doc("$push" -> $doc(
         "o" -> $doc(
           "$each" -> List(outcome),
-          "$slice" -> -20
+          "$slice" -> -30
         )
       )),
       fetchNewObject = true,


### PR DESCRIPTION
- save 30 outcomes instead of 20
- for players with long history, trigger with 12 bad outcomes
  out of 30, instead of 10 bad outcomes in 20.
- reduce sitting cutoff to 5s per minute of initial clock.
- reduce initial playban to 10 min