### PR TITLE
fix we use cookies positioning over online friends

### DIFF
--- a/public/stylesheets/swag.css
+++ b/public/stylesheets/swag.css
@@ -33,3 +33,6 @@ div.side h2 {
   margin: 100px auto;
   text-align: center;
 }
+#myShop #sprd-main {
+  z-index: auto;
+}


### PR DESCRIPTION
The fix for [issue-4378](https://github.com/ornicar/lila/issues/4378).

I'm not very satisfied with the solution, because I use external CSS id name to overwrite default behavior and id name may be changed in the future by spreadsheets developers, and after that additional fix will be needed. But it may not happen at all :) 
@ornicar you have mentioned about iframes. Do you want to display the whole page or just a shop part?