### PR TITLE
Make losses to AI show up under 'Losses'

### DIFF
--- a/modules/game/src/main/Query.scala
+++ b/modules/game/src/main/Query.scala
@@ -28,7 +28,7 @@ object Query {
 
   val mate: Bdoc = status(Status.Mate)
 
-  def draw(u: String): Bdoc = user(u) ++ finished ++ F.winnerId.$exists(false)
+  def draw(u: String): Bdoc = user(u) ++ finished ++ F.winnerColor.$exists(false)
 
   val finished: Bdoc = F.status $gte Status.Mate.id
 
@@ -72,9 +72,12 @@ object Query {
 
   def loss(u: String) = user(u) ++ $doc(
     F.status $in Status.finishedWithWinner.map(_.id),
-    F.winnerId -> $doc(
-      "$exists" -> true,
-      "$ne" -> u
+    $or(
+      $doc(F.winnerId -> $doc(
+        "$exists" -> true,
+        "$ne" -> u
+      )),
+      $and(F.winnerId.$exists(false), F.winnerColor.$exists(true))
     )
   )
 


### PR DESCRIPTION
Fixes #3815.

To remove the AI games from the 'Draws' tab, we can use the winnerColor field instead of the winnerId field - the latter does not exist on AI games, but the former does. So only games without winnerColor are definitely drawn.

To make them show up under losses, we use the fact that games must be lost if winnerColor exists but winnerId not - this only happens if you lose against the AI (if you draw against the ID, winnerColor won't exist; if you win against the ID or play against humans, winnerId will exist).