### PR TITLE
Fix Piece Deletion for the Board Editor on Mobile Devices

### DIFF
--- a/ui/editor/src/chessground.js
+++ b/ui/editor/src/chessground.js
@@ -109,8 +109,8 @@ function onMouseEvent(ctrl) {
 function deleteOrHidePiece(ctrl, key, e) {
   if (e.type === 'touchstart') {
     if (ctrl.chessground.state.pieces[key]) {
+      ctrl.chessground.state.draggable.current.element.style.display = 'none';
       ctrl.chessground.cancelMove();
-      e.srcElement.style.display = 'none';
     }
 
     document.addEventListener('touchend', function() {


### PR DESCRIPTION
When deleting a piece on the board editor while on a mobile device, e.srcElement maps to the entire chessground. It used to only map to an individual piece. This results in the entire chessground disappearing.

![image](https://user-images.githubusercontent.com/542245/39393130-182448c4-4a87-11e8-9344-c4835d17cfa1.png)

Reworked this to hide the current draggable piece, restoring the functionality.