### PR TITLE
Tablebase robustness for practice

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -211,7 +211,7 @@ declare namespace Tree {
     threat?: ClientEval;
     ceval?: ClientEval;
     eval?: ServerEval;
-    tbhit?: TablebaseHit;
+    tbhit: TablebaseHit | undefined | null;
     opening?: Opening;
     glyphs?: Glyph[];
     clock?: Clock;

--- a/ui/analyse/src/explorer/explorerCtrl.ts
+++ b/ui/analyse/src/explorer/explorerCtrl.ts
@@ -13,32 +13,26 @@ function pieceCount(fen: Fen) {
   return parts[0].split(/[nbrqkp]/i).length - 1;
 }
 
-export function tablebaseGuaranteed(variant: VariantKey, fen: Fen) {
+function tablebasePieces(variant: VariantKey) {
   switch (variant) {
     case 'standard':
     case 'fromPosition':
     case 'chess960':
+      return 7;
     case 'atomic':
     case 'antichess':
-      return pieceCount(fen) <= 6;
+      return 6;
     default:
-      return false;
+      return 0;
   }
 }
 
+export function tablebaseGuaranteed(variant: VariantKey, fen: Fen) {
+  return pieceCount(fen) <= tablebasePieces(variant);
+}
+
 function tablebaseRelevant(variant: VariantKey, fen: Fen) {
-  const count = pieceCount(fen);
-  switch (variant) {
-    case 'standard':
-    case 'fromPosition':
-    case 'chess960':
-      return count <= 8;
-    case 'atomic':
-    case 'antichess':
-      return count <= 7;
-    default:
-      return false;
-  }
+  return pieceCount(fen) - 1 <= tablebasePieces(variant);
 }
 
 export default function(root: AnalyseCtrl, opts, allow: boolean): ExplorerCtrl {

--- a/ui/analyse/src/explorer/explorerCtrl.ts
+++ b/ui/analyse/src/explorer/explorerCtrl.ts
@@ -148,6 +148,7 @@ export default function(root: AnalyseCtrl, opts, allow: boolean): ExplorerCtrl {
     fetchTablebaseHit(fen: Fen): JQueryPromise<SimpleTablebaseHit> {
       return xhr.tablebase(opts.tablebaseEndpoint, effectiveVariant, fen).then((res: TablebaseData) => {
         const move = res.moves[0];
+        if (move && move.dtz == null) throw 'unknown tablebase position';
         return {
           fen: fen,
           best: move && move.uci,

--- a/ui/analyse/src/practice/practiceCtrl.ts
+++ b/ui/analyse/src/practice/practiceCtrl.ts
@@ -5,7 +5,7 @@ import { detectThreefold } from '../nodeFinder';
 import { tablebaseGuaranteed } from '../explorer/explorerCtrl';
 import AnalyseCtrl from '../ctrl';
 import { Redraw } from '../interfaces';
-import { prop, Prop } from 'common';
+import { defined, prop, Prop } from 'common';
 
 export interface Comment {
   prev: Tree.Node;
@@ -81,7 +81,7 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
     e8h8: 'e8g8'
   };
 
-  function tbhitToEval(hit: Tree.TablebaseHit | undefined) {
+  function tbhitToEval(hit: Tree.TablebaseHit | undefined | null) {
     return hit && (
       hit.winner ? {
         mate: hit.winner === 'white' ? 10 : -10
@@ -136,7 +136,7 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
       comment(null);
       return root.redraw();
     }
-    if (tablebaseGuaranteed(variant, node.fen) && !node.tbhit) return;
+    if (tablebaseGuaranteed(variant, node.fen) && !defined(node.tbhit)) return;
     ensureCevalRunning();
     if (isMyTurn()) {
       const h = hinting();
@@ -171,6 +171,9 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
   function checkCevalOrTablebase() {
     if (tablebaseGuaranteed(variant, root.node.fen)) root.explorer.fetchTablebaseHit(root.node.fen).then(hit => {
       if (hit && root.node.fen === hit.fen) root.node.tbhit = hit;
+      checkCeval();
+    }, () => {
+      if (!defined(root.node.tbhit)) root.node.tbhit = null;
       checkCeval();
     });
     else checkCeval();


### PR DESCRIPTION
Currently if `node.tbhit` is `undefined` the tablebase was not yet queried. Now additionally set it to `null` if it was queried but failed. In that case recover by using ceval.

Also treat successful requests with unknown outcome as errors. This allows us to use the partially complete 7 piece tablebase today.