### PR TITLE
Prettier infinite scroll

### DIFF
--- a/ui/site/src/index.ts
+++ b/ui/site/src/index.ts
@@ -2,4 +2,5 @@ import './standalones/util';
 import './timeago';
 import './standalones/trans';
 import './socket';
+import './infinite-scroll';
 import './main';

--- a/ui/site/src/infinite-scroll.js
+++ b/ui/site/src/infinite-scroll.js
@@ -1,0 +1,38 @@
+lichess.loadInfiniteScroll = function(el) {
+  $(el).each(function() {
+    if (!$('.pager a', this).length) return;
+    var $scroller = $(this).infinitescroll({
+      navSelector: ".pager",
+      nextSelector: ".pager a",
+      itemSelector: ".infinitescroll .paginated_element",
+      errorCallback: function() {
+        $("#infscr-loading").remove();
+      },
+      loading: {
+        msg: $('<div id="infscr-loading">').html(lichess.spinnerHtml)
+      }
+    }, function() {
+      $("#infscr-loading").remove();
+      lichess.pubsub.emit('content_loaded')();
+      var ids = [];
+      $(el).find('.paginated_element[data-dedup]').each(function() {
+        var id = $(this).data('dedup');
+        if (id) {
+          if (lichess.fp.contains(ids, id)) $(this).remove();
+          else ids.push(id);
+        }
+      });
+    }).find('div.pager').hide().end();
+
+    const $moreButton = $('<button class="button inf-more">More</button>').on('click', function() {
+      $scroller.infinitescroll('retrieve');
+    });
+
+    var $moreButtonParent = $scroller.parent();
+    // prevent adding buttons as child of elements where buttons are note allowed
+    if ($moreButton.is('table, ul, ol, dl')) {
+      $moreButtonParent = $moreButtonParent.parent();
+    }
+    $moreButtonParent.after($moreButton);
+  });
+};

--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -507,44 +507,6 @@ lichess.topMenuIntent = function() {
         });
       });
 
-      lichess.loadInfiniteScroll = function(el) {
-        $(el).each(function() {
-          if (!$('.pager a', this).length) return;
-          var $scroller = $(this).infinitescroll({
-            navSelector: ".pager",
-            nextSelector: ".pager a",
-            itemSelector: ".infinitescroll .paginated_element",
-            errorCallback: function() {
-              $("#infscr-loading").remove();
-            },
-            loading: {
-              msg: $('<div id="infscr-loading">').html(lichess.spinnerHtml)
-            }
-          }, function() {
-            $("#infscr-loading").remove();
-            lichess.pubsub.emit('content_loaded')();
-            var ids = [];
-            $(el).find('.paginated_element[data-dedup]').each(function() {
-              var id = $(this).data('dedup');
-              if (id) {
-                if (lichess.fp.contains(ids, id)) $(this).remove();
-                else ids.push(id);
-              }
-            });
-          }).find('div.pager').hide().end();
-
-          const $moreButton = $('<button class="button inf-more">More</button>').on('click', function() {
-            $scroller.infinitescroll('retrieve');
-          });
-
-          var $moreButtonParent = $scroller.parent();
-          // prevent adding buttons as child of elements where buttons are note allowed
-          if ($moreButton.is('table, ul, ol, dl')) {
-            $moreButtonParent = $moreButtonParent.parent();
-          }
-          $moreButtonParent.after($moreButton);
-        });
-      };
       lichess.loadInfiniteScroll('.infinitescroll');
 
       $('#top').on('click', 'a.toggle', function() {

--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -532,11 +532,19 @@ lichess.topMenuIntent = function() {
               }
             });
           }).find('div.pager').hide().end();
-          $scroller.parent().append($('<button class="button inf-more">More</button>').on('click', function() {
+
+          const $moreButton = $('<button class="button inf-more">More</button>').on('click', function() {
             $scroller.infinitescroll('retrieve');
-          }));
+          });
+
+          var $moreButtonParent = $scroller.parent();
+          // prevent adding buttons as child of elements where buttons are note allowed
+          if ($moreButton.is('table, ul, ol, dl')) {
+            $moreButtonParent = $moreButtonParent.parent();
+          }
+          $moreButtonParent.after($moreButton);
         });
-      }
+      };
       lichess.loadInfiniteScroll('.infinitescroll');
 
       $('#top').on('click', 'a.toggle', function() {

--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -532,7 +532,7 @@ lichess.topMenuIntent = function() {
               }
             });
           }).find('div.pager').hide().end();
-          $scroller.parent().append($('<button class="inf-more">More</button>').on('click', function() {
+          $scroller.parent().append($('<button class="button inf-more">More</button>').on('click', function() {
             $scroller.infinitescroll('retrieve');
           }));
         });


### PR DESCRIPTION
This pull requests fixes the style of the "more" button on infinite scrolls. This button is rarely seen as the infinite scroll is automatic, but a glimps of them can observe if scrolling really fast.
The bright color button is noticeable with dark background.

Buttons weren't styled as regular lichess button.
![bad-button-2](https://user-images.githubusercontent.com/2552707/46430686-15ad8200-c74a-11e8-8978-e15bb200909c.png)

I also moved thos buttons outside of any "table" element since it messes up with the stylesheets (and also buttons are not permitted inside tables).
![bad-button-1](https://user-images.githubusercontent.com/2552707/46430792-5d340e00-c74a-11e8-81d4-37e2ddbe0ca4.png)

Also, I took the liberty of moving the infinite scroll functions in their own javascript module. I can revert this if it does not suits you.