### PR TITLE
Allow fingerprint hash searches in mod search

### DIFF
--- a/app/views/user/mod.scala.html
+++ b/app/views/user/mod.scala.html
@@ -335,6 +335,14 @@
         <li>@ua</li>
         }</ul>
     </div>
+    <div class="spy_fps">
+      <strong>@spy.prints.size Fingerprint(s)</strong> <ul>@spy.prints.sorted.map { fp =>
+        <li>
+          <a href="@{routes.Mod.search}?q=@{java.net.URLEncoder.encode(fp, "US-ASCII")}">@fp</a>
+        </li>
+        }
+      </ul>
+    </div>
   </div>
 </div>
 

--- a/modules/mod/src/main/UserSearch.scala
+++ b/modules/mod/src/main/UserSearch.scala
@@ -12,10 +12,14 @@ final class UserSearch(
     if (query.isEmpty) fuccess(Nil)
     else EmailAddress.from(query).map(searchEmail) orElse
       IpAddress.from(query).map(searchIp) getOrElse
-      searchUsername(query)
+      (searchUsername(query) zip searchFingerHash(query) map Function.tupled(_ ++ _)) // list concatenation, in case a fingerhash is also someone's username
 
   private def searchIp(ip: IpAddress) =
     securityApi recentUserIdsByIp ip map (_.reverse) flatMap UserRepo.usersFromSecondary
+
+  private def searchFingerHash(fh: String) =
+    if (fh.length() == 8) securityApi recentUserIdsByFingerHash lila.security.FingerHash(fh) map (_.reverse) flatMap UserRepo.usersFromSecondary
+    else fuccess(List[User]())
 
   private def searchUsername(username: String) = UserRepo named username map (_.toList)
 

--- a/modules/security/src/main/UserSpy.scala
+++ b/modules/security/src/main/UserSpy.scala
@@ -9,6 +9,7 @@ import lila.user.{ User, UserRepo }
 case class UserSpy(
     ips: List[UserSpy.IPData],
     uas: List[String],
+    prints: List[String],
     usersSharingIp: Set[User],
     usersSharingFingerprint: Set[User]
 ) {
@@ -41,6 +42,7 @@ private[security] final class UserSpyApi(firewall: Firewall, geoIP: GeoIP, coll:
   def apply(user: User): Fu[UserSpy] = for {
     infos ← Store.findInfoByUser(user.id)
     ips = infos.map(_.ip).distinct
+    prints = infos.map(_.fp).flatten.distinct
     blockedIps = ips map firewall.blocksIp
     locations = ips map geoIP.orUnknown
     sharingIp ← exploreSimilar("ip")(user)(coll)
@@ -50,6 +52,7 @@ private[security] final class UserSpyApi(firewall: Firewall, geoIP: GeoIP, coll:
       case ((ip, blocked), location) => IPData(ip, blocked, location)
     },
     uas = infos.map(_.ua).distinct,
+    prints = prints,
     usersSharingIp = sharingIp,
     usersSharingFingerprint = sharingFingerprint
   )

--- a/public/stylesheets/user-mod.css
+++ b/public/stylesheets/user-mod.css
@@ -74,6 +74,12 @@ body.dark .mod_zone .slist {
 .mod_zone .spy_uas {
   margin-left: 34%;
 }
+.mod_zone .spy_fps {
+  margin-left: 34%;
+}
+.mod_zone .spy_fps li {
+  font-family: monospace;
+}
 .mod_zone .listings .blocked {
   color: red;
   font-weight: bold;


### PR DESCRIPTION
... and add a list of someone's fingerhashes to the mod zone (under User agents).

Purpose: in a long list of Print matches, this will be helpful to decide which prints are unique (and thus more helpful) and which prints are less unique (and thus less useful). This could already be done with IPs, and with this PR, it can also be done with prints.