### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ node_modules/
 local/
 ui/*/npm-debug.log
 hs_*.log
+.DS_Store
 
 RUNNING_PID
 


### PR DESCRIPTION
This Mac system file gets created if you are moving around svg files etc.