### PR TITLE
Make links in notes more visible 

### DIFF
--- a/public/stylesheets/user-show.css
+++ b/public/stylesheets/user-show.css
@@ -372,6 +372,9 @@ div.sub_ratings h3 {
 .user_show .note_zone p.text {
   min-height: 2.7em;
 }
+.user_show .note_zone p.text a {
+  color: #3893E8;
+}
 .user_show div.content_box_inter.tabs {
   margin-left: -8px;
   padding-left: 30px;


### PR DESCRIPTION
`#3893E8` is the same link color used on the /mobile page. Closes #3768 