### PR TITLE
Apply rating floor after Glicko calculation

### DIFF
--- a/modules/rating/src/main/Glicko.scala
+++ b/modules/rating/src/main/Glicko.scala
@@ -33,7 +33,10 @@ case class Glicko(
       volatility > 0 &&
       volatility < (Glicko.maxVolatility * 2)
 
-  def cap = copy(volatility = volatility min Glicko.maxVolatility)
+  def cap = copy(
+    rating = rating atLeast Glicko.minRating,
+    volatility = volatility atMost Glicko.maxVolatility
+  )
 
   override def toString = s"$intRating $intDeviation"
 }


### PR DESCRIPTION
Before this change, the floor is only applied [before](https://github.com/ornicar/lila/blob/9c17d8702baa0fc6a049c6633322418ecd7de8d2/modules/rating/src/main/Perf.scala#L54) the rating adjustment, which means your rating can still end up <800 if you lose. This leads to weird inconsistencies like #1574