### PR TITLE
csp: replace inline onclick handlers

### DIFF
--- a/app/views/base/layout.scala.html
+++ b/app/views/base/layout.scala.html
@@ -150,7 +150,7 @@ csp: Option[lila.common.ContentSecurityPolicy] = None)(body: Html)(implicit ctx:
       <a class="link text reports" href="@routes.Report.list" data-icon=""><i></i></a>
       }
       <div id="clinput"><a class="link"><span data-icon="y"></span></a><input spellcheck="false" placeholder="@trans.search()"/></div>
-      <a id="reconnecting" class="link text" onclick="window.location.reload()" data-icon="B">@trans.reconnecting()</a>
+      <a id="reconnecting" class="link text" data-icon="B">@trans.reconnecting()</a>
     </div>
     <div class="content @ctx.pref.is3d.fold("is3d", "is2d")">
       <div id="site_header">

--- a/app/views/mod/permissions.scala.html
+++ b/app/views/mod/permissions.scala.html
@@ -4,9 +4,20 @@
 @cssTag("mod-communication.css")
 }
 
+@moreJs = {
+@embedJs {
+$(function() {
+  $('button.clear').on('click', function() {
+    $('#permissions option:selected').prop('selected', false);
+  });
+});
+}
+}
+
 @base.layout(
 title = u.username + " permissions",
-moreCss = moreCss) {
+moreCss = moreCss,
+moreJs = moreJs) {
 
 <div id="permissions" class="content_box small_box">
   <h1>@userLink(u) permissions</h1>
@@ -20,7 +31,7 @@ moreCss = moreCss) {
       }
     </select>
     <div>
-      <button class="button clear" onclick="$('#permissions option:selected').removeAttr('selected');">Clear</button>
+      <button class="button clear" type="button">Clear</button>
       <button type="submit" class="button">Save</button>
     </div>
   </form>

--- a/public/javascripts/study/tour.js
+++ b/public/javascripts/study/tour.js
@@ -56,17 +56,17 @@ lichess.studyTour = function(study) {
         title: "Comment on a position",
         text: "With the <i data-icon='c'></i> button, or a right click on the move list on the right.<br>" +
           "Comments are shared and persisted.",
-        attachTo: "#lichess .member_buttons .comment top"
+        attachTo: "#lichess .member_buttons .comments top"
       } : null, study.isContrib ? {
         title: "Annotate a position",
         text: "With the !? button, or a right click on the move list on the right.<br>" +
           "Annotation glyphs are shared and persisted.",
-        attachTo: "#lichess .member_buttons .glyph top"
+        attachTo: "#lichess .member_buttons .glyphs top"
       } : null, {
         title: "Thanks for your time",
         text: "You can find your <a href='/study/mine/hot'>previous studies</a> from your profile page.<br>" +
           "There is also a <a href='//lichess.org/blog/V0KrLSkAAMo3hsi4/study-chess-the-lichess-way'>blog post about studies</a>.<br>" +
-          "Power users might want to press \"?\" to see <a onclick=\"Mousetrap.trigger('?');\">the keyboard shortcuts</a>.<br>" +
+          "Power users might want to press \"?\" to see keyboard shortcuts.<br>" +
           "Have fun!",
         buttons: [{
           text: 'Done',

--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -224,6 +224,10 @@ lichess.topMenuIntent = function() {
     // delay so round starts first (just for perceived perf)
     lichess.requestIdleCallback(function() {
 
+      $('#reconnecting').on('click', function() {
+        window.location.reload();
+      });
+
       $('#friend_box').friends();
 
       $('#lichess').on('click', '.autoselect', function() {


### PR DESCRIPTION
These onclick handlers were broken:

* Onclick of `#reconnecting` moved to `main.js`.
* Onclick of clear in `permissions.scala.html` moved into `@embedJs`.
* Fixed study tour, and removed an onclick handler there.