### PR TITLE
Up all values by 0.1s instead of 0.5s

### DIFF
--- a/modules/evaluation/src/main/Statistics.scala
+++ b/modules/evaluation/src/main/Statistics.scala
@@ -11,15 +11,15 @@ object Statistics {
     s.stdDev.map { _ / s.mean }
   }
 
-  // ups all values by 0.5s
+  // ups all values by 0.1s
   // as to avoid very high variation on bullet games
   // where all move times are low (https://lichess.org/@/AlisaP?mod)
   // and drops the first move because it's always 0
   def moveTimeCoefVariation(a: List[Centis]): Option[Float] =
-    coefVariation(a.drop(1).map(_.centis + 50))
+    coefVariation(a.drop(1).map(_.centis + 10))
 
   def moveTimeCoefVariationNoDrop(a: List[Centis]): Option[Float] =
-    coefVariation(a.map(_.centis + 50))
+    coefVariation(a.map(_.centis + 10))
 
   def moveTimeCoefVariation(pov: lila.game.Pov): Option[Float] =
     for {


### PR DESCRIPTION
Had a chat with isaac about this today. This could be the reason for the many bullet false positives. At least it's not needed for blitz and slower (and could even be harmful if you play very fast in Blitz).

This might allow for re-enabling of bullet high consistency mt detection later, but more testing on that will be needed.