### PR TITLE
fix windows ui build script

### DIFF
--- a/ui/build.bat
+++ b/ui/build.bat
@@ -4,12 +4,12 @@ mkdir public\compiled
 
 set ts_apps=common chess ceval game tree chat
 
-yarn install --non-interactive
+call yarn install --non-interactive
 
 for %%t in (%ts_apps%) do @(
     call echo Building TypeScript: %%t
     call cd ui\%%t
-    call yarn run compile --non-interactive
+    call yarn run --non-interactive compile
     call cd ..\..
 )
 


### PR DESCRIPTION
1. preceed yarn command with call to avoid it exiting the script
2. pass the non-interactive flag to yarn instead of the compiler