### PR TITLE
Remove "bot" from shutup dictionary

### DIFF
--- a/modules/shutup/src/main/Dictionary.scala
+++ b/modules/shutup/src/main/Dictionary.scala
@@ -32,7 +32,6 @@ blumpkin
 bollock
 boner
 boob
-bot
 bugger
 buk?kake
 bull?shit


### PR DESCRIPTION
I got auto-insultreported for helping someone set up a Lichess bot - I guess that this line is better ignored now we have BOT accounts.