### PR TITLE
Ignore provisional ratings when displaying team's 'Best players'

### DIFF
--- a/app/mashup/TeamInfo.scala
+++ b/app/mashup/TeamInfo.scala
@@ -34,7 +34,7 @@ final class TeamInfoApi(
 
   private def fetchCachable(id: String): Fu[Cachable] = for {
     userIds ← (MemberRepo userIdsByTeam id)
-    bestUserIds ← UserRepo.idsByIdsSortRating(userIds, 10)
+    bestUserIds ← UserRepo.ratedIdsByIdsSortRating(userIds, 10)
     toints ← UserRepo.idsSumToints(userIds)
   } yield Cachable(bestUserIds, toints)
 

--- a/app/views/team/showContent.scala.html
+++ b/app/views/team/showContent.scala.html
@@ -5,12 +5,14 @@
     <p>@trans.tournamentPoints(): <strong>@info.toints.localize</strong></p>
     <p>@trans.teamLeader(): @userIdLink(t.createdBy.some)</p>
   </section>
-  <h2>@trans.teamBestPlayers()</h2>
-  <ol class="userlist best_players">
+  @if(!info.bestUserIds.isEmpty) {
+    <h2>@trans.teamBestPlayers()</h2>
+    <ol class="userlist best_players">
     @info.bestUserIds.map { userId =>
-    <li>@userIdLink(userId.some)</li>
+      <li>@userIdLink(userId.some)</li>
     }
-  </ol>
+    </ol>
+  }
   <h2>@trans.teamRecentMembers()</h2>
   <div class="userlist infinitescroll">
     @members.nextPage.map { np =>

--- a/modules/user/src/main/UserRepo.scala
+++ b/modules/user/src/main/UserRepo.scala
@@ -95,7 +95,7 @@ object UserRepo {
   // expensive, send to secondary
   def ratedIdsByIdsSortRating(ids: Iterable[ID], nb: Int): Fu[List[User.ID]] =
     coll.find(
-      $inIds(ids) ++ goodLadSelectBson ++ $doc("perfs.standard" $exists true),
+      $inIds(ids) ++ goodLadSelectBson ++ stablePerfSelect("standard"),
       $id(true)
     )
       .sort($sort desc "perfs.standard.gl.r")

--- a/modules/user/src/main/UserRepo.scala
+++ b/modules/user/src/main/UserRepo.scala
@@ -93,12 +93,12 @@ object UserRepo {
       .list[User](nb, ReadPreference.secondaryPreferred)
 
   // expensive, send to secondary
-  def idsByIdsSortRating(ids: Iterable[ID], nb: Int): Fu[List[User.ID]] =
+  def ratedIdsByIdsSortRating(ids: Iterable[ID], nb: Int): Fu[List[User.ID]] =
     coll.find(
-      $inIds(ids) ++ goodLadSelectBson,
+      $inIds(ids) ++ goodLadSelectBson ++ $doc("perfs.standard" $exists true),
       $id(true)
     )
-      .sort($doc(s"perfs.standard.gl.r" -> -1))
+      .sort($sort desc "perfs.standard.gl.r")
       .list[Bdoc](nb, ReadPreference.secondaryPreferred).map {
         _.flatMap { _.getAs[User.ID]("_id") }
       }


### PR DESCRIPTION
Naive attempt to exclude users without `standard` perfs recorded from team's `Best players` section.

I'm not yet familiar with the codebase and not sure if this would be enough or more checks are needed. Like checking `Perf.latest` not to be older than some threshold or doing something similar to https://github.com/ornicar/lila/blob/master/modules/rating/src/main/Glicko.scala#L21

Please ping me if extra changes are needed here.

Refs #721