### PR TITLE
Fixed a typo in russian translation

### DIFF
--- a/translation/dest/site/ru-RU.xml
+++ b/translation/dest/site/ru-RU.xml
@@ -336,7 +336,7 @@
   <string name="settings">Настройки</string>
   <string name="filterGames">Фильтр партий</string>
   <string name="reset">Сбросить</string>
-  <string name="apply">Соранить</string>
+  <string name="apply">Сохранить</string>
   <string name="leaderboard">Таблица лидеров</string>
   <string name="pasteTheFenStringHere">Вставьте строку в формате FEN</string>
   <string name="pasteThePgnStringHere">Вставьте строку в формате PGN</string>


### PR DESCRIPTION
The word "сохранить" missed a letter.