### PR TITLE
fixes bug where bot title formatting is incorrect

### DIFF
--- a/modules/game/src/main/Namer.scala
+++ b/modules/game/src/main/Namer.scala
@@ -13,7 +13,7 @@ object Namer {
     p.aiLevel.fold(
       p.userId.flatMap(lightUser).fold(lila.user.User.anonymous) { user =>
         val title = withTitle ?? user.title ?? { t =>
-          s"""<span class="title"${(t == Title.BOT) ?? " data-bot"} title="${Title titleName Title(t)}">$t</span>&nbsp;"""
+          s"""<span class="title"${(Title(t) == Title.BOT) ?? " data-bot"} title="${Title titleName Title(t)}">$t</span>&nbsp;"""
         }
         if (withRating) s"$title${user.name}&nbsp;(${ratingString(p)})"
         else s"$title${user.name}"


### PR DESCRIPTION
Fixes #4773 
Before:
![image](https://user-images.githubusercontent.com/45638668/49844434-cef68c80-fd77-11e8-9c48-675fadf29b2d.png)

After:
![chrome_2018-12-11_18-58-02](https://user-images.githubusercontent.com/45638668/49844403-b2f2eb00-fd77-11e8-94f2-3aa3bcc2c897.png)
