### PR TITLE
Fixed "Practice" spelling

### DIFF
--- a/translation/dest/learn/en-US.xml
+++ b/translation/dest/learn/en-US.xml
@@ -200,7 +200,7 @@ in two moves!</string>
   <string name="youKnowHowToPlayChess">You know how to play chess, congratulations! Do you want to become a stronger player?</string>
   <string name="register">Register</string>
   <string name="getAFreeLichessAccount">Get a free Lichess account</string>
-  <string name="practice">Practise</string>
+  <string name="practice">Practice</string>
   <string name="learnCommonChessPositions">Learn common chess positions</string>
   <string name="puzzles">Puzzles</string>
   <string name="exerciseYourTacticalSkills">Exercise your tactical skills</string>

--- a/translation/source/learn.xml
+++ b/translation/source/learn.xml
@@ -206,7 +206,7 @@ in two moves!</string>
   <string name="youKnowHowToPlayChess">You know how to play chess, congratulations! Do you want to become a stronger player?</string>
   <string name="register">Register</string>
   <string name="getAFreeLichessAccount">Get a free Lichess account</string>
-  <string name="practice">Practise</string>
+  <string name="practice">Practice</string>
   <string name="learnCommonChessPositions">Learn common chess positions</string>
   <string name="puzzles">Puzzles</string>
   <string name="exerciseYourTacticalSkills">Exercise your tactical skills</string>


### PR DESCRIPTION
Changed the spelling of practice from "practise" to "practice" in 2 files. The word is spelled with a 'c' everywhere else on lichess, including in the URL, avoids confusion