### PR TITLE
prevent player id collisions

### DIFF
--- a/modules/game/src/main/IdGenerator.scala
+++ b/modules/game/src/main/IdGenerator.scala
@@ -1,6 +1,10 @@
 package lila.game
 
+import chess.Color
+
 import ornicar.scalalib.Random
+
+import java.security.SecureRandom
 
 object IdGenerator {
 
@@ -14,5 +18,14 @@ object IdGenerator {
     }
   }
 
-  def player: Player.ID = Random secureString Game.playerIdSize
+  private[this] val secureRandom = new SecureRandom()
+  private[this] val whiteSuffixChars = ('0' to '4') ++ ('A' to 'Z') mkString
+  private[this] val blackSuffixChars = ('5' to '9') ++ ('a' to 'z') mkString
+
+  def player(color: Color): Player.ID = {
+    // Trick to avoid collisions between player ids in the same game.
+    val suffixChars = color.fold(whiteSuffixChars, blackSuffixChars)
+    val suffix = suffixChars(secureRandom nextInt suffixChars.size)
+    Random.secureString(Game.playerIdSize - 1) + suffix
+  }
 }

--- a/modules/game/src/main/Player.scala
+++ b/modules/game/src/main/Player.scala
@@ -96,7 +96,7 @@ object Player {
     color: Color,
     aiLevel: Option[Int] = None
   ): Player = Player(
-    id = IdGenerator.player,
+    id = IdGenerator.player(color),
     color = color,
     aiLevel = aiLevel
   )
@@ -105,7 +105,7 @@ object Player {
     color: Color,
     userPerf: (User.ID, lila.rating.Perf)
   ): Player = Player(
-    id = IdGenerator.player,
+    id = IdGenerator.player(color),
     color = color,
     aiLevel = none,
     userId = userPerf._1.some,


### PR DESCRIPTION
Player id collisions are also expected to happen regularly: Keyspace is only 58^4 = 11 316 496. As far as I know this is only relevant if it happens on the same game, so we can use a trick to prevent collisions: Make the ID depend on the color.