### PR TITLE
Bug fix: Analysis not shown as in progress until refresh after PGN import

### DIFF
--- a/app/controllers/Analyse.scala
+++ b/app/controllers/Analyse.scala
@@ -33,7 +33,7 @@ object Analyse extends LilaController {
     else GameRepo initialFen pov.gameId flatMap { initialFen =>
       Game.preloadUsers(pov.game) >> RedirectAtFen(pov, initialFen) {
         (env.analyser get pov.game) zip
-          Env.fishnet.api.prioritaryAnalysisInProgress(pov.gameId) zip
+          Env.fishnet.api.priorityAnalysisStarted(pov.gameId) zip
           (pov.game.simulId ?? Env.simul.repo.find) zip
           Round.getWatcherChat(pov.game) zip
           Env.game.crosstableApi.withMatchup(pov.game) zip

--- a/app/controllers/Analyse.scala
+++ b/app/controllers/Analyse.scala
@@ -33,7 +33,7 @@ object Analyse extends LilaController {
     else GameRepo initialFen pov.gameId flatMap { initialFen =>
       Game.preloadUsers(pov.game) >> RedirectAtFen(pov, initialFen) {
         (env.analyser get pov.game) zip
-          Env.fishnet.api.priorityAnalysisStarted(pov.gameId) zip
+          Env.fishnet.api.gameIdExists(pov.gameId) zip
           (pov.game.simulId ?? Env.simul.repo.find) zip
           Round.getWatcherChat(pov.game) zip
           Env.game.crosstableApi.withMatchup(pov.game) zip

--- a/app/views/analyse/replay.scala.html
+++ b/app/views/analyse/replay.scala.html
@@ -1,4 +1,4 @@
-@(pov: Pov, data: play.api.libs.json.JsObject, initialFen: Option[chess.format.FEN], pgn: String, analysis: Option[lila.analyse.Analysis], analysisStarted: Option[lila.fishnet.Work.Started], simul: Option[lila.simul.Simul], cross: Option[lila.game.Crosstable.WithMatchup], userTv: Option[User], chatOption: Option[lila.chat.UserChat.Mine], bookmarked: Boolean, onCheatList: Option[Boolean])(implicit ctx: Context)
+@(pov: Pov, data: play.api.libs.json.JsObject, initialFen: Option[chess.format.FEN], pgn: String, analysis: Option[lila.analyse.Analysis], analysisStarted: Boolean, simul: Option[lila.simul.Simul], cross: Option[lila.game.Crosstable.WithMatchup], userTv: Option[User], chatOption: Option[lila.chat.UserChat.Mine], bookmarked: Boolean, onCheatList: Option[Boolean])(implicit ctx: Context)
 
 @import pov._
 
@@ -58,7 +58,7 @@ atom = atom.some) {
   <div class="analysis_panels">
     @if(game.analysable) {
     <div class="panel computer_analysis">
-      @if(analysis.isDefined || analysisStarted.isDefined) {
+      @if(analysis.isDefined || analysisStarted) {
       <div id="adv_chart"></div>
       } else {
       <form class="future_game_analysis@if(ctx.isAnon){ must_login}" action="@routes.Analyse.requestAnalysis(gameId)" method="post">

--- a/app/views/analyse/replay.scala.html
+++ b/app/views/analyse/replay.scala.html
@@ -1,4 +1,4 @@
-@(pov: Pov, data: play.api.libs.json.JsObject, initialFen: Option[chess.format.FEN], pgn: String, analysis: Option[lila.analyse.Analysis], analysisInProgress: Option[lila.fishnet.Work.InProgress], simul: Option[lila.simul.Simul], cross: Option[lila.game.Crosstable.WithMatchup], userTv: Option[User], chatOption: Option[lila.chat.UserChat.Mine], bookmarked: Boolean, onCheatList: Option[Boolean])(implicit ctx: Context)
+@(pov: Pov, data: play.api.libs.json.JsObject, initialFen: Option[chess.format.FEN], pgn: String, analysis: Option[lila.analyse.Analysis], analysisStarted: Option[lila.fishnet.Work.Started], simul: Option[lila.simul.Simul], cross: Option[lila.game.Crosstable.WithMatchup], userTv: Option[User], chatOption: Option[lila.chat.UserChat.Mine], bookmarked: Boolean, onCheatList: Option[Boolean])(implicit ctx: Context)
 
 @import pov._
 
@@ -58,7 +58,7 @@ atom = atom.some) {
   <div class="analysis_panels">
     @if(game.analysable) {
     <div class="panel computer_analysis">
-      @if(analysis.isDefined || analysisInProgress.isDefined) {
+      @if(analysis.isDefined || analysisStarted.isDefined) {
       <div id="adv_chart"></div>
       } else {
       <form class="future_game_analysis@if(ctx.isAnon){ must_login}" action="@routes.Analyse.requestAnalysis(gameId)" method="post">

--- a/modules/fishnet/src/main/FishnetApi.scala
+++ b/modules/fishnet/src/main/FishnetApi.scala
@@ -138,6 +138,14 @@ final class FishnetApi(
   def prioritaryAnalysisInProgress(gameId: String): Fu[Option[Work.InProgress]] =
     repo.getAnalysisByGameId(gameId) map { _.flatMap(_.inProgress) }
 
+  /**
+   * @param gameId the game ID
+   * @return  a description of when an analysis was initially enqueued, if an analysis
+   *         has been requested on the given game.
+   */
+  def priorityAnalysisStarted(gameId: String): Fu[Option[Work.Started]] =
+    repo.getAnalysisByGameId(gameId) map { _.map(_.started) }
+
   def status = repo.countAnalysis(acquired = false) map { queued =>
     import play.api.libs.json.Json
     Json.obj(

--- a/modules/fishnet/src/main/FishnetApi.scala
+++ b/modules/fishnet/src/main/FishnetApi.scala
@@ -135,16 +135,7 @@ final class FishnetApi(
     }
   }
 
-  def prioritaryAnalysisInProgress(gameId: String): Fu[Option[Work.InProgress]] =
-    repo.getAnalysisByGameId(gameId) map { _.flatMap(_.inProgress) }
-
-  /**
-   * @param gameId the game ID
-   * @return  a description of when an analysis was initially enqueued, if an analysis
-   *         has been requested on the given game.
-   */
-  def priorityAnalysisStarted(gameId: String): Fu[Option[Work.Started]] =
-    repo.getAnalysisByGameId(gameId) map { _.map(_.started) }
+  def gameIdExists(gameId: String) = analysisColl.exists($doc("game.id" -> gameId))
 
   def status = repo.countAnalysis(acquired = false) map { queued =>
     import play.api.libs.json.Json

--- a/modules/fishnet/src/main/FishnetRepo.scala
+++ b/modules/fishnet/src/main/FishnetRepo.scala
@@ -53,9 +53,6 @@ private final class FishnetRepo(
   def countUserAnalysis = analysisColl.count($doc(
     "sender.system" -> false
   ).some)
-  def getAnalysisByGameId(gameId: String) = analysisColl.find($doc(
-    "game.id" -> gameId
-  )).uno[Work.Analysis]
 
   def getSimilarAnalysis(work: Work.Analysis): Fu[Option[Work.Analysis]] =
     analysisColl.find($doc("game.id" -> work.game.id)).uno[Work.Analysis]

--- a/modules/fishnet/src/main/Work.scala
+++ b/modules/fishnet/src/main/Work.scala
@@ -138,6 +138,8 @@ object Work {
       InProgress(a.userId, a.date)
     }
 
+    def started = Started(createdAt)
+
     def nbMoves = game.moves.count(' ' ==) + 1
 
     override def toString = s"id:$id game:${game.id} tries:$tries requestedBy:$sender acquired:$acquired"
@@ -148,5 +150,9 @@ object Work {
   case class InProgress(by: Client.UserId, since: DateTime) {
 
     def byLichess = by.value startsWith "lichess-"
+  }
+
+  case class Started(since: DateTime) {
+
   }
 }

--- a/modules/fishnet/src/main/Work.scala
+++ b/modules/fishnet/src/main/Work.scala
@@ -138,8 +138,6 @@ object Work {
       InProgress(a.userId, a.date)
     }
 
-    def started = Started(createdAt)
-
     def nbMoves = game.moves.count(' ' ==) + 1
 
     override def toString = s"id:$id game:${game.id} tries:$tries requestedBy:$sender acquired:$acquired"
@@ -150,9 +148,5 @@ object Work {
   case class InProgress(by: Client.UserId, since: DateTime) {
 
     def byLichess = by.value startsWith "lichess-"
-  }
-
-  case class Started(since: DateTime) {
-
   }
 }


### PR DESCRIPTION
I've been using the 'import' feature a bit recently ( https://lichess.org/paste ) for analysing games I've played against people in another chess program ( ssb-chess, if you must know - I'm not a traitor - honest! it's just a wee side project to explore the scuttlebutt stack :P.)

I've found it mildly irritating that when I click the 'Request a computer analysis' on the `/paste` page, I get redirected to the analysis page but the analysis isn't shown as being in progress until I refresh the page.

I believe this is because the `Analysis` controller checks to see if an analysis is *in progress* when rendering the analysis view ( https://github.com/ornicar/lila/blob/143e98d5b68e6bd6c472a14d6283930aa5346ae3/app/controllers/Analyse.scala#L36 ). This  is only the case if a fishnet worker has picked up and started the analysis (which isn't likely immediately after the HTTP redirect): 

https://github.com/ornicar/lila/blob/143e98d5b68e6bd6c472a14d6283930aa5346ae3/modules/fishnet/src/main/FishnetApi.scala#L138

(i.e. in progress is populated.)

My change tries to fix this issue by:

* Creating a new case class `Work.Started` in the spirit of `Work.InProgress`, which just has a `date` field for when the analysis was requested.

* The rdatabase is queried to check whether there is a work entry for a fishnet analysis of the game ID, and returns the `Work.Started` object to the renderer (replacing `InProgress`.)

I'm not sure if this is the best approach, or you agree this is a small UX issue. I thought I'd start a discussion though.

I realise this probably isn't a top priority =p.

I tested this by:

* Setting up a lichess dev environment (with a local fishnet instance too.)
* Verifying I could reproduce the bug (on master.) - i.e. the game isn't shown as being analysed when you redirect.
* Switching to my branch and verifying that the analysis spinner is there after being re-directed.



