### PR TITLE
Fixup bookmark block for correspondence games

### DIFF
--- a/public/stylesheets/common.css
+++ b/public/stylesheets/common.css
@@ -761,14 +761,15 @@ div.side_box .game_infos::before {
   opacity: 0.7;
 }
 div.side_box .game_infos .bookmark {
-  position: absolute;
-  right: 0;
+  float: right;
   z-index: 10;
-  display: none;
+  display: block;
+  visibility: hidden;
 }
 div.side_box .game_infos:hover .bookmark,
 body.mobile div.side_box .game_infos .bookmark {
   display: block;
+  visibility: visible;
 }
 .bookmark:not(.bookmarked) .on,
 .bookmark.bookmarked .off {
@@ -776,7 +777,6 @@ body.mobile div.side_box .game_infos .bookmark {
 }
 div.side_box .game_infos .setup {
   display: block;
-  white-space: nowrap
 }
 div.side_box .game_infos .variant-link {
   border-bottom: 1px dotted #747474;


### PR DESCRIPTION
Small UI fixup.

Before (no hover):
<img width="326" alt="screenshot 2018-04-15 20 16 06" src="https://user-images.githubusercontent.com/242988/38784700-5cf03a7a-40ec-11e8-83f8-254da669fbef.png">

Before (hover):
<img width="300" alt="screenshot 2018-04-15 20 16 13" src="https://user-images.githubusercontent.com/242988/38784699-5cc77dc4-40ec-11e8-9a22-2e7c857d3ba4.png">

<hr/>

After (hover/correspondence):
<img width="271" alt="screenshot 2018-04-15 20 27 47" src="https://user-images.githubusercontent.com/242988/38784691-44c57ad2-40ec-11e8-9bed-d17b48772bdf.png">


After (hover/rapid):
<img width="283" alt="screenshot 2018-04-15 20 27 33" src="https://user-images.githubusercontent.com/242988/38784692-44eef3bc-40ec-11e8-906d-a76680c76021.png">



