### PR TITLE
Revert "ignore #0 at ceval client level"

### DIFF
--- a/ui/ceval/src/stockfishProtocol.ts
+++ b/ui/ceval/src/stockfishProtocol.ts
@@ -63,9 +63,6 @@ export default class Protocol {
         elapsedMs: number = parseInt(matches[7]),
         moves = matches[8].split(' ');
 
-    // Sometimes we get #0. Let's just skip it.
-    if (isMate && !ev) return;
-
     // Track max pv index to determine when pv prints are done.
     if (this.expectedPvs < multiPv) this.expectedPvs = multiPv;
 


### PR DESCRIPTION
This reverts commit 065d76e4a8bc281f2c8f90ab4be83bcb85117b03.

@ornicar Do you remember what this was about, and if you were seeing this in standard chess? `mate 0` seems to be intended at least in antichess (#4248).