### PR TITLE
optimize escapeHtml

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -18,7 +18,7 @@ interface Lichess {
   loadCss(path: string): void
   unloadCss(path: string): void
   loadedCss: [string];
-  escapeHtml(html: string): string
+  escapeHtml(str: string): string
   toYouTubeEmbedUrl(url: string): string
   fp: {
     debounce(func: (...args: any[]) => void, wait: number, immediate?: boolean): (...args: any[]) => void;

--- a/ui/chat/src/enhance.ts
+++ b/ui/chat/src/enhance.ts
@@ -1,5 +1,5 @@
 export default function(text: string, parseMoves: boolean): string {
-  const escaped = escapeHtml(text);
+  const escaped = window.lichess.escapeHtml(text);
   const linked = autoLink(escaped);
   const plied = parseMoves && linked === escaped ? addPlies(linked) : linked;
   return plied;
@@ -22,15 +22,6 @@ function userLinkReplace(orig: string, prefix: String, user: string) {
 
 function autoLink(html: string) {
   return html.replace(linkPattern, linkReplace).replace(userPattern, userLinkReplace);
-}
-
-function escapeHtml(html: string) {
-  return html
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
 }
 
 const movePattern = /\b(\d+)\s?(\.+)\s?(?:[o0-]+|[NBRQK]*[a-h]?[1-8]?x?@?[a-h][0-9]=?[NBRQK]?)\+?\#?[!\?=]*/gi;

--- a/ui/learn/src/util.js
+++ b/ui/learn/src/util.js
@@ -51,20 +51,7 @@ module.exports = {
     );
   },
   withLinebreaks: function(text) {
-    return m.trust(text.replace(/['"<>&]/g, function(s) {
-      switch (s) {
-        case "'":
-          return "&#039;";
-        case "\"":
-          return "&quot;";
-        case "<":
-          return "&lt;";
-        case ">":
-          return "&gt;";
-        case "&":
-          return "&amp;";
-      }
-    }).replace(/\n/g, '<br>'));
+    return m.trust(lichess.escapeHtml(text).replace(/\n/g, '<br>'));
   },
   decomposeUci: function(uci) {
     return [uci.slice(0, 2), uci.slice(2, 4), uci.slice(4, 5)];

--- a/ui/site/src/util.js
+++ b/ui/site/src/util.js
@@ -366,10 +366,15 @@ lichess.reload = function() {
   if (window.location.hash) location.reload();
   else location.href = location.href;
 };
-lichess.escapeHtml = function(html) {
-  var div = document.createElement('div');
-  div.appendChild(document.createTextNode(html));
-  return div.innerHTML;
+lichess.escapeHtml = function(str) {
+  return /[&<>\"\']/.test(str) ?
+    str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/'/g, '&#39;')
+      .replace(/"/g, '&quot;') :
+    str;
 };
 lichess.toYouTubeEmbedUrl = function(url) {
   if (!url) return;


### PR DESCRIPTION
https://jsperf.com/html-escaping
https://jsperf.com/html-escaping-2
https://jsperf.com/optimistic-html-escaping

- Remove duplicate escapeHtml implementations.
- Using the VDOM to escape is ~4x slower than chained regex
  replacements.
- An optimistic check is very cheap even on long strings.