### PR TITLE
Actually disable 'Continue from here' button

### DIFF
--- a/ui/editor/src/view.js
+++ b/ui/editor/src/view.js
@@ -151,7 +151,7 @@ function controls(ctrl, fen) {
         m('a.button', {
           class: (looksLegit && selectedVariant === 'standard') ? '' : 'disabled',
           onclick: function() {
-            if (ctrl.positionLooksLegit()) $.modal($('.continue_with'));
+            if (ctrl.positionLooksLegit() && selectedVariant === 'standard') $.modal($('.continue_with'));
           }
         },
         m('span.text[data-icon=U]', ctrl.trans('continueFromHere'))),


### PR DESCRIPTION
When a variant is selected on the board editor, the 'Continue from here' button is disabled, but it can still be clicked