### PR TITLE
partially revert a5053e2d41e717 to fix mobile 2fa

### DIFF
--- a/app/controllers/Auth.scala
+++ b/app/controllers/Auth.scala
@@ -81,7 +81,7 @@ object Auth extends LilaController {
       api.usernameForm.bindFromRequest.fold(
         err => negotiate(
           html = Unauthorized(html.auth.login(api.loginForm, referrer)).fuccess,
-          api = _ => jsonFormError(err)
+          api = _ => Unauthorized(errorsAsJson(err)).fuccess
         ),
         username => HasherRateLimit(username, ctx.req) { chargeIpLimiter =>
           api.loadLoginForm(username) flatMap { loginForm =>
@@ -95,7 +95,7 @@ object Auth extends LilaController {
                       case _ => Unauthorized(html.auth.login(err, referrer))
                     }
                   },
-                  api = _ => jsonFormError(err)
+                  api = _ => Unauthorized(errorsAsJson(err)).fuccess
                 )
               },
               result => result.toOption match {


### PR DESCRIPTION
The status code change from 401 to 400 in a5053e2d41e717 is not compatible with mobile
(yet). It will be after veloce/lichobile#910.