### PR TITLE
Rewrite lila URL parser

### DIFF
--- a/modules/forum/src/main/MentionNotifier.scala
+++ b/modules/forum/src/main/MentionNotifier.scala
@@ -50,5 +50,8 @@ final class MentionNotifier(notifyApi: NotifyApi, relationApi: RelationApi) {
   }
 
   private def extractMentionedUsers(post: Post): Set[User.ID] =
-    lila.common.String.atUsernameRegex.findAllMatchIn(post.text).map(_ group 1).toSet - ~post.author
+    (post.text.indexOf('@') >= 0) ?? {
+      val m = lila.common.String.atUsernameRegex.findAllMatchIn(post.text)
+      (post.author foldLeft m.map(_ group 1).toSet) { _ - _ }
+    }
 }

--- a/modules/user/src/main/User.scala
+++ b/modules/user/src/main/User.scala
@@ -176,9 +176,9 @@ object User {
   implicit def playTimeHandler = reactivemongo.bson.Macros.handler[PlayTime]
 
   // what existing usernames are like
-  val historicalUsernameRegex = """(?i)[a-z0-9][\w-]*[a-z0-9]""".r
+  val historicalUsernameRegex = """(?i)[a-z0-9][\w-]{0,28}[a-z0-9]""".r
   // what new usernames should be like -- now split into further parts for clearer error messages
-  val newUsernameRegex = """(?i)[a-z][\w-]*[a-z0-9]""".r
+  val newUsernameRegex = """(?i)[a-z][\w-]{0,28}[a-z0-9]""".r
 
   val newUsernamePrefix = """(?i)[a-z].*""".r
 
@@ -186,7 +186,7 @@ object User {
 
   val newUsernameChars = """(?i)[\w-]*""".r
 
-  def couldBeUsername(str: User.ID) = historicalUsernameRegex.pattern.matcher(str).matches && str.size < 30
+  def couldBeUsername(str: User.ID) = historicalUsernameRegex.matches(str)
 
   def normalize(username: String) = username.toLowerCase
 


### PR DESCRIPTION
Major performance speedups and much improved handling
of urls embedded in surrounded text. Combine url and @username
shorthand parsing to ensure they don't parse each other.

Many new test cases.