### PR TITLE
Remove overflow:hidden for watchers, caused cutoff

### DIFF
--- a/public/stylesheets/board.css
+++ b/public/stylesheets/board.css
@@ -893,7 +893,6 @@ div.under_chat .watchers {
   opacity: 0.65;
   transition: 0.13s;
   height: 9em;
-  overflow: hidden;
 }
 div.under_chat .watchers.hidden {
   visibility: hidden;


### PR DESCRIPTION
Spotted a while back, issue posted in the discord when noticed. Can't find that image now, but LovelyByte#1604 noticed it a bunch more times recently.
Screenshot:
![image](https://user-images.githubusercontent.com/31519537/44303994-7d993c00-a347-11e8-844a-c986b9aa3964.png)
