### PR TITLE
Create translation sanity check script

### DIFF
--- a/bin/trans-sanity-check.js
+++ b/bin/trans-sanity-check.js
@@ -5,13 +5,29 @@ const baseDir = 'translation/source';
 const destDir = 'translation/dest';
 const dbs = ['site', 'arena', 'emails', 'learn', 'activity', 'coordinates'];
 
+function printTransError(r, orig, tran, prefix, e, filename) {
+  if (r.test(orig) && !r.test(tran)) {
+    console.log(`${prefix}${e['$'].name} contains <${orig.match(r)[0]}> in the source but not in ${filename}`);
+  }
+}
+
 function checkAgainstRegexes(orig, tran, prefix, e, filename) {
-  const regexes = [/lichess/i, /lichess\.org/i, /O-O/, /O-O-O/, /%s/, /%\d\$s/]
-  regexes.forEach(r => {
-    if (r.test(orig) && !r.test(tran)) {
-      console.log(`${prefix}${e['$'].name} contains <${orig.match(r)[0]}> in the source but not in ${filename}`);
+  const warnings = [/lichess/i, /lichess\.org/i, /O-O/, /O-O-O/];
+  const errors = [/%s/, /%\d\$s/];
+  warnings.forEach(r => printTransError(r, orig, tran, `WARNING: ${prefix}`, e, filename));
+  errors.forEach(r => printTransError(r, orig, tran, `ERROR: ${prefix}`, e, filename));
+}
+
+function checkPlaceholders(str, prefix, e, file) {
+  const filename = file == 'src' ? '' : ` (${file})`;
+  if (/%\d\$s/.test(str)) {
+    placeholderNums = str.match(/%\d\$s/g).map(x => parseInt(x[1])).sort();
+    for (i = 1; i <= placeholderNums.length; i++) {
+      if (placeholderNums[i-1] !== i) {
+        console.log(`ERROR: Bad placeholder in ${prefix}${e['$'].name}${filename}: ${str}`);
+      }
     }
-  });
+  }
 }
 
 function compareDestToSource(src, name) {
@@ -24,13 +40,15 @@ function compareDestToSource(src, name) {
           strings.forEach(e => {
             orig = src[e['$'].name];
             tran = e['_'];
-            checkAgainstRegexes(orig,tran, prefix, e, filename);
+            checkAgainstRegexes(orig, tran, prefix, e, filename);
+            checkPlaceholders(tran, prefix, e, filename);
           });
           const plurals = (xml.resources.plurals || []);
           plurals.forEach(e => {
             orig = src[e['$'].name];
             tran = e.item[0]['_'];
-            checkAgainstRegexes(orig,tran, prefix, e, filename);
+            checkAgainstRegexes(orig, tran, prefix, e, filename);
+            checkPlaceholders(tran, prefix, e, filename);
           });
         }));
       });
@@ -41,14 +59,17 @@ function compareDestToSource(src, name) {
 function VerifyTranslations(name) {
   return fs.readFile(`${baseDir}/${name}.xml`, { encoding: 'utf8' }).then(txt => {
     return new Promise((resolve, reject) => parseString(txt, (_, xml) => {
+      const prefix = name === 'site' ? '' : `${name}:`
       const strings = (xml.resources.string || []);
       let source_strings = {};
       strings.forEach(e => {
         source_strings[e['$'].name] = e['_'];
+        checkPlaceholders(e['_'], prefix, e, 'src');
       });
       const plurals = (xml.resources.plurals || []);
       plurals.forEach(e => {
         source_strings[e['$'].name] = e.item[0]['_'];
+        checkPlaceholders(e.item[0]['_'], prefix, e, 'src');
       });
       resolve(source_strings);
     })).then(src => {

--- a/bin/trans-sanity-check.js
+++ b/bin/trans-sanity-check.js
@@ -1,0 +1,60 @@
+const fs = require('fs-extra');
+const parseString = require('xml2js').parseString;
+
+const baseDir = 'translation/source';
+const destDir = 'translation/dest';
+const dbs = ['site', 'arena', 'emails', 'learn', 'activity', 'coordinates'];
+
+function checkAgainstRegexes(orig, tran, prefix, e, filename) {
+  const regexes = [/lichess/i, /lichess\.org/i, /O-O/, /O-O-O/, /%s/, /%\d\$s/]
+  regexes.forEach(r => {
+    if (r.test(orig) && !r.test(tran)) {
+      console.log(`${prefix}${e['$'].name} contains <${orig.match(r)[0]}> in the source but not in ${filename}`);
+    }
+  });
+}
+
+function compareDestToSource(src, name) {
+  fs.readdir(`${destDir}/${name}`, { encoding: 'utf8' }).then(filenames => {
+    Promise.all(filenames.map((filename, index, resolve, reject) =>  {
+      fs.readFile(`${destDir}/${name}/${filename}`, { encoding: 'utf8' }).then(txt => {
+        return new Promise((resolve, reject) => parseString(txt, (_, xml) => {
+          const strings = (xml.resources.string || []);
+          const prefix = name === 'site' ? '' : `${name}:`
+          strings.forEach(e => {
+            orig = src[e['$'].name];
+            tran = e['_'];
+            checkAgainstRegexes(orig,tran, prefix, e, filename);
+          });
+          const plurals = (xml.resources.plurals || []);
+          plurals.forEach(e => {
+            orig = src[e['$'].name];
+            tran = e.item[0]['_'];
+            checkAgainstRegexes(orig,tran, prefix, e, filename);
+          });
+        }));
+      });
+    }));
+  })
+}
+
+function VerifyTranslations(name) {
+  return fs.readFile(`${baseDir}/${name}.xml`, { encoding: 'utf8' }).then(txt => {
+    return new Promise((resolve, reject) => parseString(txt, (_, xml) => {
+      const strings = (xml.resources.string || []);
+      let source_strings = {};
+      strings.forEach(e => {
+        source_strings[e['$'].name] = e['_'];
+      });
+      const plurals = (xml.resources.plurals || []);
+      plurals.forEach(e => {
+        source_strings[e['$'].name] = e.item[0]['_'];
+      });
+      resolve(source_strings);
+    })).then(src => {
+      compareDestToSource(src, name)
+    });
+  });
+}
+
+Promise.all(dbs.map(VerifyTranslations));


### PR DESCRIPTION
Working prototype of the translation sanity check script asked for in #3453. 

I think it still needs some work, but I wanted to get some eyes on it as soon as possible.
What I have so far:
- Checks if "Lichess" and "lichess.org" are properly translated
- Checks if "O-O", "O-O-O", "%s", and "%1$s" (Also "%2$s", etc.) are properly translated
- Prints to the console if one of these conditions is not met. This behavior can be changed to return a list of incorrect terms or simply True/False, depending what we want