### PR TITLE
Perf optimization for otp

### DIFF
--- a/modules/user/src/main/TotpSecret.scala
+++ b/modules/user/src/main/TotpSecret.scala
@@ -12,7 +12,7 @@ import User.TotpToken
 case class TotpSecret(secret: Array[Byte]) extends AnyVal {
   import TotpSecret._
 
-  override def toString = "TotpSecret(****************)"
+  override def toString = "TotpSecret(****)"
 
   def base32: String = new Base32().encodeAsString(secret)
 
@@ -50,7 +50,7 @@ object TotpSecret {
   def apply(base32: String) = new TotpSecret(new Base32().decode(base32))
 
   def random: TotpSecret = {
-    val secret = new Array[Byte](10)
+    val secret = new Array[Byte](20)
     secureRandom.nextBytes(secret)
     TotpSecret(secret)
   }

--- a/modules/user/src/main/TotpSecret.scala
+++ b/modules/user/src/main/TotpSecret.scala
@@ -25,8 +25,7 @@ case class TotpSecret(secret: Array[Byte]) extends AnyVal {
     hmac.init(new SecretKeySpec(secret, "RAW"))
     val hash = hmac.doFinal(msg)
 
-    val offset = hash(19) & 0xf
-
+    val offset = hash.last & 0xf
     otpString(ByteBuffer.wrap(hash).getInt(offset) & 0x7fffffff)
   }
 
@@ -37,11 +36,8 @@ case class TotpSecret(secret: Array[Byte]) extends AnyVal {
 }
 
 object TotpSecret {
-  // requires clock precision of at least window * 30 seconds
-  private final val window = 3
-
-  // valid 'skews' in rough order of likelihood
-  private val skewList = (0 to window).flatMap(i => Set(-i, i)).toList
+  // clock skews in rough order of likelihood
+  private val skewList = List(0, 1, -1, 2, -2, 3, -3)
 
   private def otpString(otp: Int) = {
     val s = (otp % 1000000).toString

--- a/modules/user/src/main/User.scala
+++ b/modules/user/src/main/User.scala
@@ -164,9 +164,7 @@ object User {
   case class ClearPassword(value: String) extends AnyVal {
     override def toString = "ClearPassword(****)"
   }
-  case class TotpToken(value: String) extends AnyVal {
-    override def toString = "TotpToken(****)"
-  }
+  case class TotpToken(value: String) extends AnyVal
   case class PasswordAndToken(password: ClearPassword, token: Option[TotpToken])
 
   case class PlayTime(total: Int, tv: Int) {

--- a/modules/user/src/test/TotpTest.scala
+++ b/modules/user/src/test/TotpTest.scala
@@ -27,12 +27,12 @@ class TotpTest extends Specification {
     "reference" in {
       // https://tools.ietf.org/html/rfc6238#appendix-B
       val secret = TotpSecret("12345678901234567890".getBytes)
-      secret.totp(59 / 30).value must_== "287082"
-      secret.totp(1111111109L / 30).value must_== "081804"
-      secret.totp(1111111111L / 30).value must_== "050471"
-      secret.totp(1234567890L / 30).value must_== "005924"
-      secret.totp(2000000000L / 30).value must_== "279037"
-      secret.totp(20000000000L / 30).value must_== "353130"
+      secret.totp(59 / 30) must_== TotpToken("287082")
+      secret.totp(1111111109L / 30) must_== TotpToken("081804")
+      secret.totp(1111111111L / 30) must_== TotpToken("050471")
+      secret.totp(1234567890L / 30) must_== TotpToken("005924")
+      secret.totp(2000000000L / 30) must_== TotpToken("279037")
+      secret.totp(20000000000L / 30) must_== TotpToken("353130")
     }
   }
 }


### PR DESCRIPTION
jmh shows string formatters are ridiculously slow, accounting for about
half of the compute time. The hand coded toString compute is negligable
compared to the hash computation.

Also:
- use ByteBuffer to avoid some bit math.
- calc tokens as needed in verification function