### PR TITLE
Team settings enhancements: change team owner + admin access

### DIFF
--- a/app/controllers/Team.scala
+++ b/app/controllers/Team.scala
@@ -234,6 +234,6 @@ object Team extends LilaController {
     }
 
   private def Owner(team: TeamModel)(a: => Fu[Result])(implicit ctx: Context): Fu[Result] = {
-    ctx.me.??(me => team.isCreator(me.id) || Granter.superAdmin(me))
+    ctx.me.??(me => team.isCreator(me.id) || Granter.admin(me))
   }.fold(a, renderTeam(team) map { Forbidden(_) })
 }

--- a/app/controllers/Team.scala
+++ b/app/controllers/Team.scala
@@ -105,6 +105,25 @@ object Team extends LilaController {
     }
   }
 
+  def changeOwnerForm(id: String) = Auth { implicit ctx => me =>
+    OptionFuResult(api team id) { team =>
+      Owner(team) {
+        MemberRepo userIdsByTeam team.id map { userIds =>
+          html.team.changeOwner(team, userIds.filterNot(me.id ==).toList.sorted)
+        }
+      }
+    }
+  }
+
+  def changeOwner(id: String) = AuthBody { implicit ctx => me =>
+    OptionFuResult(api team id) { team =>
+      Owner(team) {
+        implicit val req = ctx.body
+        forms.kick.bindFromRequest.value ?? { api.changeOwner(team, _) } inject Redirect(routes.Team.show(team.id))
+      }
+    }
+  }
+
   def close(id: String) = Secure(_.CloseTeam) { implicit ctx => me =>
     OptionFuResult(api team id) { team =>
       (api delete team) >>

--- a/app/controllers/Team.scala
+++ b/app/controllers/Team.scala
@@ -100,7 +100,7 @@ object Team extends LilaController {
     OptionFuResult(api team id) { team =>
       Owner(team) {
         implicit val req = ctx.body
-        forms.kick.bindFromRequest.value ?? { api.kick(team, _) } inject Redirect(routes.Team.show(team.id))
+        forms.kick.bindFromRequest.value ?? { api.kick(team, _, me) } inject Redirect(routes.Team.show(team.id))
       }
     }
   }
@@ -119,7 +119,7 @@ object Team extends LilaController {
     OptionFuResult(api team id) { team =>
       Owner(team) {
         implicit val req = ctx.body
-        forms.kick.bindFromRequest.value ?? { api.changeOwner(team, _) } inject Redirect(routes.Team.show(team.id))
+        forms.kick.bindFromRequest.value ?? { api.changeOwner(team, _, me) } inject Redirect(routes.Team.show(team.id))
       }
     }
   }

--- a/app/controllers/Team.scala
+++ b/app/controllers/Team.scala
@@ -109,7 +109,7 @@ object Team extends LilaController {
     OptionFuResult(api team id) { team =>
       Owner(team) {
         MemberRepo userIdsByTeam team.id map { userIds =>
-          html.team.changeOwner(team, userIds.filterNot(me.id ==).toList.sorted)
+          html.team.changeOwner(team, userIds.filterNot(team.createdBy ==).toList.sorted)
         }
       }
     }

--- a/app/views/team/changeOwner.scala.html
+++ b/app/views/team/changeOwner.scala.html
@@ -1,0 +1,17 @@
+@(t: lila.team.Team, userIds: List[String])(implicit ctx: Context)
+
+@title = @{ "Change owner of Team " + t.name }
+
+@team.layout(title = title) {
+<div id="team">
+  <div class="content_box team_box">
+    <h1>@title</h1>
+    <p class="undertitle">Who do you want to make owner of this team?</p>
+    <form class="kick" action="@routes.Team.changeOwner(t.id)" method="POST">
+      @userIds.sorted.map { userId =>
+      <button name="userId" class="submit button small confirm" value="@userId">@usernameOrId(userId)</button>
+      }
+    </form>
+  </div>
+</div>
+}

--- a/app/views/team/edit.scala.html
+++ b/app/views/team/edit.scala.html
@@ -7,7 +7,8 @@
   <div class="content_box team_box">
     <h1>@title</h1>
     <p class="links undertitle">
-      <a href="@routes.Team.kick(t.id)">Kick someone out of the team</a>
+      <a href="@routes.Team.kick(t.id)">Kick someone out of the team</a><br>
+      <a href="@routes.Team.changeOwner(t.id)">Appoint another team owner</a>
     </p>
     <form class="new-team wide" action="@routes.Team.update(t.id)" method="POST">
       <section class="team-data">

--- a/app/views/team/showContent.scala.html
+++ b/app/views/team/showContent.scala.html
@@ -68,7 +68,7 @@
         <input class="submit button small confirm" type="submit" value="@trans.quitTeam()" />
       </form>
       }
-      @if(info.createdByMe) {
+      @if(info.createdByMe || isGranted(_.Admin)) {
       <a href="@routes.Team.edit(t.id)" class="submit button small" data-icon="%"> @trans.settings()</a>
       }
     </div>

--- a/conf/routes
+++ b/conf/routes
@@ -278,6 +278,8 @@ GET   /team/:id/edit                          controllers.Team.edit(id: String)
 POST  /team/:id/edit                          controllers.Team.update(id: String)
 GET   /team/:id/kick                          controllers.Team.kickForm(id: String)
 POST  /team/:id/kick                          controllers.Team.kick(id: String)
+GET   /team/:id/changeOwner                   controllers.Team.changeOwnerForm(id: String)
+POST  /team/:id/changeOwner                   controllers.Team.changeOwner(id: String)
 POST  /team/:id/close                         controllers.Team.close(id: String)
 GET   /team/:id/users                         controllers.Team.users(id: String)
 

--- a/modules/mod/src/main/Modlog.scala
+++ b/modules/mod/src/main/Modlog.scala
@@ -58,6 +58,9 @@ case class Modlog(
     case Modlog.streamerUnlist => "unlist streamer"
     case Modlog.streamerFeature => "feature streamer"
     case Modlog.streamerUnfeature => "unfeature streamer"
+    case Modlog.teamKick => "kick from team"
+    case Modlog.teamEdit => "edited team"
+    case Modlog.teamMadeOwner => "made team owner"
     case a => a
   }
 
@@ -119,4 +122,7 @@ object Modlog {
   val streamerUnlist = "streamerunlist"
   val streamerFeature = "streamerFeature"
   val streamerUnfeature = "streamerUnfeature"
+  val teamKick = "teamKick"
+  val teamEdit = "teamEdit"
+  val teamMadeOwner = "teamMadeOwner"
 }

--- a/modules/mod/src/main/ModlogApi.scala
+++ b/modules/mod/src/main/ModlogApi.scala
@@ -149,6 +149,18 @@ final class ModlogApi(coll: Coll) {
     Modlog.make(mod, sus, if (v) Modlog.rankban else Modlog.unrankban)
   }
 
+  def teamKick(mod: String, user: String, teamName: String) = add {
+    Modlog(mod, user.some, Modlog.teamKick, details = Some(teamName take 140))
+  }
+
+  def teamEdit(mod: String, teamOwner: String, teamName: String) = add {
+    Modlog(mod, teamOwner.some, Modlog.teamEdit, details = Some(teamName take 140))
+  }
+
+  def teamMadeOwner(mod: String, user: String, teamName: String) = add {
+    Modlog(mod, user.some, Modlog.teamMadeOwner, details = Some(teamName take 140))
+  }
+
   def recent = coll.find($empty).sort($sort naturalDesc).cursor[Modlog]().gather[List](100)
 
   def wasUnengined(sus: Suspect) = coll.exists($doc(

--- a/modules/notify/src/main/BSONHandlers.scala
+++ b/modules/notify/src/main/BSONHandlers.scala
@@ -39,6 +39,10 @@ private object BSONHandlers {
   implicit val TeamNameHandler = stringAnyValHandler[TeamJoined.Name](_.value, TeamJoined.Name.apply)
   implicit val TeamJoinedHandler = Macros.handler[TeamJoined]
 
+  implicit val TeamMadeOwnerIdHandler = stringAnyValHandler[TeamMadeOwner.Id](_.value, TeamMadeOwner.Id.apply)
+  implicit val TeamMadeOwnerNameHandler = stringAnyValHandler[TeamMadeOwner.Name](_.value, TeamMadeOwner.Name.apply)
+  implicit val TeamMadeOwnerHandler = Macros.handler[TeamMadeOwner]
+
   implicit val GameEndGameIdHandler = stringAnyValHandler[GameEnd.GameId](_.value, GameEnd.GameId.apply)
   implicit val GameEndOpponentHandler = stringAnyValHandler[GameEnd.OpponentId](_.value, GameEnd.OpponentId.apply)
   implicit val GameEndWinHandler = booleanAnyValHandler[GameEnd.Win](_.value, GameEnd.Win.apply)
@@ -70,6 +74,7 @@ private object BSONHandlers {
         case p: PrivateMessage => PrivateMessageHandler.write(p)
         case q: QaAnswer => QaAnswerHandler.write(q)
         case t: TeamJoined => TeamJoinedHandler.write(t)
+        case o: TeamMadeOwner => TeamMadeOwnerHandler.write(o)
         case LimitedTournamentInvitation => $empty
         case x: TitledTournamentInvitation => TitledTournamentInvitationHandler.write(x)
         case x: GameEnd => GameEndHandler.write(x)
@@ -108,6 +113,7 @@ private object BSONHandlers {
       case "privateMessage" => PrivateMessageHandler read reader.doc
       case "qaAnswer" => QaAnswerHandler read reader.doc
       case "teamJoined" => TeamJoinedHandler read reader.doc
+      case "teamMadeOwner" => TeamMadeOwnerHandler read reader.doc
       case "u" => LimitedTournamentInvitation
       case "titledTourney" => TitledTournamentInvitationHandler read reader.doc
       case "gameEnd" => GameEndHandler read reader.doc

--- a/modules/notify/src/main/JsonHandlers.scala
+++ b/modules/notify/src/main/JsonHandlers.scala
@@ -36,6 +36,10 @@ final class JSONHandlers(getLightUser: LightUser.GetterSync) {
           "id" -> id.value,
           "name" -> name.value
         )
+        case TeamMadeOwner(id, name) => Json.obj(
+          "id" -> id.value,
+          "name" -> name.value
+        )
         case LimitedTournamentInvitation | ReportedBanned | CoachReview => Json.obj()
         case TitledTournamentInvitation(id, text) => Json.obj(
           "id" -> id,

--- a/modules/notify/src/main/Notification.scala
+++ b/modules/notify/src/main/Notification.scala
@@ -97,6 +97,16 @@ object TeamJoined {
   case class Name(value: String) extends AnyVal with StringValue
 }
 
+case class TeamMadeOwner(
+    id: TeamMadeOwner.Id,
+    name: TeamMadeOwner.Name
+) extends NotificationContent("teamMadeOwner")
+
+object TeamMadeOwner {
+  case class Id(value: String) extends AnyVal with StringValue
+  case class Name(value: String) extends AnyVal with StringValue
+}
+
 case object LimitedTournamentInvitation extends NotificationContent("u")
 
 case class TitledTournamentInvitation(

--- a/modules/security/src/main/Granter.scala
+++ b/modules/security/src/main/Granter.scala
@@ -10,5 +10,7 @@ object Granter {
   def apply(f: Permission.type => Permission)(user: User): Boolean =
     apply(f(Permission))(user)
 
+  def admin(user: User): Boolean = apply(Permission.Admin)(user)
+
   def superAdmin(user: User): Boolean = apply(Permission.SuperAdmin)(user)
 }

--- a/modules/team/src/main/Env.scala
+++ b/modules/team/src/main/Env.scala
@@ -3,12 +3,14 @@ package lila.team
 import com.typesafe.config.Config
 import akka.actor._
 
+import lila.mod.ModlogApi
 import lila.notify.NotifyApi
 import lila.common.MaxPerPage
 
 final class Env(
     config: Config,
     hub: lila.hub.Env,
+    modLog: ModlogApi,
     notifyApi: NotifyApi,
     system: ActorSystem,
     asyncCache: lila.memo.AsyncCache.Builder,
@@ -40,7 +42,8 @@ final class Env(
     notifier = notifier,
     bus = system.lilaBus,
     indexer = hub.actor.teamSearch,
-    timeline = hub.actor.timeline
+    timeline = hub.actor.timeline,
+    modLog = modLog
   )
 
   lazy val paginator = new PaginatorBuilder(
@@ -67,6 +70,7 @@ object Env {
   lazy val current = "team" boot new Env(
     config = lila.common.PlayApp loadConfig "team",
     hub = lila.hub.Env.current,
+    modLog = lila.mod.Env.current.logApi,
     notifyApi = lila.notify.Env.current.api,
     system = lila.common.PlayApp.system,
     asyncCache = lila.memo.Env.current.asyncCache,

--- a/modules/team/src/main/Notifier.scala
+++ b/modules/team/src/main/Notifier.scala
@@ -1,14 +1,23 @@
 package lila.team
 
 import lila.notify.Notification.Notifies
-import lila.notify.TeamJoined.{ Id, Name }
-import lila.notify.{ Notification, TeamJoined, NotifyApi }
+import lila.notify.TeamJoined.{ Id => TJId, Name => TJName }
+import lila.notify.TeamMadeOwner.{ Id => TMOId, Name => TMOName }
+import lila.notify.{ Notification, TeamJoined, TeamMadeOwner, NotifyApi }
+import lila.user.User
 
 private[team] final class Notifier(notifyApi: NotifyApi) {
 
   def acceptRequest(team: Team, request: Request) = {
-    val notificationContent = TeamJoined(Id(team.id), Name(team.name))
+    val notificationContent = TeamJoined(TJId(team.id), TJName(team.name))
     val notification = Notification.make(Notifies(request.user), notificationContent)
+
+    notifyApi.addNotification(notification)
+  }
+
+  def madeOwner(team: Team, newOwner: String) = {
+    val notificationContent = TeamMadeOwner(TMOId(team.id), TMOName(team.name))
+    val notification = Notification.make(Notifies(newOwner), notificationContent)
 
     notifyApi.addNotification(notification)
   }

--- a/modules/team/src/main/TeamApi.scala
+++ b/modules/team/src/main/TeamApi.scala
@@ -165,7 +165,8 @@ final class TeamApi(
 
   def changeOwner(team: Team, userId: String, me: User): Funit =
     TeamRepo.changeOwner(team.id, userId) >>
-      modLog.teamMadeOwner(me.id, userId, team.name)
+      modLog.teamMadeOwner(me.id, userId, team.name) >>-
+      notifier.madeOwner(team, userId)
 
   def enable(team: Team): Funit =
     TeamRepo.enable(team).void >>- (indexer ! InsertTeam(team))

--- a/modules/team/src/main/TeamApi.scala
+++ b/modules/team/src/main/TeamApi.scala
@@ -164,9 +164,13 @@ final class TeamApi(
       }
 
   def changeOwner(team: Team, userId: String, me: User): Funit =
-    TeamRepo.changeOwner(team.id, userId) >>
-      modLog.teamMadeOwner(me.id, userId, team.name) >>-
-      notifier.madeOwner(team, userId)
+    MemberRepo.exists(team.id, userId) flatMap { e =>
+      e ?? {
+        TeamRepo.changeOwner(team.id, userId) >>
+          modLog.teamMadeOwner(me.id, userId, team.name) >>-
+          notifier.madeOwner(team, userId)
+      }
+    }
 
   def enable(team: Team): Funit =
     TeamRepo.enable(team).void >>- (indexer ! InsertTeam(team))

--- a/modules/team/src/main/TeamApi.scala
+++ b/modules/team/src/main/TeamApi.scala
@@ -153,6 +153,8 @@ final class TeamApi(
 
   def kick(team: Team, userId: String): Funit = doQuit(team, userId)
 
+  def changeOwner(team: Team, userId: String): Funit = TeamRepo.changeOwner(team.id, userId).void
+
   def enable(team: Team): Funit =
     TeamRepo.enable(team).void >>- (indexer ! InsertTeam(team))
 

--- a/modules/team/src/main/TeamRepo.scala
+++ b/modules/team/src/main/TeamRepo.scala
@@ -59,6 +59,9 @@ object TeamRepo {
       $push("requests", request.user)
     ).void
 
+  def changeOwner(teamId: String, newOwner: User.ID) =
+    coll.update($id(teamId), $set("createdBy" -> newOwner))
+
   val enabledQuery = $doc("enabled" -> true)
 
   val sortPopular = $sort desc "nbMembers"

--- a/modules/team/src/main/TeamRepo.scala
+++ b/modules/team/src/main/TeamRepo.scala
@@ -60,7 +60,7 @@ object TeamRepo {
     ).void
 
   def changeOwner(teamId: String, newOwner: User.ID) =
-    coll.update($id(teamId), $set("createdBy" -> newOwner))
+    coll.updateField($id(teamId), "createdBy", newOwner)
 
   val enabledQuery = $doc("enabled" -> true)
 

--- a/ui/notify/src/renderers.ts
+++ b/ui/notify/src/renderers.ts
@@ -68,6 +68,16 @@ export const renderers: Renderers = {
     ]),
     text: n => "You have joined  « " + n.content.name + "  »."
   },
+  teamMadeOwner: {
+    html: n => generic(n, "/team/" + n.content.id, 'f', [
+      h('span', [
+        h('strong', n.content.name),
+        drawTime(n)
+      ]),
+      h('span', "You are appointed as team owner.")
+    ]),
+    text: n => "You are now the owner of  « " + n.content.name + "  »."
+  },
   u: {
     html: n => generic(n, '/tournament/limited-invitation', 'g', [
       h('span', [


### PR DESCRIPTION
Functionality that I wished to have available a few months ago during some drama in a major variant team, and I finally got around to writing the code.

1. **Team owners can be changed by the team owner.** Owner changes are mod-logged.
2. **Admins have access to team settings.** All admin actions on teams (edit, kick, and owner change) are mod-logged. (Apparently SuperAdmins used to be able to access them already but now there's also a link to easily open it, and the permission level is lowered, which imo makes sense if logging is available, which it now is).

**Concern:** the "createdBy" field on Team now no longer necessarily indicates who created the team, as it was always used as the owner field as well. Can the createdBy field somehow be renamed to owner (with or without major database changes)? Or should a second field "owner" be added so createdBy doesn't get affected on owner change?