### PR TITLE
use camo for embedded images

### DIFF
--- a/app/templating/Environment.scala
+++ b/app/templating/Environment.scala
@@ -74,4 +74,6 @@ object Environment
     }
     s"""<signal data-hint="$title" class="q$v hint--top">$bars</signal>"""
   }
+
+  def camo(url: String) = new lila.common.Camo(apiEnv.Camo.Endpoint, apiEnv.Camo.Secret).apply(url)
 }

--- a/app/templating/Environment.scala
+++ b/app/templating/Environment.scala
@@ -75,5 +75,6 @@ object Environment
     s"""<signal data-hint="$title" class="q$v hint--top">$bars</signal>"""
   }
 
-  def camo(url: String) = new lila.common.Camo(apiEnv.Camo.Endpoint, apiEnv.Camo.Secret).apply(url)
+  private lazy val camo = new lila.common.Camo(apiEnv.Camo.Endpoint, apiEnv.Camo.Secret)
+  def rewriteImgSrc(url: String) = camo.apply(url)
 }

--- a/app/templating/StringHelper.scala
+++ b/app/templating/StringHelper.scala
@@ -4,6 +4,7 @@ package templating
 import ornicar.scalalib.Zero
 import play.twirl.api.Html
 
+import lila.base.RawHtml
 import lila.user.UserContext
 
 trait StringHelper { self: NumberHelper =>
@@ -51,5 +52,12 @@ trait StringHelper { self: NumberHelper =>
 
   def htmlList(htmls: List[Html], separator: String = ", ") = Html {
     htmls mkString separator
+  }
+
+  def camo(url: String): String
+
+  def richText(rawText: String, nl2br: Boolean = true) = Html {
+    val withLinks = RawHtml.addLinks(rawText, camo)
+    if (nl2br) RawHtml.nl2br(withLinks) else withLinks
   }
 }

--- a/app/templating/StringHelper.scala
+++ b/app/templating/StringHelper.scala
@@ -54,10 +54,10 @@ trait StringHelper { self: NumberHelper =>
     htmls mkString separator
   }
 
-  def camo(url: String): String
+  def rewriteImgSrc(url: String): String
 
   def richText(rawText: String, nl2br: Boolean = true) = Html {
-    val withLinks = RawHtml.addLinks(rawText, camo)
+    val withLinks = RawHtml.addLinks(rawText, rewriteImgSrc)
     if (nl2br) RawHtml.nl2br(withLinks) else withLinks
   }
 }

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -97,6 +97,10 @@ blog {
     email = ${net.email}
   }
 }
+camo {
+  endpoint = "https://camo.lichess.ovh"
+  secret = ""
+}
 qa {
   collection {
     question = qa_question

--- a/modules/api/src/main/Env.scala
+++ b/modules/api/src/main/Env.scala
@@ -57,6 +57,11 @@ final class Env(
   val ExplorerEndpoint = config getString "explorer.endpoint"
   val TablebaseEndpoint = config getString "explorer.tablebase.endpoint"
 
+  object Camo {
+    val Endpoint = config getString "camo.endpoint"
+    val Secret = config getString "camo.secret"
+  }
+
   private val InfluxEventEndpoint = config getString "api.influx_event.endpoint"
   private val InfluxEventEnv = config getString "api.influx_event.env"
 

--- a/modules/common/src/main/Camo.scala
+++ b/modules/common/src/main/Camo.scala
@@ -1,0 +1,14 @@
+package lila.common
+
+final class Camo(endpoint: String, secret: String) {
+  def apply(url: String): String = {
+    if (secret == "") url
+    else {
+      val mac = javax.crypto.Mac.getInstance("HMACSHA1")
+      mac.init(new javax.crypto.spec.SecretKeySpec(secret.getBytes, "HMACSHA1"))
+      val signature = java.util.Base64.getUrlEncoder.encodeToString(mac.doFinal(url.getBytes))
+      val target = java.util.Base64.getUrlEncoder.encodeToString(url.getBytes)
+      s"""$endpoint/$signature/$target"""
+    }
+  }
+}

--- a/modules/common/src/main/String.scala
+++ b/modules/common/src/main/String.scala
@@ -52,11 +52,6 @@ final object String {
   val atUsernameRegex = RawHtml.atUsernameRegex
 
   object html {
-    def richText(rawText: String, nl2br: Boolean = true) = Html {
-      val withLinks = RawHtml.addLinks(rawText)
-      if (nl2br) RawHtml.nl2br(withLinks) else withLinks
-    }
-
     def nl2brUnsafe(text: String) = Html {
       RawHtml.nl2br(text)
     }
@@ -92,5 +87,4 @@ final object String {
       safeJsonValue(jsValue)
     }
   }
-
 }

--- a/modules/common/src/main/base/RawHtml.scala
+++ b/modules/common/src/main/base/RawHtml.scala
@@ -162,9 +162,17 @@ final object RawHtml {
   private[this] val imgurRegex = """https?://imgur\.com/(\w+)""".r
   private[this] val imgUrlPat = """\.(?:jpg|jpeg|png|gif)$""".r.pattern
 
+  private def camo(url: String): String = {
+    val mac = javax.crypto.Mac.getInstance("HMACSHA1")
+    mac.init(new javax.crypto.spec.SecretKeySpec("uk9QueChuh3ku4ceiphe8aefeequ5See0pheeVei".getBytes, "HMACSHA1"))
+    val signature = java.util.Base64.getUrlEncoder.encodeToString(mac.doFinal(url.getBytes))
+    val target = java.util.Base64.getUrlEncoder.encodeToString(url.getBytes)
+    s"""https://camo.lichess.ovh/$signature/$target"""
+  }
+
   private[this] def imgUrl(url: String): Option[String] = (url match {
     case imgurRegex(id) => Some(s"""https://i.imgur.com/$id.jpg""")
-    case _ if imgUrlPat.matcher(url).find => Some(url)
+    case _ if imgUrlPat.matcher(url).find => Some(camo(url))
     case _ => None
   }) map { img => s"""<img class="embed" src="$img" alt="$url"/>""" }
 

--- a/modules/common/src/main/base/RawHtml.scala
+++ b/modules/common/src/main/base/RawHtml.scala
@@ -67,7 +67,7 @@ final object RawHtml {
     } else List(text)
   }
 
-  def addLinks(text: String, camo: String => String): String = {
+  def addLinks(text: String, rewriteImgSrc: String => String): String = {
     expandAtUser(text) map { expanded =>
       val m = urlPattern.matcher(expanded)
 
@@ -120,7 +120,7 @@ final object RawHtml {
             val isHttp = domainS - start == 7
             val url = (if (isHttp) "http://" else "https://") + allButScheme
             val text = if (isHttp) url else allButScheme
-            sb.append(imgUrl(url, camo).getOrElse(
+            sb.append(imgUrl(url, rewriteImgSrc).getOrElse(
               s"""<a rel="nofollow" href="$url" target="_blank">$text</a>"""
             ))
           }
@@ -162,9 +162,9 @@ final object RawHtml {
   private[this] val imgurRegex = """https?://imgur\.com/(\w+)""".r
   private[this] val imgUrlPat = """\.(?:jpg|jpeg|png|gif)$""".r.pattern
 
-  private[this] def imgUrl(url: String, camo: String => String): Option[String] = (url match {
+  private[this] def imgUrl(url: String, rewriteImgSrc: String => String): Option[String] = (url match {
     case imgurRegex(id) => Some(s"""https://i.imgur.com/$id.jpg""")
-    case _ if imgUrlPat.matcher(url).find => Some(camo(url))
+    case _ if imgUrlPat.matcher(url).find => Some(rewriteImgSrc(url))
     case _ => None
   }) map { img => s"""<img class="embed" src="$img" alt="$url"/>""" }
 


### PR DESCRIPTION
GitHub [created](https://blog.github.com/2010-11-13-sidejack-prevention-phase-3-ssl-proxied-assets/) a small server "camo" to proxy their images. This allows them to embed user defined images from plain http URLs without causing warnings in https context. It also no longer exposes the user's IP to the server that is providing the image.

I think we should do the same. If it ever causes too much maintenance work it can be easily rolled back or disabled.

I set up [go-camo](https://github.com/cactus/go-camo) on [camo.lichess.ovh](https://camo.lichess.ovh/ZG8zDOsmJaJtn9ZSY2p3XE2Zsd8=/aHR0cHM6Ly9jbG91ZC5naXRodWJ1c2VyY29udGVudC5jb20vYXNzZXRzLzM4LzI0NTE0NTUyLzg4ZjI5ZWRjLTE1MjktMTFlNy04MzJmLTZkMjk0MjE0NGM4Ny5naWY=). Private key is `uk9QueChuh3ku4ceiphe8aefeequ5See0pheeVei` for now (but should be changed later). The key is so that the proxy can't be conveniently (ab)used by third parties.

Proof of concept attached. Obviously we would not want to hardcode the secret and the servername.

cc @isaacl 