### PR TITLE
Filter lame players (whose ratings are provisional) from rated TV #3818

### DIFF
--- a/modules/game/src/main/Game.scala
+++ b/modules/game/src/main/Game.scala
@@ -415,6 +415,8 @@ case class Game(
   def rated = mode.rated
   def casual = !rated
 
+  def hasProvisional: Boolean = players.exists(_.provisional)
+
   def finished = status >= Status.Mate
 
   def finishedOrAborted = finished || aborted

--- a/modules/tv/src/main/Tv.scala
+++ b/modules/tv/src/main/Tv.scala
@@ -142,7 +142,7 @@ object Tv {
     val byKey = all.map { c => c.key -> c }.toMap
   }
 
-  private def rated = (g: Game) => g.rated
+  private def rated = (g: Game) => g.rated && !g.hasProvisional
   private def speed(speed: chess.Speed) = (g: Game) => g.speed == speed
   private def variant(variant: chess.variant.Variant) = (g: Game) => g.variant == variant
   private val standard = variant(V.Standard)


### PR DESCRIPTION
This PR has the very unfortunate side effect that only non-provisional players will be featured (a non-provisional player defeating a newbie won't be featured; or a titled provisional player won't be featured).

Since Game and Player do not have visibility to whether a user is lame, filter provisional players and trust that lame players get their ratings reset.  Feel free to edit this PR to filter lame players instead of provisional players.