### PR TITLE
Increase maximum clock base to 10 minutes and inc to 5 seconds

### DIFF
--- a/modules/tournament/src/main/DataForm.scala
+++ b/modules/tournament/src/main/DataForm.scala
@@ -70,7 +70,7 @@ object DataForm {
 
   import chess.variant._
 
-  val clockTimes: Seq[Double] = Seq(0d, 1 / 4d, 1 / 2d, 3 / 4d, 1d, 3 / 2d) ++ (2d to 7d by 1d)
+  val clockTimes: Seq[Double] = Seq(0d, 1 / 4d, 1 / 2d, 3 / 4d, 1d, 3 / 2d) ++ (2d to 10d by 1d)
   val clockTimesPrivate: Seq[Double] = clockTimes ++ (10d to 30d by 5d) ++ (40d to 60d by 10d)
   val clockTimeDefault = 2d
   private def formatLimit(l: Double) =
@@ -80,7 +80,7 @@ object DataForm {
   val clockTimeChoices = optionsDouble(clockTimes, formatLimit)
   val clockTimePrivateChoices = optionsDouble(clockTimesPrivate, formatLimit)
 
-  val clockIncrements = 0 to 2 by 1
+  val clockIncrements = 0 to 5 by 1
   val clockIncrementsPrivate = clockIncrements ++ (3 to 7) ++ (10 to 30 by 5) ++ (40 to 60 by 10)
   val clockIncrementDefault = 0
   val clockIncrementChoices = options(clockIncrements, "%d second{s}")


### PR DESCRIPTION
I think a few more options can be added without cluttering the UI, allowing players to play Rapid time controls slower than 7+2.

If this is too much UI clutter, I can look into making the TC selection more like "Create a game" sliders.