### PR TITLE
Adjust rating refund logic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -171,7 +171,7 @@ lazy val event = module("event", Seq(common, db, memo, i18n)).settings(
 )
 
 lazy val mod = module("mod", Seq(common, db, user, hub, security, tournament, simul, game, analyse, evaluation,
-  report, notifyModule, history)).settings(
+  report, notifyModule, history, perfStat)).settings(
   libraryDependencies ++= provided(play.api, play.test, reactivemongo.driver)
 )
 

--- a/modules/common/src/main/base/PimpedPrimatives.scala
+++ b/modules/common/src/main/base/PimpedPrimatives.scala
@@ -31,6 +31,8 @@ final class PimpedLong(private val self: Long) extends AnyVal {
 
   def atMost(topValue: Long): Long = min(self, topValue)
 
+  def squeeze(bottom: Long, top: Long): Long = max(min(self, top), bottom)
+
   def truncInt: Int =
     if (self.toInt == self) self.toInt
     else if (self > 0) Integer.MAX_VALUE
@@ -42,6 +44,8 @@ final class PimpedInt(private val self: Int) extends AnyVal {
   def atLeast(bottomValue: Int): Int = max(self, bottomValue)
 
   def atMost(topValue: Int): Int = min(self, topValue)
+
+  def squeeze(bottom: Int, top: Int): Int = max(min(self, top), bottom)
 }
 
 final class PimpedFloat(private val self: Float) extends AnyVal {
@@ -49,6 +53,8 @@ final class PimpedFloat(private val self: Float) extends AnyVal {
   def atLeast(bottomValue: Float): Float = max(self, bottomValue)
 
   def atMost(topValue: Float): Float = min(self, topValue)
+
+  def squeeze(bottom: Float, top: Float): Float = max(min(self, top), bottom)
 }
 
 final class PimpedDouble(private val self: Double) extends AnyVal {
@@ -56,4 +62,6 @@ final class PimpedDouble(private val self: Double) extends AnyVal {
   def atLeast(bottomValue: Double): Double = max(self, bottomValue)
 
   def atMost(topValue: Double): Double = min(self, topValue)
+
+  def squeeze(bottom: Double, top: Double): Double = max(min(self, top), bottom)
 }

--- a/modules/mod/src/main/Env.scala
+++ b/modules/mod/src/main/Env.scala
@@ -10,6 +10,7 @@ final class Env(
     config: Config,
     db: lila.db.Env,
     hub: lila.hub.Env,
+    perfStat: lila.perfStat.Env,
     system: ActorSystem,
     scheduler: lila.common.Scheduler,
     firewall: Firewall,
@@ -54,7 +55,8 @@ final class Env(
     notifier = notifier,
     historyApi = historyApi,
     rankingApi = rankingApi,
-    wasUnengined = logApi.wasUnengined
+    wasUnengined = logApi.wasUnengined,
+    perfStatter = perfStat.get _
   )
 
   lazy val publicChat = new PublicChat(chatApi, tournamentApi, simulEnv)
@@ -134,6 +136,7 @@ object Env {
     config = lila.common.PlayApp loadConfig "mod",
     db = lila.db.Env.current,
     hub = lila.hub.Env.current,
+    perfStat = lila.perfStat.Env.current,
     system = lila.common.PlayApp.system,
     scheduler = lila.common.PlayApp.scheduler,
     firewall = lila.security.Env.current.firewall,


### PR DESCRIPTION
Cap refunds to 50 above best rating, and adjust
logic when current rating is higher than rating
during unfair game.

This closes #4073.