### PR TITLE
add mistake visibility options

### DIFF
--- a/translation/dest/site/en-US.xml
+++ b/translation/dest/site/en-US.xml
@@ -810,6 +810,8 @@ in %3$s</string>
   <string name="learnFromYourMistakes">Learn from your mistakes</string>
   <string name="learnFromThisMistake">Learn from this mistake</string>
   <string name="skipThisMove">Skip this move</string>
+  <string name="toggleMistakeArrow">Toggle mistake arrow</string>
+  <string name="originalMistakePlayed">You played the same mistake!</string>
   <string name="next">Next</string>
   <string name="xWasPlayed">%s was played</string>
   <string name="findBetterMoveForWhite">Find a better move for white</string>

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -809,6 +809,8 @@ in %3$s</string>
   <string name="learnFromYourMistakes">Learn from your mistakes</string>
   <string name="learnFromThisMistake">Learn from this mistake</string>
   <string name="skipThisMove">Skip this move</string>
+  <string name="toggleMistakeArrow">Toggle mistake arrow</string>
+  <string name="originalMistakePlayed">You played the same mistake!</string>
   <string name="next">Next</string>
   <string name="xWasPlayed">%s was played</string>
   <string name="findBetterMoveForWhite">Find a better move for white</string>

--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -61,10 +61,15 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
   } = ctrl.node;
 
   let shapes: DrawShape[] = [];
-  if (ctrl.retro && ctrl.retro.showBadNode()) {
-    return makeShapesFromUci(color, ctrl.retro.showBadNode().uci, 'paleRed', {
-      lineWidth: 8
-    });
+  if (ctrl.retro && ctrl.retro.getBadNode()) {
+    if(ctrl.retro.mistakeArrowEnabled) {
+      return makeShapesFromUci(color, ctrl.retro.getBadNode().uci, 'paleRed', {
+        lineWidth: 8
+      });
+    }
+    else {
+      return [];
+    }
   }
   if (hovering && hovering.fen === nFen) shapes = shapes.concat(makeShapesFromUci(color, hovering.uci, 'paleBlue'));
   if (ctrl.showAutoShapes() && ctrl.showComputer()) {

--- a/ui/analyse/src/retrospect/retroCtrl.ts
+++ b/ui/analyse/src/retrospect/retroCtrl.ts
@@ -8,6 +8,8 @@ import AnalyseCtrl from '../ctrl';
 export interface RetroCtrl {
   isSolving(): boolean
   trans: Trans
+  mistakeArrowEnabled: boolean
+  isFailedMoveOriginalMistake: boolean
   [key: string]: any
 }
 
@@ -135,6 +137,11 @@ export function make(root: AnalyseCtrl): RetroCtrl {
   }
 
   function onFail(): void {
+
+    if(root.retro) {
+      root.retro.isFailedMoveOriginalMistake = root.node.eval != undefined;
+    }
+
     feedback('fail');
     const bad = {
       node: root.node,
@@ -152,6 +159,13 @@ export function make(root: AnalyseCtrl): RetroCtrl {
     solveCurrent();
   }
 
+  function toggleMistakeArrow() {
+    if(root.retro) {
+      root.retro.mistakeArrowEnabled = !root.retro.mistakeArrowEnabled;
+      root.setAutoShapes();
+    }
+  }
+
   function skip() {
     solveCurrent();
     jumpToNext();
@@ -165,7 +179,7 @@ export function make(root: AnalyseCtrl): RetroCtrl {
     return (node.ply % 2 === 0) !== (color === 'white') && !isPlySolved(node.ply);
   };
 
-  function showBadNode(): Tree.Node | undefined {
+  function getBadNode(): Tree.Node | undefined {
     const cur = current();
     if (cur && isSolving() && cur.prev.path === root.path) return cur.fault.node;
   }
@@ -189,8 +203,9 @@ export function make(root: AnalyseCtrl): RetroCtrl {
     jumpToNext,
     skip,
     viewSolution,
+    toggleMistakeArrow,
     hideComputerLine,
-    showBadNode,
+    getBadNode,
     onCeval: checkCeval,
     onMergeAnalysisData,
     feedback,
@@ -202,6 +217,8 @@ export function make(root: AnalyseCtrl): RetroCtrl {
     },
     close: root.toggleRetro,
     trans: root.trans,
+    mistakeArrowEnabled: true,
+    isFailedMoveOriginalMistake: false,
     node: () => root.node,
     redraw
   };

--- a/ui/analyse/src/retrospect/retroView.ts
+++ b/ui/analyse/src/retrospect/retroView.ts
@@ -12,7 +12,10 @@ function skipOrViewSolution(ctrl: RetroCtrl) {
     }, ctrl.trans.noarg('viewTheSolution')),
     h('a', {
       hook: bind('click', ctrl.skip)
-    }, ctrl.trans.noarg('skipThisMove'))
+    }, ctrl.trans.noarg('skipThisMove')),
+    h('a', {
+      hook: bind('click', ctrl.toggleMistakeArrow)
+    }, ctrl.trans.noarg('toggleMistakeArrow'))
   ]);
 }
 
@@ -74,7 +77,7 @@ const feedback = {
       h('div.player', [
         h('div.icon', '✗'),
         h('div.instruction', [
-          h('strong', ctrl.trans.noarg('youCanDoBetter')),
+          h('strong', ctrl.trans.noarg(ctrl.isFailedMoveOriginalMistake ? 'originalMistakePlayed' : 'youCanDoBetter')),
           h('em', ctrl.trans.noarg(ctrl.color === 'white' ? 'tryAnotherMoveForWhite' : 'tryAnotherMoveForBlack')),
           skipOrViewSolution(ctrl)
         ])


### PR DESCRIPTION
This PR adds an option to toggle the red mistake arrow in the "Learn from you mistakes" screen, and also gives specific feedback when making the same mistake again. I also renamed showBadNode to getBadNode to better reflect its purpose.

This is a bit stateful/hacky. Let me know how you would like this to be improved. I also need some help with the internationalization stuff.