### PR TITLE
[WIP] 0-rtt assets

### DIFF
--- a/app/templating/AssetHelper.scala
+++ b/app/templating/AssetHelper.scala
@@ -17,25 +17,28 @@ trait AssetHelper { self: I18nHelper =>
 
   val assetBaseUrl = s"//$assetDomain"
 
-  def assetRoute(path: String) = s"/assets/$path"
+  def assetUrl(path: String, version: AssetVersion): String =
+    s"$assetBaseUrl/assets/$version/$path"
+  def assetUrl(path: String)(implicit ctx: Context): String =
+    assetUrl(path, ctx.pageData.assetVersion)
 
   def cdnUrl(path: String) = s"$assetBaseUrl$path"
-  def staticUrl(path: String) = s"$assetBaseUrl${assetRoute(path)}"
+  def staticUrl(path: String) = s"$assetBaseUrl/assets/$path"
 
   def dbImageUrl(path: String) = s"$assetBaseUrl/image/$path"
 
-  def cssTag(name: String, staticDomain: Boolean = true)(implicit ctx: Context): Html =
-    cssAt("stylesheets/" + name, staticDomain)
+  def cssTag(name: String)(implicit ctx: Context): Html =
+    cssAt("stylesheets/" + name)
 
-  def cssVendorTag(name: String, staticDomain: Boolean = true)(implicit ctx: Context) =
-    cssAt("vendor/" + name, staticDomain)
+  def cssVendorTag(name: String)(implicit ctx: Context) =
+    cssAt("vendor/" + name)
 
-  def cssAt(path: String, staticDomain: Boolean, version: AssetVersion): Html = Html {
-    val href = if (staticDomain) staticUrl(path) else assetRoute(path)
-    s"""<link href="$href?v=$version" type="text/css" rel="stylesheet"/>"""
+  def cssAt(path: String, version: AssetVersion): Html = Html {
+    val href = assetUrl(path, version)
+    s"""<link href="$href" type="text/css" rel="stylesheet"/>"""
   }
-  def cssAt(path: String, staticDomain: Boolean = true)(implicit ctx: Context): Html =
-    cssAt(path, staticDomain, ctx.pageData.assetVersion)
+  def cssAt(path: String)(implicit ctx: Context): Html =
+    cssAt(path, ctx.pageData.assetVersion)
 
   def jsTag(name: String, async: Boolean = false)(implicit ctx: Context) =
     jsAt("javascripts/" + name, async = async)
@@ -43,11 +46,12 @@ trait AssetHelper { self: I18nHelper =>
   def jsTagCompiled(name: String)(implicit ctx: Context) =
     if (isProd) jsAt("compiled/" + name) else jsTag(name)
 
-  def jsAt(path: String, static: Boolean, async: Boolean, version: AssetVersion): Html = Html {
-    s"""<script${if (async) " async defer" else ""} src="${if (static) staticUrl(path) else path}?v=$version"></script>"""
+  def jsAt(path: String, async: Boolean, version: AssetVersion): Html = Html {
+    val src = assetUrl(path, version)
+    s"""<script${if (async) " async defer" else ""} src="$src"></script>"""
   }
-  def jsAt(path: String, static: Boolean = true, async: Boolean = false)(implicit ctx: Context): Html =
-    jsAt(path, static, async, ctx.pageData.assetVersion)
+  def jsAt(path: String, async: Boolean = false)(implicit ctx: Context): Html =
+    jsAt(path, async, ctx.pageData.assetVersion)
 
   val jQueryTag = Html {
     s"""<script src="${staticUrl("javascripts/vendor/jquery.min.js")}"></script>"""

--- a/app/views/tv/embed.scala.html
+++ b/app/views/tv/embed.scala.html
@@ -7,11 +7,11 @@
     <meta name="Content-Security-Policy" content="@basicCsp">
     <title>lichess.org TV</title>
     @if(bg == "dark") {
-    @cssAt("stylesheets/dark.css", true, assetVersion)
+    @cssAt("stylesheets/dark.css", assetVersion)
     }
-    @cssAt(s"stylesheets/piece/merida.css", true, assetVersion)
-    @cssAt("stylesheets/common.css", true, assetVersion)
-    @cssAt("stylesheets/board.css", true, assetVersion)
+    @cssAt(s"stylesheets/piece/merida.css", assetVersion)
+    @cssAt("stylesheets/common.css", assetVersion)
+    @cssAt("stylesheets/board.css", assetVersion)
   </head>
   <body
     class="base highlight @bg"
@@ -22,7 +22,7 @@
       @game.vstext(pov)(none)
     </div>
     @jQueryTag
-    @jsAt("javascripts/vendor/chessground.min.js", true, false, assetVersion)
-    @jsAt("compiled/tv.js", true, false, assetVersion)
+    @jsAt("javascripts/vendor/chessground.min.js", false, assetVersion)
+    @jsAt("compiled/tv.js", false, assetVersion)
   </body>
 </html>

--- a/conf/routes
+++ b/conf/routes
@@ -612,6 +612,7 @@ POST  /jslog/$id<\w{12}>               controllers.Main.jslog(id: String)
 POST  /jsmon/:event                    controllers.Main.jsmon(event: String)
 
 # Assets
+#GET   /assets/$version<\d+>/*file     controllers.Assets.at(path="/public", file)
 GET   /assets/*file                    controllers.Assets.at(path="/public", file)
 
 GET   /robots.txt                      controllers.Main.robots

--- a/public/javascripts/chart/acpl.js
+++ b/public/javascripts/chart/acpl.js
@@ -2,8 +2,8 @@ function toBlurArray(player) {
   return player.blurs && player.blurs.bits ? player.blurs.bits.split('') : [];
 }
 lichess.advantageChart = function(data, trans, el) {
-  lichess.loadScript('/assets/javascripts/chart/common.js').done(function() {
-    lichess.loadScript('/assets/javascripts/chart/division.js').done(function() {
+  lichess.loadScript('javascripts/chart/common.js').done(function() {
+    lichess.loadScript('javascripts/chart/division.js').done(function() {
       lichess.chartCommon('highchart').done(function() {
 
         lichess.advantageChart.update = function(d, partial) {

--- a/public/javascripts/chart/common.js
+++ b/public/javascripts/chart/common.js
@@ -2,7 +2,7 @@ lichess.highchartsPromise;
 lichess.chartCommon = function(type) {
   if (lichess.highchartsPromise) return lichess.highchartsPromise;
   var file = type === 'highstock' ? 'highstock.js' : 'highcharts.js';
-  return lichess.highchartsPromise = lichess.loadScript('/assets/vendor/highcharts-4.2.5/' + file, true).done(function() {
+  return lichess.highchartsPromise = lichess.loadScript('vendor/highcharts-4.2.5/' + file, { noVersion: true }).done(function() {
     Highcharts.makeFont = function(size) {
       return size + "px 'Noto Sans', 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Arial, Helvetica, sans-serif";
     };

--- a/public/javascripts/chart/movetime.js
+++ b/public/javascripts/chart/movetime.js
@@ -2,8 +2,8 @@ function toBlurArray(player) {
   return player.blurs && player.blurs.bits ? player.blurs.bits.split('') : [];
 }
 lichess.movetimeChart = function(data, trans) {
-  lichess.loadScript('/assets/javascripts/chart/common.js').done(function() {
-    lichess.loadScript('/assets/javascripts/chart/division.js').done(function() {
+  lichess.loadScript('javascripts/chart/common.js').done(function() {
+    lichess.loadScript('javascripts/chart/division.js').done(function() {
       lichess.chartCommon('highchart').done(function() {
         lichess.movetimeChart.render = function() {
           $('#movetimes_chart:not(.rendered)').each(function() {

--- a/public/javascripts/chart/ratingDistribution.js
+++ b/public/javascripts/chart/ratingDistribution.js
@@ -1,5 +1,5 @@
 lichess.ratingDistributionChart = function(data) {
-  lichess.loadScript('/assets/javascripts/chart/common.js').done(function() {
+  lichess.loadScript('javascripts/chart/common.js').done(function() {
     lichess.chartCommon('highchart').done(function() {
       var disabled = {
         enabled: false

--- a/public/javascripts/chart/ratingHistory.js
+++ b/public/javascripts/chart/ratingHistory.js
@@ -1,5 +1,5 @@
 lichess.ratingHistoryChart = function(data) {
-  lichess.loadScript('/assets/javascripts/chart/common.js').done(function() {
+  lichess.loadScript('javascripts/chart/common.js').done(function() {
     lichess.chartCommon('highstock').done(function() {
       var disabled = {
         enabled: false

--- a/public/javascripts/forum-post.js
+++ b/public/javascripts/forum-post.js
@@ -25,7 +25,7 @@ $(function() {
 
     var textarea = this;
 
-    lichess.loadScript('/assets/vendor/textcomplete.min.js').then(function() {
+    lichess.loadScript('vendor/textcomplete.min.js').then(function() {
 
       var searchCandidates = function(term, candidateUsers) {
         return candidateUsers.filter(function(user) {

--- a/public/javascripts/music/lobby.js
+++ b/public/javascripts/music/lobby.js
@@ -2,7 +2,7 @@ function lichessLobbyMusic() {
 
   var orchestra;
 
-  lichess.loadScript('/assets/javascripts/music/orchestra.js').then(function() {
+  lichess.loadScript('javascripts/music/orchestra.js').then(function() {
     orchestra = lichessOrchestra();
   });
 

--- a/public/javascripts/music/orchestra.js
+++ b/public/javascripts/music/orchestra.js
@@ -1,6 +1,6 @@
 function lichessOrchestra() {
 
-  var soundDir = lichess.assetUrl('/assets/sound/instrument/', {noVersion:true});
+  var soundDir = lichess.assetUrl('sound/instrument/', {noVersion: true});
 
   var makeSoundPair = function(sound) {
     return [soundDir + sound + '.ogg', soundDir + sound + '.mp3'];

--- a/public/javascripts/music/play.js
+++ b/public/javascripts/music/play.js
@@ -2,7 +2,7 @@ function lichessPlayMusic() {
 
   var orchestra;
 
-  lichess.loadScript('/assets/javascripts/music/orchestra.js').then(function() {
+  lichess.loadScript('javascripts/music/orchestra.js').then(function() {
     orchestra = lichessOrchestra();
   });
 

--- a/public/javascripts/music/replay.js
+++ b/public/javascripts/music/replay.js
@@ -2,7 +2,7 @@ function lichessReplayMusic() {
 
   var orchestra;
 
-  lichess.loadScript('/assets/javascripts/music/orchestra.js').then(function() {
+  lichess.loadScript('javascripts/music/orchestra.js').then(function() {
     orchestra = lichessOrchestra();
   });
 

--- a/public/javascripts/user.js
+++ b/public/javascripts/user.js
@@ -7,7 +7,7 @@ $(function() {
       if ($zone.is(':visible')) $zone.hide();
       else {
         $zone.html(lichess.spinnerHtml).show();
-        lichess.loadCss('/assets/stylesheets/user-mod.css');
+        lichess.loadCss('stylesheets/user-mod.css');
         $zone.load($(this).attr('href'));
       }
       return false;
@@ -66,7 +66,7 @@ $(function() {
         $angles.find('.active').removeClass('active');
         $(this).addClass('active');
         browseTo($(this).attr('href'));
-        if ($(this).data('tab') === 'activity') lichess.loadCss('/assets/stylesheets/activity.css');
+        if ($(this).data('tab') === 'activity') lichess.loadCss('stylesheets/activity.css');
         return false;
       });
       $('.user_show').on('click', '#games a', function() {

--- a/public/stylesheets/common.css
+++ b/public/stylesheets/common.css
@@ -53,8 +53,8 @@ time {
 }
 @font-face {
   font-family: "lichess";
-  src: url("../font80/fonts/lichess.eot");
-  src: url("../font80/fonts/lichess.eot?#iefix") format("embedded-opentype"), url("../font80/fonts/lichess.woff") format("woff"), url("../font80/fonts/lichess.ttf") format("truetype");
+  src: url("/assets/font80/fonts/lichess.eot");
+  src: url("/assets/font80/fonts/lichess.eot?#iefix") format("embedded-opentype"), url("/assets/font80/fonts/lichess.woff") format("woff"), url("/assets/font80/fonts/lichess.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }

--- a/ui/analyse/src/boot.js
+++ b/ui/analyse/src/boot.js
@@ -108,7 +108,7 @@ module.exports = function(element, cfg) {
     var $panel = $panels.filter('.computer_analysis');
     if (!$("#adv_chart").length) $panel.html('<div id="adv_chart"></div>' + (loading ? chartLoader() : ''));
     else if (loading && !$("#adv_chart_loader").length) $panel.append(chartLoader());
-    lichess.loadScript('/assets/javascripts/chart/acpl.js').then(function() {
+    lichess.loadScript('javascripts/chart/acpl.js').then(function() {
       lichess.advantageChart(data, cfg.trans, $("#adv_chart")[0]);
     });
   };
@@ -120,7 +120,7 @@ module.exports = function(element, cfg) {
     $menu.children('.active').removeClass('active').end().find('.' + panel).addClass('active');
     $panels.removeClass('active').filter('.' + panel).addClass('active');
     if (panel === 'move_times' && !lichess.movetimeChart) try {
-      lichess.loadScript('/assets/javascripts/chart/movetime.js').then(function() {
+      lichess.loadScript('javascripts/chart/movetime.js').then(function() {
         lichess.movetimeChart(data, cfg.trans);
       });
     } catch (e) {}

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -154,7 +154,7 @@ export default class AnalyseCtrl {
 
     li.pubsub.on('sound_set', (set: string) => {
       if (!this.music && set === 'music')
-        li.loadScript('/assets/javascripts/music/replay.js').then(() => {
+        li.loadScript('javascripts/music/replay.js').then(() => {
           this.music = window.lichessReplayMusic();
         });
         if (this.music && set !== 'music') this.music = null;

--- a/ui/analyse/src/keyboard.ts
+++ b/ui/analyse/src/keyboard.ts
@@ -102,7 +102,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
   return h('div.lichess_overboard.keyboard_help', {
     hook: {
       insert: vnode => {
-        window.lichess.loadCss('/assets/stylesheets/keyboard.css')
+        window.lichess.loadCss('stylesheets/keyboard.css')
         $(vnode.elm as HTMLElement).find('.scrollable').load('/analysis/help?study=' + (ctrl.study ? 1 : 0));
       }
     }

--- a/ui/analyse/src/study/chapterDescription.ts
+++ b/ui/analyse/src/study/chapterDescription.ts
@@ -64,7 +64,7 @@ export function view(study: StudyCtrl): VNode | undefined {
 function edit(ctrl: ChapterDescriptionCtrl, chapterId: string): VNode {
   return h('div.chapter_desc_form.underboard_form', {
     hook: {
-      insert: _ => window.lichess.loadCss('/assets/stylesheets/material.form.css')
+      insert: _ => window.lichess.loadCss('stylesheets/material.form.css')
     }
   }, [
     h('p.title', [

--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -152,7 +152,7 @@ export function view(ctrl): VNode {
           hook: {
             insert: vnode => {
               $.when(
-                window.lichess.loadScript('/assets/compiled/lichess.editor.min.js'),
+                window.lichess.loadScript('compiled/lichess.editor.min.js'),
                 $.get('/editor.json', {
                   fen: ctrl.root.node.fen
                 })

--- a/ui/analyse/src/study/commentForm.ts
+++ b/ui/analyse/src/study/commentForm.ts
@@ -106,7 +106,7 @@ export function view(root: AnalyseCtrl): VNode {
 
   return h('div.study_comment_form.underboard_form', {
     hook: {
-      insert: _ => window.lichess.loadCss('/assets/stylesheets/material.form.css')
+      insert: _ => window.lichess.loadCss('stylesheets/material.form.css')
     }
   }, [
     currentComments(root, !study.members.canContribute()),

--- a/ui/analyse/src/study/dialog.ts
+++ b/ui/analyse/src/study/dialog.ts
@@ -12,7 +12,7 @@ interface Dialog {
 export function form(d: Dialog): VNode {
   return h('div.lichess_overboard.study_overboard.' + d.class, {
     hook: {
-      insert() { window.lichess.loadCss('/assets/stylesheets/material.form.css') }
+      insert() { window.lichess.loadCss('stylesheets/material.form.css') }
     }
   }, ([
     h('a.close.icon', {

--- a/ui/analyse/src/study/gamebook/gamebookEdit.ts
+++ b/ui/analyse/src/study/gamebook/gamebookEdit.ts
@@ -92,7 +92,7 @@ export function render(ctrl: AnalyseCtrl): VNode {
   ];
 
   return h('div.gamebook_wrap', {
-    hook: { insert: _ => window.lichess.loadCss('/assets/stylesheets/gamebook.edit.css') }
+    hook: { insert: _ => window.lichess.loadCss('stylesheets/gamebook.edit.css') }
   }, [
     h('div.gamebook', content)
   ]);

--- a/ui/analyse/src/study/gamebook/gamebookPlayView.ts
+++ b/ui/analyse/src/study/gamebook/gamebookPlayView.ts
@@ -16,7 +16,7 @@ export function render(ctrl: GamebookPlayCtrl): VNode {
   comment = state.comment || defaultComments[state.feedback];
 
   return h('div.gamebook', {
-    hook: { insert: _ => window.lichess.loadCss('/assets/stylesheets/gamebook.play.css') }
+    hook: { insert: _ => window.lichess.loadCss('stylesheets/gamebook.play.css') }
   }, [
     comment ? h('div.comment', {
       class: { hinted: state.showHint }
@@ -30,7 +30,7 @@ export function render(ctrl: GamebookPlayCtrl): VNode {
         attrs: {
           width: 120,
           height: 120,
-          src: window.lichess.assetUrl('/assets/images/mascot/octopus.svg')
+          src: window.lichess.assetUrl('images/mascot/octopus.svg')
         }
       })
     ])

--- a/ui/analyse/src/study/serverEval.ts
+++ b/ui/analyse/src/study/serverEval.ts
@@ -78,7 +78,7 @@ export function view(ctrl: ServerEvalCtrl): VNode {
       insert(vnode) {
         ctrl.lastPly(false);
         li.requestIdleCallback(() => {
-          li.loadScript('/assets/javascripts/chart/acpl.js').then(() => {
+          li.loadScript('javascripts/chart/acpl.js').then(() => {
             li.advantageChart(ctrl.root.data, ctrl.root.trans, vnode.elm as HTMLElement);
             ctrl.chartEl(vnode.elm as HTMLElement);
           });

--- a/ui/analyse/src/study/studyChapters.ts
+++ b/ui/analyse/src/study/studyChapters.ts
@@ -90,7 +90,7 @@ export function view(ctrl: StudyCtrl): VNode {
         });
       }
       if (window['Sortable']) makeSortable();
-      else window.lichess.loadScript('/assets/javascripts/vendor/Sortable.min.js').done(makeSortable);
+      else window.lichess.loadScript('javascripts/vendor/Sortable.min.js').done(makeSortable);
     }
   }
 

--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -51,7 +51,7 @@ export function view(ctrl): VNode {
   }
   return h('div.study_share.underboard_form.box', {
     hook: {
-      insert() { window.lichess.loadCss('/assets/stylesheets/material.form.css') }
+      insert() { window.lichess.loadCss('stylesheets/material.form.css') }
     }
   }, [
     h('div.downloads', [

--- a/ui/analyse/src/study/studyTour.ts
+++ b/ui/analyse/src/study/studyTour.ts
@@ -2,7 +2,7 @@ import AnalyseCtrl from '../ctrl';
 import { Tab } from './interfaces';
 
 export function study(ctrl: AnalyseCtrl) {
-  window.lichess.loadScript('/assets/javascripts/study/tour.js').then(() => {
+  window.lichess.loadScript('javascripts/study/tour.js').then(() => {
     window.lichess['studyTour']({
       userId: ctrl.opts.userId,
       isContrib: ctrl.study!.members.canContribute(),
@@ -15,7 +15,7 @@ export function study(ctrl: AnalyseCtrl) {
 }
 
 export function chapter(setTab: (tab: string) => void) {
-  window.lichess.loadScript('/assets/javascripts/study/tour-chapter.js').then(() => {
+  window.lichess.loadScript('javascripts/study/tour-chapter.js').then(() => {
     window.lichess['studyTourChapter']({
       setTab
     });

--- a/ui/analyse/src/study/studyXhr.ts
+++ b/ui/analyse/src/study/studyXhr.ts
@@ -21,7 +21,7 @@ export function variants() {
 
 export function glyphs() {
   return $.ajax({
-    url: window.lichess.assetUrl('/assets/glyphs.json', { noVersion: true }),
+    url: window.lichess.assetUrl('glyphs.json', { noVersion: true }),
     headers,
     cache: true
   });

--- a/ui/analyse/src/view.ts
+++ b/ui/analyse/src/view.ts
@@ -245,7 +245,7 @@ function renderChapterName(ctrl: AnalyseCtrl) {
   if (ctrl.embed && ctrl.study) return h('div.chapter_name', ctrl.study.currentChapter().name);
 }
 
-const innerCoordsCss = '/assets/stylesheets/board.coords.inner.css';
+const innerCoordsCss = 'stylesheets/board.coords.inner.css';
 
 function forceInnerCoords(ctrl: AnalyseCtrl, v: boolean) {
   const pref = ctrl.data.pref.coords;

--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -30,7 +30,7 @@ export default function(opts: CevalOpts): CevalCtrl {
   const hovering = prop<Hovering | null>(null);
   const isDeeper = prop(false);
 
-  const sfPath = '/assets/vendor/stockfish/stockfish';
+  const sfPath = 'vendor/stockfish/stockfish';
   const pool = new Pool({
     asmjs: li.assetUrl(sfPath + '.js', {sameDomain: true}),
     pnacl: pnaclSupported && li.assetUrl(sfPath + '.nmf'),

--- a/ui/chat/src/ctrl.ts
+++ b/ui/chat/src/ctrl.ts
@@ -74,7 +74,7 @@ export default function(opts: ChatOpts, redraw: Redraw): Ctrl {
       send: li.pubsub.emit('socket.send'),
       redraw
     }) : undefined;
-    if (canMod()) opts.loadCss('/assets/stylesheets/chat.mod.css');
+    if (canMod()) opts.loadCss('stylesheets/chat.mod.css');
   }
   instanciateModeration();
 

--- a/ui/dasher/src/langs.ts
+++ b/ui/dasher/src/langs.ts
@@ -32,7 +32,7 @@ export function ctrl(data: LangsData, trans: Trans, redraw: Redraw, close: Close
     data,
     list: () => list,
     load() {
-      get(window.lichess.assetUrl('/assets/trans/refs.json'), true).then(d => {
+      get(window.lichess.assetUrl('trans/refs.json'), true).then(d => {
         const accs: Lang[] = [];
         const others: Lang[] = [];
         d.forEach((l: Lang) => {

--- a/ui/editor/src/view.js
+++ b/ui/editor/src/view.js
@@ -286,7 +286,7 @@ function makeCursor(selected) {
   if (selected === 'pointer') return 'pointer';
 
   var name = selected === 'trash' ? 'trash' : selected.join('-');
-  var url = lichess.assetUrl('/assets/cursors/' + name + '.cur');
+  var url = lichess.assetUrl('cursors/' + name + '.cur');
 
   return 'url(' + url + '), default !important';
 }

--- a/ui/lobby/src/boot.js
+++ b/ui/lobby/src/boot.js
@@ -429,7 +429,7 @@ module.exports = function(cfg, element) {
   }
 
   $startButtons.find('a').not('.disabled').on('mousedown', function() {
-    lichess.loadCss('/assets/stylesheets/setup.css');
+    lichess.loadCss('stylesheets/setup.css');
     lobby.leavePool();
     $.ajax({
       url: $(this).attr('href'),

--- a/ui/lobby/src/socket.ts
+++ b/ui/lobby/src/socket.ts
@@ -55,7 +55,7 @@ export default class LobbySocket {
 
     li.pubsub.on('sound_set', (set: string) => {
       if (!this.music && set === 'music')
-        li.loadScript('/assets/javascripts/music/lobby.js').then(() => {
+        li.loadScript('javascripts/music/lobby.js').then(() => {
           this.music = window['lichessLobbyMusic']();
           ctrl.setMode('chart');
         });

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -111,7 +111,7 @@ export default class RoundController {
 
     li.pubsub.on('sound_set', set => {
       if (!this.music && set === 'music')
-        li.loadScript('/assets/javascripts/music/play.js').then(() => {
+        li.loadScript('javascripts/music/play.js').then(() => {
           this.music = window.lichessPlayMusic();
         });
         if (this.music && set !== 'music') this.music = undefined;

--- a/ui/round/src/keyboardMove.ts
+++ b/ui/round/src/keyboardMove.ts
@@ -64,7 +64,7 @@ export function render(ctrl: KeyboardMove) {
       },
       hook: {
         insert: vnode => {
-          window.lichess.loadScript('/assets/javascripts/keyboardMove.js').then(() => {
+          window.lichess.loadScript('javascripts/keyboardMove.js').then(() => {
             ctrl.registerHandler(window.lichess.keyboardMove({
               input: vnode.elm,
               setFocus: ctrl.setFocus,

--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -131,8 +131,8 @@ lichess.topMenuIntent = function() {
 
   lichess.userAutocomplete = function($input, opts) {
     opts = opts || {};
-    lichess.loadCss('/assets/stylesheets/autocomplete.css');
-    return lichess.loadScript('/assets/javascripts/vendor/typeahead.jquery.min.js', {noVersion:true}).done(function() {
+    lichess.loadCss('stylesheets/autocomplete.css');
+    return lichess.loadScript('javascripts/vendor/typeahead.jquery.min.js', {noVersion:true}).done(function() {
       $input.typeahead(null, {
         minLength: opts.minLength || 3,
         hint: true,
@@ -317,8 +317,8 @@ lichess.topMenuIntent = function() {
           booted = true;
           var $el = $('#challenge_app').html(lichess.initiatingHtml);
           var isDev = $('body').data('dev');
-          lichess.loadCss('/assets/stylesheets/challengeApp.css');
-          lichess.loadScript("/assets/compiled/lichess.challenge" + (isDev ? '' : '.min') + '.js').done(function() {
+          lichess.loadCss('stylesheets/challengeApp.css');
+          lichess.loadScript('compiled/lichess.challenge' + (isDev ? '' : '.min') + '.js').done(function() {
             instance = LichessChallenge.default($el[0], {
               data: data,
               show: function() {
@@ -356,8 +356,8 @@ lichess.topMenuIntent = function() {
           booted = true;
           var $el = $('#notify_app').html(lichess.initiatingHtml);
           var isDev = $('body').data('dev');
-          lichess.loadCss('/assets/stylesheets/notifyApp.css');
-          lichess.loadScript("/assets/compiled/lichess.notify" + (isDev ? '' : '.min') + '.js').done(function() {
+          lichess.loadCss('stylesheets/notifyApp.css');
+          lichess.loadScript('compiled/lichess.notify' + (isDev ? '' : '.min') + '.js').done(function() {
             instance = LichessNotify.default($el.empty()[0], {
               data: data,
               incoming: incoming,
@@ -457,8 +457,8 @@ lichess.topMenuIntent = function() {
           var $el = $('#dasher_app').html(lichess.initiatingHtml);
           var isDev = $('body').data('dev');
           var isPlaying = $('body').hasClass('playing');
-          lichess.loadCss('/assets/stylesheets/dasherApp.css');
-          lichess.loadScript("/assets/compiled/lichess.dasher" + (isDev ? '' : '.min') + '.js').done(function() {
+          lichess.loadCss('stylesheets/dasherApp.css');
+          lichess.loadScript('compiled/lichess.dasher' + (isDev ? '' : '.min') + '.js').done(function() {
             instance = LichessDasher.default($el.empty()[0], {
               setZoom: setZoom,
               playing: isPlaying
@@ -475,8 +475,8 @@ lichess.topMenuIntent = function() {
         var boot = function() {
           if (booted) return;
           booted = true;
-          lichess.loadCss('/assets/stylesheets/cli.css');
-          lichess.loadScript("/assets/compiled/lichess.cli" + ($('body').data('dev') ? '' : '.min') + '.js').done(function() {
+          lichess.loadCss('stylesheets/cli.css');
+          lichess.loadScript('compiled/lichess.cli' + ($('body').data('dev') ? '' : '.min') + '.js').done(function() {
             LichessCli.app($wrap, toggle);
           });
         }
@@ -584,7 +584,7 @@ lichess.topMenuIntent = function() {
               .attr('action', '/login?referrer=' + window.location.pathname);
           }));
         }
-        lichess.loadCss('/assets/stylesheets/fpmenu.css');
+        lichess.loadCss('stylesheets/fpmenu.css');
       }).click(function() {
         document.body.classList.toggle('fpmenu');
       });
@@ -669,7 +669,7 @@ lichess.topMenuIntent = function() {
         };
         set = 'standard';
       }
-      var baseUrl = lichess.assetUrl('/assets/sound', {noVersion:true});
+      var baseUrl = lichess.assetUrl('sound', {noVersion: true});
       return new Howl({
         src: ['ogg', 'mp3'].map(function(ext) {
           return [baseUrl, set, names[k] + '.' + ext].join('/');

--- a/ui/site/src/util.js
+++ b/ui/site/src/util.js
@@ -217,7 +217,7 @@ lichess.assetUrl = function(url, opts) {
   opts = opts || {};
   var baseUrl = opts.sameDomain ? '' : document.body.getAttribute('data-asset-url');
   var version = document.body.getAttribute('data-asset-version');
-  return baseUrl + url + (opts.noVersion ? '' : '?v=' + version);
+  return baseUrl + '/assets/' + url + (opts.noVersion ? '' : '?v=' + version);
 };
 lichess.loadedCss = {};
 lichess.loadCss = function(url) {
@@ -241,19 +241,19 @@ lichess.loadScript = function(url, opts) {
   });
 };
 lichess.hopscotch = function(f) {
-  lichess.loadCss('/assets/vendor/hopscotch/dist/css/hopscotch.min.css');
-  lichess.loadScript("/assets/vendor/hopscotch/dist/js/hopscotch.min.js", {noVersion:true}).done(f);
+  lichess.loadCss('vendor/hopscotch/dist/css/hopscotch.min.css');
+  lichess.loadScript('vendor/hopscotch/dist/js/hopscotch.min.js', {noVersion:true}).done(f);
 }
 lichess.slider = function() {
-  lichess.loadCss('/assets/stylesheets/jquery-ui.css');
-  return lichess.loadScript('/assets/javascripts/vendor/jquery-ui.slider.min.js', {noVersion:true});
+  lichess.loadCss('stylesheets/jquery-ui.css');
+  return lichess.loadScript('javascripts/vendor/jquery-ui.slider.min.js', {noVersion:true});
 };
 lichess.shepherd = function(f) {
   var theme = 'shepherd-theme-' + ($('body').hasClass('dark') ? 'default' : 'dark');
-  lichess.loadCss('/assets/vendor/shepherd/dist/css/' + theme + '.css');
-  lichess.loadCss('/assets/stylesheets/shepherd.css');
-  lichess.loadScript("/assets/vendor/shepherd/dist/js/tether.js", {noVersion:true}).done(function() {
-    lichess.loadScript("/assets/vendor/shepherd/dist/js/shepherd.min.js", {noVersion:true}).done(function() {
+  lichess.loadCss('vendor/shepherd/dist/css/' + theme + '.css');
+  lichess.loadCss('stylesheets/shepherd.css');
+  lichess.loadScript('vendor/shepherd/dist/js/tether.js', {noVersion:true}).done(function() {
+    lichess.loadScript('vendor/shepherd/dist/js/shepherd.min.js', {noVersion:true}).done(function() {
       f(theme);
     });
   });

--- a/ui/site/src/util.js
+++ b/ui/site/src/util.js
@@ -213,11 +213,11 @@ lichess.isTrident = navigator.userAgent.indexOf('Trident/') > -1;
 lichess.isChrome = navigator.userAgent.indexOf('Chrome/') > -1;
 lichess.spinnerHtml = '<div class="spinner"><svg viewBox="0 0 40 40"><circle cx=20 cy=20 r=18 fill="none"></circle></svg></div>';
 lichess.initiatingHtml = '<div class="initiating">' + lichess.spinnerHtml + '</div>';
-lichess.assetUrl = function(url, opts) {
+lichess.assetUrl = function(path, opts) {
   opts = opts || {};
   var baseUrl = opts.sameDomain ? '' : document.body.getAttribute('data-asset-url');
   var version = document.body.getAttribute('data-asset-version');
-  return baseUrl + '/assets/' + url + (opts.noVersion ? '' : '?v=' + version);
+  return baseUrl + '/assets' + (opts.noVersion ? '' : '/' + version) + '/' + path;
 };
 lichess.loadedCss = {};
 lichess.loadCss = function(url) {

--- a/ui/tournament/src/view/finished.ts
+++ b/ui/tournament/src/view/finished.ts
@@ -13,7 +13,7 @@ function confetti(data: TournamentData): VNode | undefined {
   if (data.me && data.isRecentlyFinished && window.lichess.once('tournament.end.canvas.' + data.id))
   return h('canvas#confetti', {
     hook: {
-      insert: _ => window.lichess.loadScript('/assets/javascripts/confetti.js')
+      insert: _ => window.lichess.loadScript('javascripts/confetti.js')
     }
   });
 }

--- a/ui/tournament/src/view/header.ts
+++ b/ui/tournament/src/view/header.ts
@@ -50,7 +50,7 @@ function image(d): VNode | undefined {
   if (hasFreq('shield', d) || hasFreq('marathon', d)) return;
   const s = d.spotlight;
   if (s && s.iconImg) return h('img.img', {
-    attrs: { src: window.lichess.assetUrl('/assets/images/' + s.iconImg) }
+    attrs: { src: window.lichess.assetUrl('images/' + s.iconImg) }
   });
   return h('i.img', {
     attrs: dataIcon((s && s.iconFont) || 'g')


### PR DESCRIPTION
Cloudflare provides 0-rtt, but only for GET requests without query strings. This switches `assets/foo?v=42` to `assets/42/foo`. Goes along with

```
  location /assets {
    rewrite ^/assets/\d+/(.*)$ /assets/$1;
    # ...
  }
```

in nginx.

Needs more testing and perhaps discussion.

Also a minor issue is that I couldn't find a nice way to ignore the version segment in the router yet (https://github.com/ornicar/lila/compare/master...niklasf:0rtt-assets?expand=1#diff-93c1ebbcb555c5f7d8ee08519974efa6R615).