### PR TITLE
Tournament scheduling rewrite

### DIFF
--- a/modules/tournament/src/main/Condition.scala
+++ b/modules/tournament/src/main/Condition.scala
@@ -131,7 +131,9 @@ object Condition {
 
     def sameMaxRating(other: All) = maxRating.map(_.rating) == other.maxRating.map(_.rating)
     def sameMinRating(other: All) = minRating.map(_.rating) == other.minRating.map(_.rating)
-    def sameRatings(other: All) = sameMinRating(other) && sameMaxRating(other)
+    def sameRatings(other: All) = sameMaxRating(other) && sameMinRating(other)
+
+    def similar(other: All) = sameRatings(other) && titled == other.titled && teamMember == other.teamMember
 
     def isRatingLimited = maxRating.isDefined || minRating.isDefined
   }

--- a/modules/tournament/src/main/Schedule.scala
+++ b/modules/tournament/src/main/Schedule.scala
@@ -44,6 +44,8 @@ case class Schedule(
 
   def sameMaxRating(other: Schedule) = conditions sameMaxRating other.conditions
 
+  def similarConditions(other: Schedule) = conditions similar other.conditions
+
   def sameDay(other: Schedule) = day == other.day
 
   def hasMaxRating = conditions.maxRating.isDefined
@@ -61,7 +63,13 @@ case class Schedule(
 
 object Schedule {
 
-  case class Plan(schedule: Schedule, build: Option[Tournament => Tournament])
+  case class Plan(schedule: Schedule, buildFunc: Option[Tournament => Tournament]) {
+
+    def build: Tournament = {
+      val t = Tournament.schedule(addCondition(schedule), durationFor(schedule))
+      buildFunc.foldRight(t) { _(_) }
+    }
+  }
 
   sealed abstract class Freq(val id: Int, val importance: Int) extends Ordered[Freq] {
 

--- a/modules/tournament/src/main/Tournament.scala
+++ b/modules/tournament/src/main/Tournament.scala
@@ -83,7 +83,7 @@ case class Tournament(
 
   def duration = new Duration(minutes * 60 * 1000)
 
-  def interval = new Interval(startsAt, finishesAt)
+  def interval = new Interval(startsAt, duration)
 
   def overlaps(other: Tournament) = interval overlaps other.interval
 

--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -74,9 +74,7 @@ final class TournamentApi(
     TournamentRepo.insert(tour) >>- join(tour.id, me, tour.password, getUserTeamIds) inject tour
   }
 
-  private[tournament] def createFromPlan(plan: Schedule.Plan): Funit = {
-    val minutes = Schedule durationFor plan.schedule
-    val tournament = plan.build.foldRight(Tournament.schedule(plan.schedule, minutes)) { _(_) }
+  private[tournament] def create(tournament: Tournament): Funit = {
     logger.info(s"Create $tournament")
     TournamentRepo.insert(tournament).void
   }


### PR DESCRIPTION
- Use actual durations when looking for conflicts with saved
  tournaments
- Restrict overlap to require same minRating, maxRating and titled
  entry conditions
- Misc optimizations