### PR TITLE
fix #4468: display network error and reconnection status in zen mode

### DIFF
--- a/app/views/base/layout.scala.html
+++ b/app/views/base/layout.scala.html
@@ -99,7 +99,7 @@ csp: Option[lila.common.ContentSecurityPolicy] = None)(body: Html)(implicit ctx:
     <div id="stage">This is an empty lichess preview website for developers. <a href="https://lichess.org">Go to lichess.org instead</a></div>
     }
     @lila.security.EmailConfirm.cookie.get(ctx.req).map(auth.emailConfirmBanner(_))
-    @if(playing) { <a data-icon="E" id="zentog" class="text fbt active@if(!ctx.pref.isZen){ none}">ZEN MODE</a> }
+    @if(playing) { <a data-icon="E" id="zentog" class="text fbt active">ZEN MODE</a> }
     <div id="top" class="@if(ctx.pref.is3d){is3d}else{is2d}">
       @topmenu()
       <div id="ham-plate" class="link hint--bottom" data-hint="@trans.menu()">

--- a/public/stylesheets/board.css
+++ b/public/stylesheets/board.css
@@ -1122,17 +1122,19 @@ body.playing.zen #chat,
 body.playing.zen .underboard .center .crosstable,
 body.playing.zen #now_playing,
 body.playing.zen .clock .moretime,
-body.playing.zen #top > *,
-body.playing.zen #site_title,
-#zentog {
+body.playing.zen #topmenu,
+body.playing.zen #ham-plate,
+body.playing.zen .dasher,
+body.playing.zen .site_notifications,
+body.playing.zen .challenge_notifications,
+body.playing.zen #clinput,
+body.playing.zen #site_title {
   display: none;
 }
-body.playing.zen .table_wrap .replay .buttons,
-body.playing.zen.offline #reconnecting {
+body.playing.zen .table_wrap .replay .buttons {
   opacity: 0!important;
 }
-body.playing.zen .table_wrap:hover .replay .buttons,
-body.playing.zen.offline #reconnecting {
+body.playing.zen .table_wrap:hover .replay .buttons {
   opacity: 1!important;
 }
 #zentog {
@@ -1141,6 +1143,7 @@ body.playing.zen.offline #reconnecting {
   left: 0;
   padding: 10px 15px;
   opacity: 0.5;
+  display: none;
 }
 body.playing.zen #zentog {
   display: block;

--- a/public/stylesheets/common.css
+++ b/public/stylesheets/common.css
@@ -564,7 +564,6 @@ body.online.reconnected #reconnecting {
 body.online #reconnecting::before {
   content: 'J'
 }
-
 #clinput {
   display: flex;
   height: 24px;


### PR DESCRIPTION
fix https://github.com/ornicar/lila/issues/4468
make display: none in zen mode more explicit (we can make it implicit by defining additional rules for '#reconnecting and #network_error selectors', but for me, explicit is better)

remove unnecessary css and html class.

As always comments and questions are welcome.