### PR TITLE
fishnet: require analysis contempt fix

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -587,7 +587,7 @@ fishnet {
   actor.name = fishnet
   analysis.nodes = 4000000
   move.plies = 300
-  client_min_version = "1.13.0"
+  client_min_version = "1.15.10"
 }
 application {
   global="lila.app.Global"


### PR DESCRIPTION
I think enough clients have updated that we can reject analysis like https://lichess.org/forum/lichess-feedback/sawtooth-evaluation-back-again (that one was produced by fishnet v1.15.6
with Stockfish 2018-07-25 64 BMI2 Multi-Variant).