### PR TITLE
do not linkify trailing colon (closes #4622)

### DIFF
--- a/modules/common/src/main/base/RawHtml.scala
+++ b/modules/common/src/main/base/RawHtml.scala
@@ -136,7 +136,7 @@ final object RawHtml {
   private[this] def adjustUrlEnd(sArr: Array[Char], start: Int, end: Int): Int = {
     var last = end - 1
     while ((sArr(last): @switch) match {
-      case '.' | ',' | '?' | '!' | ';' | '-' | '–' | '—' | '@' | '\'' | '(' => true
+      case '.' | ',' | '?' | '!' | ':' | ';' | '-' | '–' | '—' | '@' | '\'' | '(' => true
       case _ => false
     }) { last -= 1 }
 
@@ -150,7 +150,7 @@ final object RawHtml {
         }))
       var parenCnt = pCnter(start, -1)
       while ((sArr(last): @switch) match {
-        case '.' | ',' | '?' | '!' | ';' | '-' | '–' | '—' | '@' | '\'' => true
+        case '.' | ',' | '?' | '!' | ':' | ';' | '-' | '–' | '—' | '@' | '\'' => true
         case '(' => { parenCnt -= 1; true }
         case ')' => { parenCnt += 1; parenCnt <= 0 }
         case _ => false

--- a/modules/common/src/test/RawHtmlTest.scala
+++ b/modules/common/src/test/RawHtmlTest.scala
@@ -81,6 +81,9 @@ class RawHtmlTest extends Specification {
       addLinks("lichess.org/(2)-)?") must_== """<a href="/(2)">lichess.org/(2)</a>-)?"""
 
       addLinks("lichess.org.-") must_== """<a href="/">lichess.org</a>.-"""
+
+      addLinks("lichess.org/foo:bar") must_== """<a href="/foo:bar">lichess.org/foo:bar</a>"""
+      addLinks("lichess.org/foo:bar:") must_== """<a href="/foo:bar">lichess.org/foo:bar</a>:"""
     }
 
     "handle embedded links" in {


### PR DESCRIPTION
For links like https://en.wikipedia.org/wiki/Talk:Lichess: Let the trailing `:` not be part of the link, like on GitHub or Slack. `:` inside of URLs should be allowed.

cc @isaacl 