### PR TITLE
use move-dest:hover instead of div.over

### DIFF
--- a/public/stylesheets/board.css
+++ b/public/stylesheets/board.css
@@ -83,8 +83,8 @@ piece {
   top: 0;
   left: 0;
   background-size: cover;
-  z-index: 2;
-  /* no less than 2 */
+  z-index: 2; /* no less than 2 */
+  pointer-events: none;
 }
 .cg-512 piece {
   will-change: transform, opacity;
@@ -116,10 +116,6 @@ piece.ghost {
 piece.fading {
   z-index: 2!important;
   opacity: 0.5;
-}
-.cg-board-wrap .over {
-  will-change: transform;
-  background-color: rgba(20, 85, 30, 0.2);
 }
 .cg-board-wrap svg {
   overflow: hidden;


### PR DESCRIPTION
@isaacl was reporting dropped frames when dragging pieces. @veloce found out the whole page is beeing repainted whenever `div.over` is changed.

Optimization idea: There is already a style for `most-dest:hover`, but it does not work for dragging because the piece will be in front of the move-dest. `pointer-events: none;` makes the piece transparent to mouse events, so now `div.over` is no longer needed. I confirmed with devtools that only the affected squares are beeing repainted.