### PR TITLE
disable highly consistent move time/streaks to 1+0

### DIFF
--- a/modules/evaluation/src/main/Assessible.scala
+++ b/modules/evaluation/src/main/Assessible.scala
@@ -47,7 +47,7 @@ case class Assessible(analysed: Analysed) {
     highestChunkBlurs(color) >= 7
 
   def highlyConsistentMoveTimes(color: Color): Boolean =
-    if (game.clock.forall(_.estimateTotalSeconds > 40))
+    if (game.clock.forall(_.estimateTotalSeconds > 60))
       moveTimeCoefVariation(Pov(game, color)) ?? { cvIndicatesHighlyFlatTimes(_) }
     else
       false
@@ -55,9 +55,12 @@ case class Assessible(analysed: Analysed) {
   // moderatelyConsistentMoveTimes must stay in Statistics because it's used in classes that do not use Assessible
 
   def highlyConsistentMoveTimeStreaks(color: Color): Boolean =
-    slidingMoveTimesCvs(Pov(game, color)) ?? {
-      _ exists cvIndicatesHighlyFlatTimesForStreaks
-    }
+    if (game.clock.forall(_.estimateTotalSeconds > 60))
+      slidingMoveTimesCvs(Pov(game, color)) ?? {
+        _ exists cvIndicatesHighlyFlatTimesForStreaks
+      }
+    else
+      false
 
   def moderatelyConsistentMoveTimeStreaks(color: Color): Boolean =
     slidingMoveTimesCvs(Pov(game, color)) ?? {


### PR DESCRIPTION
too many 1+0 games getting evaluated as :( or >:( because of this. so let's only keep that for games slower than 1+0, where it actually is useful