### PR TITLE
Updated Twitch domain to match new format.

### DIFF
--- a/modules/user/src/main/Links.scala
+++ b/modules/user/src/main/Links.scala
@@ -30,7 +30,7 @@ object Link {
     case object Twitter extends Site("Twitter", List("twitter.com"))
     case object Facebook extends Site("Facebook", List("facebook.com"))
     case object YouTube extends Site("YouTube", List("youtube.com"))
-    case object Twitch extends Site("Twitch", List("twitch.com"))
+    case object Twitch extends Site("Twitch", List("twitch.tv"))
     case object Github extends Site("Github", List("github.com"))
     case object VKontakte extends Site("VKontakte", List("vk.com"))
     case object ChessCom extends Site("Chess.com", List("chess.com"))


### PR DESCRIPTION
It seems like Twitch has made a full transition from twitch.com to twitch.tv so as a user, if I type http://www.twitch.com/chessbrah into my browser the end URL I copy and paste in would be https://www.twitch.tv/chessbrah since they automatically redirect users and their browser URL bar changes.

My reasoning is one of user experience, I'd suspect most people are just copying and pasting their URL right in, so using the correct ultimate domain seems to make the most sense, otherwise when I paste https://www.twitch.tv/chessbrah into lichess currently, it ends up rendering "www.twitch.tv" on my profile which is ugly compared to the expected "Twitch" output.

Please consider this pull request if this is the appropriate way to contribute.