### PR TITLE
Enable blindfold mode for puzzles #4776

### DIFF
--- a/modules/puzzle/src/main/JsonView.scala
+++ b/modules/puzzle/src/main/JsonView.scala
@@ -52,6 +52,7 @@ final class JsonView(
   }
 
   def pref(p: lila.pref.Pref) = Json.obj(
+    "blindfold" -> p.blindfold,
     "coords" -> p.coords,
     "rookCastle" -> p.rookCastle,
     "animation" -> Json.obj(

--- a/ui/puzzle/src/view/main.ts
+++ b/ui/puzzle/src/view/main.ts
@@ -95,7 +95,7 @@ export default function(ctrl: Controller): VNode {
       },
       class: { gauge_displayed: ctrl.showEvalGauge() }
     }, [
-      h('div.lichess_game', {
+      h('div.lichess_game' + (ctrl.pref.blindfold ? '.blindfold' : ''), {
         hook: {
           insert: _ => window.lichess.pubsub.emit('content_loaded')()
         }


### PR DESCRIPTION
Players can reference the move list to figure out piece locations (assuming a standard start position).
Currently deployed at http://dugovic.mooo.com/training/1