### PR TITLE
Remove outline:0 to go back to default browser behavior

### DIFF
--- a/public/stylesheets/common.css
+++ b/public/stylesheets/common.css
@@ -1065,7 +1065,6 @@ group.radio label:hover {
 a.button:active {
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12) inset;
 }
-.button:focus {outline:0;}
 
 /* active gradient */
 


### PR DESCRIPTION
This fix re-introduces outlines for all button-classes. This is extremely important for accessibility. 