### PR TITLE
Removes clickable game link from unsolved puzzle.

### DIFF
--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -46,7 +46,7 @@ function gameInfos(ctrl: Controller, game, puzzle): VNode[] {
     }, [
       h('div.header', [
         h('p', {
-          hook: innerHTML(ctrl.trans('fromGameLink', '<a href="/' + game.id + '/' + puzzle.color + '#' + puzzle.initialPly + '">#' + game.id + '</a>'))
+          hook: innerHTML(ctrl.trans('fromGameLink', ctrl.vm.mode === 'play' ? hidden() : '<a href="/' + game.id + '/' + puzzle.color + '#' + puzzle.initialPly + '">#' + game.id + '</a>'))
         }),
         h('p', [
           game.clock, ' • ',


### PR DESCRIPTION
As it stood previously, you could click the game link to basically find out the answer.
Once the puzzle is solved, you can click the game link; just like how puzzle ratings can't be seen until you've solved the puzzle.
Before:
![](https://i.imgur.com/ggUzkTD.png)
After:
![](https://i.imgur.com/2RbFItd.png)