### PR TITLE
fixed submit on return key pressed (players page)

### DIFF
--- a/app/views/user/list.scala.html
+++ b/app/views/user/list.scala.html
@@ -28,6 +28,12 @@
 </div>
 }
 
+@moreJs = {
+  @embedJs {
+    $('.user-autocomplete').data('onselect', function (q) { window.location = '/@@/' + q })
+  }
+}
+
 @side = {
 <div class="side">
   <form class="search public">
@@ -55,6 +61,7 @@
 @user.layout(
 trans.players.txt(),
 side = side.some,
+evenMoreJs = moreJs,
 openGraph = lila.app.ui.OpenGraph(
 title = "Chess players and leaderboards",
 url = s"$netBaseUrl${routes.User.list.url}",

--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -461,9 +461,7 @@ lichess.topMenuIntent = function() {
           focus: 1,
           friend: $(this).data('friend'),
           tag: $(this).data('tag'),
-          onSelect: function(q) {
-            location.href = '/@/' + q
-          }
+          onSelect: eval($(this).data('onselect'))
         };
         if ($(this).attr('autofocus')) lichess.userAutocomplete($(this), opts);
         else $(this).one('focus', function() {

--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -460,7 +460,10 @@ lichess.topMenuIntent = function() {
         var opts = {
           focus: 1,
           friend: $(this).data('friend'),
-          tag: $(this).data('tag')
+          tag: $(this).data('tag'),
+          onSelect: function(q) {
+            location.href = '/@/' + q
+          }
         };
         if ($(this).attr('autofocus')) lichess.userAutocomplete($(this), opts);
         else $(this).one('focus', function() {


### PR DESCRIPTION
return key must submit the player-search form
actually, i guess that this fix will be applied to not only the` /player` route but for every input matches the `input.user-autocomplete` selector 

corresponding issue: #4049