### PR TITLE
Fix https://lichess.org/learn#/17/2

### DIFF
--- a/ui/learn/src/stage/value.js
+++ b/ui/learn/src/stage/value.js
@@ -23,8 +23,8 @@ module.exports = {
     detectCapture: false
   }, {
     goal: 'takeThePieceWithTheHighestValue',
-    fen: '8/8/4b3/1p6/6r1/8/4Q3/8 w - -',
-    scenario: ['e2e6'],
+    fen: '4b3/8/8/1p6/6r1/8/4Q3/8 w - -',
+    scenario: ['e2g4'],
     nbMoves: 1,
     captures: 1,
     success: assert.scenarioComplete,


### PR DESCRIPTION
https://lichess.org/learn#/17/2

This training task asks the user to take the piece with the highest value. However, the correct answer is to take a piece with a lower value (presumably because the queen would get recaptured if it took the rook, although it has a higher value. Since the theme of this training task is to take the piece with the higher value, I think it makes sense to move the bishop so that it wouldn't recapture the queen, and change the win scenario to taking the rook (which has the higher value.)