### PR TITLE
Fix missing paren in socket handler

### DIFF
--- a/modules/socket/src/main/Handler.scala
+++ b/modules/socket/src/main/Handler.scala
@@ -93,7 +93,7 @@ object Handler {
         // Unfortunately this map function is only called
         // if the JS closes the socket with lichess.socket.disconnect()
         // but not if the tab is closed or browsed away!
-        .map(_ => socket ! Quit(uid)
+        .map(_ => socket ! Quit(uid))
     }
 
     socket ? join map connecter map {


### PR DESCRIPTION
Project won't compile without it.

It was deleted by mistake here: https://github.com/ornicar/lila/commit/cc0010dd7a212851646f48933af0e997289acbc0