### PR TITLE
Tournament CRUD form: retain variant

### DIFF
--- a/modules/tournament/src/main/DataForm.scala
+++ b/modules/tournament/src/main/DataForm.scala
@@ -108,6 +108,10 @@ object DataForm {
     v.key == from || parseIntOption(from).exists(v.id ==)
   }
 
+  def variantFromId(id: Int): Option[Variant] = validVariants.find { v =>
+    v.id == id
+  }
+
   def startingPosition(fen: String, variant: Variant): StartingPosition =
     Thematic.byFen(fen).ifTrue(variant.standard) | StartingPosition.initial
 }

--- a/modules/tournament/src/main/DataForm.scala
+++ b/modules/tournament/src/main/DataForm.scala
@@ -108,10 +108,6 @@ object DataForm {
     v.key == from || parseIntOption(from).exists(v.id ==)
   }
 
-  def variantFromId(id: Int): Option[Variant] = validVariants.find { v =>
-    v.id == id
-  }
-
   def startingPosition(fen: String, variant: Variant): StartingPosition =
     Thematic.byFen(fen).ifTrue(variant.standard) | StartingPosition.initial
 }

--- a/modules/tournament/src/main/crud/CrudApi.scala
+++ b/modules/tournament/src/main/crud/CrudApi.scala
@@ -15,7 +15,7 @@ final class CrudApi {
     clockTime = tour.clock.limitInMinutes,
     clockIncrement = tour.clock.incrementSeconds,
     minutes = tour.minutes,
-    variant = tour.variant.key,
+    variant = tour.variant.id,
     position = tour.position.fen,
     date = tour.startsAt,
     image = ~tour.spotlight.flatMap(_.iconImg),

--- a/modules/tournament/src/main/crud/CrudForm.scala
+++ b/modules/tournament/src/main/crud/CrudForm.scala
@@ -7,6 +7,7 @@ import play.api.data.Forms._
 import play.api.data.validation.Constraints._
 
 import chess.StartingPosition
+import chess.variant.Variant
 import lila.common.Form._
 
 object CrudForm {
@@ -22,7 +23,7 @@ object CrudForm {
     "clockTime" -> numberInDouble(clockTimePrivateChoices),
     "clockIncrement" -> numberIn(clockIncrementPrivateChoices),
     "minutes" -> number(min = 20, max = 1440),
-    "variant" -> number.verifying(v => variantFromId(v).isDefined),
+    "variant" -> number.verifying(v => Variant.byId.get(v).isDefined),
     "position" -> nonEmptyText.verifying(DataForm.positions contains _),
     "date" -> utcDate,
     "image" -> stringIn(imageChoices),
@@ -64,7 +65,7 @@ object CrudForm {
       berserkable: Boolean
   ) {
 
-    def realVariant = DataForm.variantFromId(variant) | chess.variant.Standard
+    def realVariant = Variant.byId.get(variant) | chess.variant.Standard
 
     def validClock = (clockTime + clockIncrement) > 0
 

--- a/modules/tournament/src/main/crud/CrudForm.scala
+++ b/modules/tournament/src/main/crud/CrudForm.scala
@@ -22,7 +22,7 @@ object CrudForm {
     "clockTime" -> numberInDouble(clockTimePrivateChoices),
     "clockIncrement" -> numberIn(clockIncrementPrivateChoices),
     "minutes" -> number(min = 20, max = 1440),
-    "variant" -> nonEmptyText.verifying(v => guessVariant(v).isDefined),
+    "variant" -> number.verifying(v => variantFromId(v).isDefined),
     "position" -> nonEmptyText.verifying(DataForm.positions contains _),
     "date" -> utcDate,
     "image" -> stringIn(imageChoices),
@@ -38,7 +38,7 @@ object CrudForm {
     clockTime = clockTimeDefault,
     clockIncrement = clockIncrementDefault,
     minutes = minuteDefault,
-    variant = chess.variant.Standard.key,
+    variant = chess.variant.Standard.id,
     position = StartingPosition.initial.fen,
     date = DateTime.now plusDays 7,
     image = "",
@@ -54,7 +54,7 @@ object CrudForm {
       clockTime: Double,
       clockIncrement: Int,
       minutes: Int,
-      variant: String,
+      variant: Int,
       position: String,
       date: DateTime,
       image: String,
@@ -64,7 +64,7 @@ object CrudForm {
       berserkable: Boolean
   ) {
 
-    def realVariant = DataForm.guessVariant(variant) | chess.variant.Standard
+    def realVariant = DataForm.variantFromId(variant) | chess.variant.Standard
 
     def validClock = (clockTime + clockIncrement) > 0
 

--- a/modules/tournament/src/main/crud/CrudForm.scala
+++ b/modules/tournament/src/main/crud/CrudForm.scala
@@ -23,7 +23,7 @@ object CrudForm {
     "clockTime" -> numberInDouble(clockTimePrivateChoices),
     "clockIncrement" -> numberIn(clockIncrementPrivateChoices),
     "minutes" -> number(min = 20, max = 1440),
-    "variant" -> number.verifying(v => Variant.byId.get(v).isDefined),
+    "variant" -> number.verifying(Variant exists _),
     "position" -> nonEmptyText.verifying(DataForm.positions contains _),
     "date" -> utcDate,
     "image" -> stringIn(imageChoices),
@@ -65,7 +65,7 @@ object CrudForm {
       berserkable: Boolean
   ) {
 
-    def realVariant = Variant.byId.get(variant) | chess.variant.Standard
+    def realVariant = Variant orDefault variant
 
     def validClock = (clockTime + clockIncrement) > 0
 


### PR DESCRIPTION
When editing a tournament using the CRUD form, the variant selector would reset to 'Standard' because the option tags have the variant IDs as their value, whereas the CrudApi would pass the string keys. This adjusts the CRUD form to work with the IDs entirely.

Maybe related to #4592.