### PR TITLE
use altCastles only for castling (fixes #4617)

### DIFF
--- a/ui/puzzle/src/moveTest.ts
+++ b/ui/puzzle/src/moveTest.ts
@@ -18,13 +18,17 @@ export default function(vm, puzzle) {
     var playedByColor = vm.node.ply % 2 === 1 ? 'white' : 'black';
     if (playedByColor !== puzzle.color) return;
 
-    var ucis = vm.nodeList.slice(pathOps.size(vm.initialPath) + 1).map(function(node) {
-      return node.uci;
+    var nodes = vm.nodeList.slice(pathOps.size(vm.initialPath) + 1).map(function(node) {
+      return {
+        uci: node.uci,
+        castle: node.san.indexOf('O-O') === 0
+      };
     });
 
     var progress = puzzle.lines;
-    for (var i in ucis) {
-      progress = progress[ucis[i]] || progress[altCastles[ucis[i]]];
+    for (var i in nodes) {
+      progress = progress[nodes[i].uci];
+      if (!progress && nodes[i].castle) progress = progress[altCastles[nodes[i].uci]];
       if (!progress) progress = 'fail';
       if (typeof progress === 'string') break;
     }


### PR DESCRIPTION
Puzzles were accepting altCastles even when the piece that moved was not the king, leading to a position where no legal move was accepted (#4617).