### PR TITLE
Don't linkify expanded images.

### DIFF
--- a/modules/common/src/main/base/RawHtml.scala
+++ b/modules/common/src/main/base/RawHtml.scala
@@ -120,9 +120,9 @@ final object RawHtml {
             val isHttp = domainS - start == 7
             val url = (if (isHttp) "http://" else "https://") + allButScheme
             val text = if (isHttp) url else allButScheme
-            sb.append(s"""<a rel="nofollow" href="$url" target="_blank">${
-              imgUrl(url).getOrElse(text)
-            }</a>""")
+            sb.append(imgUrl(url).getOrElse(
+              s"""<a rel="nofollow" href="$url" target="_blank">$text</a>"""
+            ))
           }
           lastAppendIdx = end
         } while (m.find)

--- a/modules/common/src/test/RawHtmlTest.scala
+++ b/modules/common/src/test/RawHtmlTest.scala
@@ -38,16 +38,14 @@ class RawHtmlTest extends Specification {
     "detect image" in {
       val url = "http://zombo.com/pic.jpg"
       addLinks(s"""img to $url here""") must_== {
-        val img = s"""<img class="embed" src="$url" alt="$url"/>"""
-        s"""img to <a rel="nofollow" href="$url" target="_blank">$img</a> here"""
+        s"""img to <img class="embed" src="$url" alt="$url"/> here"""
       }
     }
     "detect imgur image URL" in {
       val url = "https://imgur.com/NXy19Im"
       val picUrl = "https://i.imgur.com/NXy19Im.jpg"
-      val img = s"""<img class="embed" src="$picUrl" alt="$url"/>"""
       addLinks(s"""img to $url here""") must_==
-        s"""img to <a rel="nofollow" href="$url" target="_blank">$img</a> here"""
+        s"""img to <img class="embed" src="$picUrl" alt="$url"/> here"""
     }
     "ignore imgur gallery URL" in {
       val url = "http://imgur.com/gallery/pMtTE"


### PR DESCRIPTION
Links suggest to the user that additional information is available
by clicking through. But on expanded images, the link goes to the
exact same content as the inline image. So instead the user has to
remember that image links aren't going somewhere helpful.

Users can still right click -> view image to get to the image.