### PR TITLE
issue-2103: check browser and notify about unsupported

### DIFF
--- a/app/views/base/layout.scala.html
+++ b/app/views/base/layout.scala.html
@@ -100,6 +100,12 @@ csp: Option[lila.common.ContentSecurityPolicy] = None)(body: Html)(implicit ctx:
     }
     @lila.security.EmailConfirm.cookie.get(ctx.req).map(auth.emailConfirmBanner(_))
     @if(playing) { <a data-icon="E" id="zentog" class="text fbt active@if(!ctx.pref.isZen){ none}">ZEN MODE</a> }
+    <div id="unsupported_browser">
+      <div class="content">
+        @trans.unsupportedBrowser()
+        <a aria-label="Close" href="#">&times;</a>
+      </div>
+    </div>
     <div id="top" class="@if(ctx.pref.is3d){is3d}else{is2d}">
       @topmenu()
       <div id="ham-plate" class="link hint--bottom" data-hint="@trans.menu()">

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -747,6 +747,7 @@ val `availableInNbLanguages` = new Translated("availableInNbLanguages", Site)
 val `nbSecondsToPlayTheFirstMove` = new Translated("nbSecondsToPlayTheFirstMove", Site)
 val `nbSeconds` = new Translated("nbSeconds", Site)
 val `andSaveNbPremoveLines` = new Translated("andSaveNbPremoveLines", Site)
+val `unsupportedBrowser` = new Translated("unsupportedBrowser", Site)
 
 object arena {
 val `isItRated` = new Translated("isItRated", Arena)

--- a/public/stylesheets/common.css
+++ b/public/stylesheets/common.css
@@ -1944,3 +1944,27 @@ body ::-webkit-scrollbar-thumb:active {
 body ::-webkit-scrollbar-track {
   box-shadow: 0 0 6px rgba(50, 50, 50, 0.3) inset;
 }
+#unsupported_browser {
+  display: none;
+  width: 100%;
+  position: fixed;
+  text-align: center;
+  background-color: rgba(0,0,0,.8);
+  color: #dc322f;
+  z-index: 4;
+  bottom: 0;
+  padding-top: 5px;
+}
+#unsupported_browser .content {
+  margin: 0 auto;
+  width: 1005px;
+}
+#unsupported_browser a {
+  position: relative;
+  top: -5px;
+  right: auto;
+  font-size: large;
+  cursor: pointer;
+  color: white;
+  float: right;
+}

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -846,4 +846,5 @@ in %3$s</string>
     <item quantity="one">and save %s premove line</item>
     <item quantity="other">and save %s premove lines</item>
   </plurals>
+  <string name="unsupportedBrowser">You are using an unsupported browser or browser version. Some features may work incorrectly.</string>
 </resources>

--- a/ui/site/package.json
+++ b/ui/site/package.json
@@ -21,6 +21,7 @@
     "vinyl-source-stream": "^1"
   },
   "dependencies": {
+    "bowser": "^2.0.0-alpha.4",
     "tablesort": "^5.0.0"
   }
 }

--- a/ui/site/src/browser-verifier.js
+++ b/ui/site/src/browser-verifier.js
@@ -1,6 +1,6 @@
 (function() {
-  const bowser = require('bowser');
-  const browser = bowser.getParser(window.navigator.userAgent);
+  var bowser = require('bowser');
+  var browser = bowser.getParser(window.navigator.userAgent);
 
   if (browser.getPlatformType() === 'desktop' && !supportBrowser(browser)) {
     $('#unsupported_browser a').click(function(e) {

--- a/ui/site/src/browser-verifier.js
+++ b/ui/site/src/browser-verifier.js
@@ -1,0 +1,23 @@
+(function() {
+  const bowser = require('bowser');
+  const browser = bowser.getParser(window.navigator.userAgent);
+
+  if (browser.getPlatformType() === 'desktop' && !supportBrowser(browser)) {
+    $('#unsupported_browser a').click(function(e) {
+      e.preventDefault();
+      $('#unsupported_browser').hide();
+    });
+    $('#unsupported_browser').show();
+  }
+
+  function supportBrowser(browser) {
+    return browser.satisfies({
+      chrome: '>44',
+      firefox: '>43',
+      opera: ">34",
+      safari: ">9",
+      'Internet Explorer': '>10.99',
+      edge: '>12'
+    });
+  }
+})();

--- a/ui/site/src/index.js
+++ b/ui/site/src/index.js
@@ -1,4 +1,5 @@
 require('./util');
+require('./browser-verifier');
 require('./timeago');
 require('./trans');
 require('./socket');

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,6 +391,10 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
+bowser@^2.0.0-alpha.4:
+  version "2.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.0.0-alpha.4.tgz#4897ef9714030e083481c5bfaf8b59aa0a467827"
+
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
Implemented issue https://github.com/ornicar/lila/issues/2103  
I have investigated top site behavior on mobile devices -> they redirect to mobile site version or support adaptive design. 
Now implementation and warning only for desktop versions and look like(we can change text, colors or position):

![2018-08-17 15 27 27](https://user-images.githubusercontent.com/10829386/44266129-13db3e00-a232-11e8-875c-c77501fd883e.jpg)

Also a question :) Should I save in cookies a close action and don't show it again for users who dismissed? 
Comments are welcome!