### PR TITLE
Prevent game ID collisions (closes #4300)

### DIFF
--- a/app/controllers/UserAnalysis.scala
+++ b/app/controllers/UserAnalysis.scala
@@ -58,7 +58,7 @@ object UserAnalysis extends LilaController with TheftPrevention {
       mode = chess.Mode.Casual,
       source = lila.game.Source.Api,
       pgnImport = None
-    ).copy(id = "synthetic"),
+    ).withId("synthetic"),
     from.situation.color
   )
 

--- a/modules/challenge/src/main/Joiner.scala
+++ b/modules/challenge/src/main/Joiner.scala
@@ -40,7 +40,7 @@ private[challenge] final class Joiner(onStart: String => Unit) {
             source = if (chessGame.board.variant.fromPosition) Source.Position else Source.Friend,
             daysPerTurn = c.daysPerTurn,
             pgnImport = None
-          ).copy(id = c.id).|> { g =>
+          ).withId(c.id).|> { g =>
               state.fold(g) {
                 case sit @ SituationPlus(Situation(board, _), _) => g.copy(
                   chess = g.chess.copy(

--- a/modules/game/src/main/Game.scala
+++ b/modules/game/src/main/Game.scala
@@ -629,10 +629,10 @@ object Game {
     source: Source,
     pgnImport: Option[PgnImport],
     daysPerTurn: Option[Int] = None
-  ): Game = {
+  ): NewGame = {
     val createdAt = DateTime.now
-    Game(
-      id = IdGenerator.game,
+    NewGame(Game(
+      id = IdGenerator.uncheckedGame,
       whitePlayer = whitePlayer,
       blackPlayer = blackPlayer,
       chess = chess,
@@ -648,7 +648,7 @@ object Game {
       ),
       createdAt = createdAt,
       movedAt = createdAt
-    )
+    ))
   }
 
   object BSONFields {

--- a/modules/game/src/main/IdGenerator.scala
+++ b/modules/game/src/main/IdGenerator.scala
@@ -4,7 +4,15 @@ import ornicar.scalalib.Random
 
 object IdGenerator {
 
-  def uncheckedGame = Random nextString Game.gameIdSize
+  def uncheckedGame: Game.ID = Random nextString Game.gameIdSize
 
-  def player = Random secureString Game.playerIdSize
+  def game: Fu[Game.ID] = {
+    val id = uncheckedGame
+    GameRepo.exists(id).flatMap {
+      case true => game
+      case false => fuccess(id)
+    }
+  }
+
+  def player: Player.ID = Random secureString Game.playerIdSize
 }

--- a/modules/game/src/main/IdGenerator.scala
+++ b/modules/game/src/main/IdGenerator.scala
@@ -4,7 +4,7 @@ import ornicar.scalalib.Random
 
 object IdGenerator {
 
-  def game = Random nextString Game.gameIdSize
+  def uncheckedGame = Random nextString Game.gameIdSize
 
   def player = Random secureString Game.playerIdSize
 }

--- a/modules/game/src/main/NewGame.scala
+++ b/modules/game/src/main/NewGame.scala
@@ -1,0 +1,15 @@
+package lila.game
+
+// Wrapper around newly created games. We do not know if the id is unique, yet.
+case class NewGame(sloppy: Game) {
+  def withId(id: Game.ID): Game = sloppy.withId(id)
+  def withUniqueId: Fu[Game] = IdGenerator.game dmap { id => sloppy.withId(id) }
+
+  def start: NewGame = NewGame(sloppy.start)
+
+  // Forward methods as needed, but do not expose the unchecked id.
+  def variant = sloppy.variant
+  def finished = sloppy.finished
+  def winnerColor = sloppy.winnerColor
+  def status = sloppy.status
+}

--- a/modules/importer/src/main/DataForm.scala
+++ b/modules/importer/src/main/DataForm.scala
@@ -22,7 +22,7 @@ private[importer] final class DataForm {
 
 private[importer] case class Result(status: Status, winner: Option[Color])
 case class Preprocessed(
-    game: Game,
+    game: NewGame,
     replay: Replay,
     result: Result,
     initialFen: Option[FEN],

--- a/modules/importer/src/main/Importer.scala
+++ b/modules/importer/src/main/Importer.scala
@@ -29,7 +29,7 @@ final class Importer(
     gameExists {
       (data preprocess user).future flatMap {
         case Preprocessed(g, replay, result, initialFen, _) =>
-          val game = applyResult(forceId.fold(g)(g.withId), result, replay.state.situation)
+          val game = applyResult(forceId.fold(g.sloppy)(g.withId), result, replay.state.situation)
           (GameRepo.insertDenormalized(game, initialFen = initialFen)) >> {
             game.pgnImport.flatMap(_.user).isDefined ?? GameRepo.setImportCreatedAt(game)
           } >> {

--- a/modules/lobby/src/main/Biter.scala
+++ b/modules/lobby/src/main/Biter.scala
@@ -21,11 +21,11 @@ private[lobby] object Biter {
     userOption ← lobbyUserOption.map(_.id) ?? UserRepo.byId
     ownerOption ← hook.userId ?? UserRepo.byId
     creatorColor <- assignCreatorColor(ownerOption, userOption, hook.realColor)
-    game = makeGame(
+    game <- makeGame(
       hook,
       whiteUser = creatorColor.fold(ownerOption, userOption),
       blackUser = creatorColor.fold(userOption, ownerOption)
-    )
+    ).withUniqueId
     _ ← GameRepo insertDenormalized game
   } yield {
     lila.mon.lobby.hook.join()
@@ -36,11 +36,11 @@ private[lobby] object Biter {
     user ← UserRepo byId lobbyUser.id flatten s"No such user: ${lobbyUser.id}"
     owner ← UserRepo byId seek.user.id flatten s"No such user: ${seek.user.id}"
     creatorColor <- assignCreatorColor(owner.some, user.some, seek.realColor)
-    game = makeGame(
+    game <- makeGame(
       seek,
       whiteUser = creatorColor.fold(owner.some, user.some),
       blackUser = creatorColor.fold(user.some, owner.some)
-    )
+    ).withUniqueId
     _ ← GameRepo insertDenormalized game
   } yield JoinSeek(user.id, seek, game, creatorColor)
 

--- a/modules/pool/src/main/GameStarter.scala
+++ b/modules/pool/src/main/GameStarter.scala
@@ -30,12 +30,11 @@ private final class GameStarter(
         p1White <- UserRepo.firstGetsWhite(p1.userId, p2.userId)
         (whitePerf, blackPerf) = if (p1White) perf1 -> perf2 else perf2 -> perf1
         (whiteMember, blackMember) = if (p1White) p1 -> p2 else p2 -> p1
-        g <- makeGame(
+        game <- makeGame(
           pool,
           whiteMember.userId -> whitePerf,
           blackMember.userId -> blackPerf
-        ).withUniqueId
-        game = g.start
+        ).start.withUniqueId
         _ <- GameRepo insertDenormalized game
       } yield {
 

--- a/modules/pool/src/main/GameStarter.scala
+++ b/modules/pool/src/main/GameStarter.scala
@@ -30,11 +30,12 @@ private final class GameStarter(
         p1White <- UserRepo.firstGetsWhite(p1.userId, p2.userId)
         (whitePerf, blackPerf) = if (p1White) perf1 -> perf2 else perf2 -> perf1
         (whiteMember, blackMember) = if (p1White) p1 -> p2 else p2 -> p1
-        game = makeGame(
+        g <- makeGame(
           pool,
           whiteMember.userId -> whitePerf,
           blackMember.userId -> blackPerf
-        ).start
+        ).withUniqueId
+        game = g.start
         _ <- GameRepo insertDenormalized game
       } yield {
 

--- a/modules/setup/src/main/AiConfig.scala
+++ b/modules/setup/src/main/AiConfig.scala
@@ -40,7 +40,7 @@ case class AiConfig(
       source = if (chessGame.board.variant.fromPosition) Source.Position else Source.Ai,
       daysPerTurn = makeDaysPerTurn,
       pgnImport = None
-    )
+    ).sloppy
   } start
 
   def pov(user: Option[User]) = Pov(game(user), creatorColor)

--- a/modules/simul/src/main/SimulApi.scala
+++ b/modules/simul/src/main/SimulApi.scala
@@ -200,8 +200,8 @@ final class SimulApi(
       pgnImport = None
     )
     game2 = game1
-      .withSimulId(simul.id)
       .withId(pairing.gameId)
+      .withSimulId(simul.id)
       .start
     _ ← (GameRepo insertDenormalized game2) >>-
       onGameStart(game2.id) >>-

--- a/modules/simul/src/main/SimulPairing.scala
+++ b/modules/simul/src/main/SimulPairing.scala
@@ -30,7 +30,7 @@ private[simul] object SimulPairing {
 
   def apply(player: SimulPlayer): SimulPairing = new SimulPairing(
     player = player,
-    gameId = IdGenerator.game,
+    gameId = IdGenerator.uncheckedGame,
     status = chess.Status.Created,
     wins = none,
     hostColor = chess.White

--- a/modules/tournament/src/main/AutoPairing.scala
+++ b/modules/tournament/src/main/AutoPairing.scala
@@ -39,8 +39,8 @@ final class AutoPairing(
       mode = tour.mode,
       source = Source.Tournament,
       pgnImport = None
-    ).withTournamentId(tour.id)
-      .withId(pairing.gameId)
+    ).withId(pairing.gameId)
+      .withTournamentId(tour.id)
       .start
     (GameRepo insertDenormalized game) >>- {
       onStart(game.id)

--- a/modules/tournament/src/main/Pairing.scala
+++ b/modules/tournament/src/main/Pairing.scala
@@ -61,7 +61,7 @@ private[tournament] object Pairing {
   case class LastOpponents(hash: Map[User.ID, User.ID]) extends AnyVal
 
   private def make(tourId: Tournament.ID, u1: User.ID, u2: User.ID): Fu[Pairing] =
-    fuccess(IdGenerator.uncheckedGame) dmap { id =>
+    IdGenerator.game dmap { id =>
       new Pairing(
         id = id,
         tourId = tourId,

--- a/modules/tournament/src/main/Pairing.scala
+++ b/modules/tournament/src/main/Pairing.scala
@@ -60,22 +60,25 @@ private[tournament] object Pairing {
 
   case class LastOpponents(hash: Map[User.ID, User.ID]) extends AnyVal
 
-  def apply(tourId: Tournament.ID, u1: User.ID, u2: User.ID): Pairing = new Pairing(
-    id = IdGenerator.uncheckedGame,
-    tourId = tourId,
-    status = chess.Status.Created,
-    user1 = u1,
-    user2 = u2,
-    winner = none,
-    turns = none,
-    berserk1 = false,
-    berserk2 = false
-  )
+  private def make(tourId: Tournament.ID, u1: User.ID, u2: User.ID): Fu[Pairing] =
+    fuccess(IdGenerator.uncheckedGame) dmap { id =>
+      new Pairing(
+        id = id,
+        tourId = tourId,
+        status = chess.Status.Created,
+        user1 = u1,
+        user2 = u2,
+        winner = none,
+        turns = none,
+        berserk1 = false,
+        berserk2 = false
+      )
+    }
 
   case class Prep(tourId: Tournament.ID, user1: User.ID, user2: User.ID) {
-    def toPairing(firstGetsWhite: Boolean) =
-      if (firstGetsWhite) Pairing(tourId, user1, user2)
-      else Pairing(tourId, user2, user1)
+    def toPairing(firstGetsWhite: Boolean): Fu[Pairing] =
+      if (firstGetsWhite) Pairing.make(tourId, user1, user2)
+      else Pairing.make(tourId, user2, user1)
   }
 
   def prep(tour: Tournament, ps: (Player, Player)) = Pairing.Prep(tour.id, ps._1.userId, ps._2.userId)

--- a/modules/tournament/src/main/Pairing.scala
+++ b/modules/tournament/src/main/Pairing.scala
@@ -61,7 +61,7 @@ private[tournament] object Pairing {
   case class LastOpponents(hash: Map[User.ID, User.ID]) extends AnyVal
 
   def apply(tourId: Tournament.ID, u1: User.ID, u2: User.ID): Pairing = new Pairing(
-    id = IdGenerator.game,
+    id = IdGenerator.uncheckedGame,
     tourId = tourId,
     status = chess.Status.Created,
     user1 = u1,

--- a/modules/tournament/src/main/Player.scala
+++ b/modules/tournament/src/main/Player.scala
@@ -3,6 +3,8 @@ package lila.tournament
 import lila.rating.Perf
 import lila.user.{ User, Perfs }
 
+import ornicar.scalalib.Random
+
 private[tournament] case class Player(
     _id: Player.ID, // random
     tourId: Tournament.ID,
@@ -38,7 +40,7 @@ private[tournament] object Player {
   case class WithUser(player: Player, user: User)
 
   private[tournament] def make(tourId: Tournament.ID, user: User, perfLens: Perfs => Perf): Player = new Player(
-    _id = lila.game.IdGenerator.game,
+    _id = Random.nextString(8),
     tourId = tourId,
     userId = user.id,
     rating = perfLens(user.perfs).intRating,

--- a/modules/tournament/src/main/arena/PairingSystem.scala
+++ b/modules/tournament/src/main/arena/PairingSystem.scala
@@ -64,11 +64,9 @@ private[tournament] object PairingSystem extends AbstractPairingSystem {
 
   private def prepsToPairings(preps: List[Pairing.Prep]): Fu[List[Pairing]] =
     if (preps.size < 50) preps.map { prep =>
-      UserRepo.firstGetsWhite(prep.user1.some, prep.user2.some) map prep.toPairing
+      UserRepo.firstGetsWhite(prep.user1.some, prep.user2.some) flatMap prep.toPairing
     }.sequenceFu
-    else fuccess {
-      preps.map(_ toPairing Random.nextBoolean)
-    }
+    else preps.map(_ toPairing Random.nextBoolean).sequenceFu
 
   private def naivePairings(tour: Tournament, players: RankedPlayers): List[Pairing.Prep] =
     players grouped 2 collect {


### PR DESCRIPTION
Introduce a wrapper `NewGame` around newly created games. In places:
* where we don't care get the underlying game with `sloppy (NewGame => Game)`
* where we want a unique id use `withUniqueId (NewGame => Fu[Game])`
* where we have an externally generated id use `withId (NewGame => Game)`