### PR TITLE
adjust kamon ticks

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -713,7 +713,7 @@ akka {
 
 kamon {
   metric {
-    tick-interval = 2 second
+    # tick-interval = 2 second
     track-unmatched-entities = yes
     filters {
       trace {
@@ -741,7 +741,7 @@ kamon {
     hostname-override = none
 
     # For histograms, which percentiles to count
-    percentiles = []
+    percentiles = [25, 50, 75, 95]
 
     # Subscription patterns used to select which metrics will be pushed to InfluxDB. Note that first, metrics
     # collection for your desired entities must be activated under the kamon.metrics.filters settings.

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -741,7 +741,7 @@ kamon {
     hostname-override = none
 
     # For histograms, which percentiles to count
-    percentiles = [25, 50, 75, 95]
+    percentiles = [25.0, 50.0, 75.0, 95.0]
 
     # Subscription patterns used to select which metrics will be pushed to InfluxDB. Note that first, metrics
     # collection for your desired entities must be activated under the kamon.metrics.filters settings.


### PR DESCRIPTION
return tick-rate to default 10s and add percentiles for histograms.