### PR TITLE
fix capcha error display and buttons aligment on qa page

### DIFF
--- a/app/views/qa/ask.scala.html
+++ b/app/views/qa/ask.scala.html
@@ -20,9 +20,7 @@ side = popularBox(popular).some) {
   <form class="wide question" action="@routes.QaQuestion.ask()" method="post">
     @questionForm(form, tags, captcha)
     <button type="submit" class="pure submit button" data-icon="E"> Post your question</button>
-    <br />
-    <br />
-    <a href="@routes.QaQuestion.index()">@trans.cancel()</a>
+    <a href="@routes.QaQuestion.index()" style="margin-left:20px">@trans.cancel()</a>
   </form>
 </div>
 }

--- a/app/views/qa/edit.scala.html
+++ b/app/views/qa/edit.scala.html
@@ -21,9 +21,7 @@ side = popularBox(popular).some) {
   <form class="wide question" action="@routes.QaQuestion.doEdit(q.id)" method="post">
     @questionForm(form, tags, captcha)
     <button type="submit" class="pure submit button" data-icon="E"> Update your question</button>
-    <br />
-    <br />
-    <a href="@routes.QaQuestion.show(q.id, q.slug)">@trans.cancel()</a>
+    <a href="@routes.QaQuestion.show(q.id, q.slug)" style="margin-left:20px">@trans.cancel()</a>
   </form>
 </div>
 }

--- a/app/views/qa/questionForm.scala.html
+++ b/app/views/qa/questionForm.scala.html
@@ -17,3 +17,4 @@
   <div class="tags_list"></div>
 </div>
 @base.captcha(form("move"), form("gameId"), captcha)
+@errMsg(form)


### PR DESCRIPTION
Hi! I have added to qa form. (https://lichess.org/qa/ask)

Error message for capcha is not displayed on qa form.
Cancel button is under "Post or update your question"

**Note:** we use inline css margin-left:20px in many places. Probably we should define a class for all c"cancel" buttons :) 