### PR TITLE
Make plan.build optional

### DIFF
--- a/modules/tournament/src/main/Schedule.scala
+++ b/modules/tournament/src/main/Schedule.scala
@@ -53,15 +53,15 @@ case class Schedule(
 
   def perfType = PerfType.byVariant(variant) | Schedule.Speed.toPerfType(speed)
 
-  def plan = Schedule.Plan(this, identity)
-  def plan(build: Tournament => Tournament) = Schedule.Plan(this, build)
+  def plan = Schedule.Plan(this, None)
+  def plan(build: Tournament => Tournament) = Schedule.Plan(this, build.some)
 
   override def toString = s"$freq $variant $speed $conditions $at"
 }
 
 object Schedule {
 
-  case class Plan(schedule: Schedule, build: Tournament => Tournament)
+  case class Plan(schedule: Schedule, build: Option[Tournament => Tournament])
 
   sealed abstract class Freq(val id: Int, val importance: Int) extends Ordered[Freq] {
 

--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -76,7 +76,7 @@ final class TournamentApi(
 
   private[tournament] def createFromPlan(plan: Schedule.Plan): Funit = {
     val minutes = Schedule durationFor plan.schedule
-    val tournament = plan build Tournament.schedule(plan.schedule, minutes)
+    val tournament = plan.build.foldRight(Tournament.schedule(plan.schedule, minutes)) { _(_) }
     logger.info(s"Create $tournament")
     TournamentRepo.insert(tournament).void
   }


### PR DESCRIPTION
identity creates a lambda closure that has a gibberish toString
method, making it difficult to read the Plan case object.