### PR TITLE
title label in user search results

### DIFF
--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -164,7 +164,7 @@ lichess.topMenuIntent = function() {
           suggestion: function(o) {
             var tag = opts.tag || 'a';
             return '<' + tag + ' class="ulpt user_link' + (o.online ? ' online' : '') + '" ' + (tag === 'a' ? '' : 'data-') + 'href="/@/' + o.name + '">' +
-            '<i class="line' + (o.patron ? ' patron' : '') + '"></i>' + (o.title ? o.title + ' ' : '') + o.name +
+            '<i class="line' + (o.patron ? ' patron' : '') + '"></i>' + (o.title ? '<span class="title">' + o.title + '</span>&nbsp;' : '')  + o.name +
             '</' + tag + '>';
           }
         }


### PR DESCRIPTION
Fixes #2864 

btw, I'm wondering why don't we use [template strings](https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/template_strings)? It seems to me that it could make our code look more cleaner & easier to write (especially in multi-line expressions).