### PR TITLE
Fix coordinate training overlay overlapping large boards

### DIFF
--- a/ui/site/src/standalones/coordinate.js
+++ b/ui/site/src/standalones/coordinate.js
@@ -182,5 +182,9 @@ $(function() {
       }, 1000);
     });
   });
-  lichess.pubsub.emit('reset_zoom')();
+
+  // reset_zoom subscriber is added in requestIdleCallback
+  lichess.requestIdleCallback(function() {
+    lichess.pubsub.emit('reset_zoom')();
+  });
 });


### PR DESCRIPTION
#### Issue
The coordinate training overlay overlaps the chess board when the board is large.

![image](https://user-images.githubusercontent.com/114549/51430086-b6e31a00-1c0d-11e9-9b39-84e589de814d.png)

Mouse events don't pass through the score, so in the screenshot above it's very tricky to click the C2 square.

The overlay will correctly reposition itself if you resize the board _while you are on the page_, but once you refresh the problem reappears.

#### Fix
There is an attempt to reposition the overlay in `coordinate.js` by emitting the `reset_zoom` event, but the [subscriber to this event](https://github.com/ornicar/lila/blob/3036e34154796f387027cc69c7ed03905303d6a0/ui/site/src/main.js#L450) is bound slightly later due to it being added in a `requestIdleCallback`.

This change just raises the event slightly later as well by also emitting in a `requestIdleCallback`.