### PR TITLE
Misaligned tabs under Community

### DIFF
--- a/public/stylesheets/tournament_leaderboard.css
+++ b/public/stylesheets/tournament_leaderboard.css
@@ -1,3 +1,6 @@
+.content_box {
+  position: relative;
+}
 .content_box h1 {
   text-align: center;
 }

--- a/public/stylesheets/tournament_shields.css
+++ b/public/stylesheets/tournament_shields.css
@@ -1,3 +1,6 @@
+.content_box {
+  position: relative;
+}
 .content_box h1 {
   text-align: center;
 }


### PR DESCRIPTION
The Community 'Tournament winners' & 'Shields' tabs are misaligned when active:
![lichess issue 1](https://user-images.githubusercontent.com/39120611/39845158-94956264-53f4-11e8-97e4-ccbc9a0418f6.png)
_(Bad)_

![lichess issue 2](https://user-images.githubusercontent.com/39120611/39845165-9d73bcf0-53f4-11e8-8d8f-f4b40830365b.png)
_(Good)_

Suggest setting the position of the main content box relative.

After the code is added:
![lichess fix1](https://user-images.githubusercontent.com/39120611/39845206-cdc55800-53f4-11e8-870b-2b6afe4cf78d.png)
_(Fixed)_

Tested on Chrome, Firefox, Edge