### PR TITLE
change dasher zen mode item on zen mode toggle

### DIFF
--- a/public/stylesheets/dasherApp.css
+++ b/public/stylesheets/dasherApp.css
@@ -115,10 +115,6 @@
   background: #F0F0F0;
   color: #444;
 }
-#dasher_app .selector a.active {
-  background: #3893E8!important;
-  color: #fff!important;
-}
 #dasher_app .selector a::before {
   margin-right: 8px;
   font-size: 19px;
@@ -130,17 +126,12 @@
   opacity: 1;
   color: #3893E8;
 }
-#dasher_app .selector a.active::before {
-  opacity: 1;
-  color: #fff!important;
-}
 #dasher_app .zen a::before {
   font-size: 18px;
   margin-right: 3px;
   opacity: 0.5;
 }
-#dasher_app .zen:hover a::before,
-#dasher_app .zen.active a::before {
+#dasher_app .zen:hover a::before{
   opacity: 1;
 }
 #dasher_app .sound .content {

--- a/ui/dasher/src/dasher.ts
+++ b/ui/dasher/src/dasher.ts
@@ -77,7 +77,7 @@ export function makeCtrl(opts: DasherOpts, data: DasherData, redraw: Redraw): Da
 
   function toggleZen() {
     data.zen = data.zen ? 0 : 1;
-    $('body').toggleClass('zen', data.zen)
+    $('body').toggleClass('zen', data.zen);
     $.post('/pref/zen', { zen: data.zen });
     redraw();
   }

--- a/ui/dasher/src/links.ts
+++ b/ui/dasher/src/links.ts
@@ -81,9 +81,8 @@ export default function(ctrl: DasherCtrl): VNode {
 
   const zenToggle = ctrl.opts.playing ? h('div.zen.selector', [
     h('a', {
-      class: { active: !!ctrl.data.zen },
       attrs: {
-        'data-icon': ctrl.data.zen ? 'E' : 'K',
+        'data-icon': 'K',
         title: 'Keyboard: z'
       },
       hook: bind('click', ctrl.toggleZen)

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -663,7 +663,9 @@ export default class RoundController {
   toggleZen = () => {
     if (this.isPlaying()) {
       const zen = !$('body').hasClass('zen');
-      $('body').toggleClass('zen', zen)
+      $('body').toggleClass('zen', zen);
+      $('#dasher_app .zen a').attr('data-icon', zen ? 'E' : 'K');
+      $('#dasher_app .zen a').toggleClass('active', zen);
       $.post('/pref/zen', { zen: zen ? 1 : 0 });
     }
   }

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -664,8 +664,6 @@ export default class RoundController {
     if (this.isPlaying()) {
       const zen = !$('body').hasClass('zen');
       $('body').toggleClass('zen', zen);
-      $('#dasher_app .zen a').attr('data-icon', zen ? 'E' : 'K');
-      $('#dasher_app .zen a').toggleClass('active', zen);
       $.post('/pref/zen', { zen: zen ? 1 : 0 });
     }
   }


### PR DESCRIPTION
PR for issue https://github.com/ornicar/lila/issues/4580

Here I change dasher on toggleZenMode via jquery. 

I am little bit worrying about _userLinks(): VNode._ 
It is not a good thing to change via jquery, if it works like React virtual dom.

The main **purpose of PR** is to discuss the main question. Do we need an active state of this user menu toggle item? It seems that menu is not displaying when in zen mode and not playing users don't see it.