### PR TITLE
scale board in steps of 8px

### DIFF
--- a/ui/dasher/src/board.ts
+++ b/ui/dasher/src/board.ts
@@ -78,7 +78,7 @@ function makeSlider(ctrl: BoardCtrl, el: HTMLElement) {
       min: 100,
       max: 200,
       range: 'min',
-      step: 1,
+      step: 8 / 512 * 100,
       value: ctrl.data.zoom,
       slide: (_: any, ui: any) => ctrl.setZoom(ui.value)
     });


### PR DESCRIPTION
Make the zoom slider go in steps of 8px (1.5625%) instead of 5.12px (1%). This makes highlighted squares on the board pixel perfect *if there is no browser zoom*.

If we chose to apply this we would potentially revert it once we've got a subpixel perfect solution or another solution that works with browser zoom.

See also: https://github.com/ornicar/chessground/issues/51

cc @isaacl 