### PR TITLE
Recalculate checks with rewind ply in 3check (2nd try)

### DIFF
--- a/ui/round/src/interfaces.ts
+++ b/ui/round/src/interfaces.ts
@@ -55,7 +55,7 @@ export interface RoundData extends GameData {
   url: {
     socket: string;
     round: string;
-  },
+  };
   tv?: Tv;
   userTv?: {
     id: string;
@@ -198,4 +198,8 @@ export interface MaterialDiffSide {
 export interface MaterialDiff {
   white: MaterialDiffSide;
   black: MaterialDiffSide;
+}
+export interface ChecksData {
+  white: number;
+  black: number;
 }

--- a/ui/round/src/util.ts
+++ b/ui/round/src/util.ts
@@ -3,7 +3,7 @@ import { VNodeData } from 'snabbdom/vnode'
 import { Hooks } from 'snabbdom/hooks'
 import * as cg from 'chessground/types'
 import { opposite } from 'chessground/util';
-import { Redraw, EncodedDests, DecodedDests, MaterialDiff } from './interfaces';
+import { Redraw, EncodedDests, DecodedDests, MaterialDiff, Step, ChecksData } from './interfaces';
 
 const pieceScores = {
   pawn: 1,
@@ -45,7 +45,7 @@ export function parsePossibleMoves(dests?: EncodedDests): DecodedDests {
     dests.split(' ').forEach(ds => {
       dec[ds.slice(0,2)] = ds.slice(2).match(/.{2}/g) as cg.Key[];
     });
-    else for (let k in dests) dec[k] = dests[k].match(/.{2}/g) as cg.Key[];
+  else for (let k in dests) dec[k] = dests[k].match(/.{2}/g) as cg.Key[];
   return dec;
 }
 
@@ -69,6 +69,27 @@ export function getScore(pieces: cg.Pieces): number {
     score += pieceScores[pieces[k]!.role] * (pieces[k]!.color === 'white' ? 1 : -1);
   }
   return score;
+}
+
+export function getChecks(steps: Step[], ply: Ply): ChecksData {
+  const checksData: ChecksData = { white: 0, black: 0 };
+  for (let step of steps) {
+    if (ply < step.ply) {
+      break;
+    }
+
+    if (!step.check) {
+      continue;
+    }
+
+    if (step.ply % 2 == 1) {
+      checksData.white += 1;
+    } else {
+      checksData.black += 1;
+    }
+  }
+
+  return checksData;
 }
 
 export function spinner() {

--- a/ui/round/src/view/main.ts
+++ b/ui/round/src/view/main.ts
@@ -10,7 +10,7 @@ import * as keyboard from '../keyboard';
 import crazyView from '../crazy/crazyView';
 import { render as keyboardMove } from '../keyboardMove';
 import RoundController from '../ctrl';
-import { MaterialDiff, MaterialDiffSide } from '../interfaces';
+import { MaterialDiff, MaterialDiffSide, ChecksData } from '../interfaces';
 
 function renderMaterial(material: MaterialDiffSide, score: number, checks?: number) {
   const children: VNode[] = [];
@@ -41,17 +41,27 @@ const emptyMaterialDiff: MaterialDiff = {
   black: {}
 };
 
+const emptyChecksData: ChecksData = {
+  white: 0,
+  black: 0
+}
+
 export function main(ctrl: RoundController): VNode {
   const d = ctrl.data,
     cgState = ctrl.chessground && ctrl.chessground.state,
     topColor = d[ctrl.flip ? 'player' : 'opponent'].color,
     bottomColor = d[ctrl.flip ? 'opponent' : 'player'].color;
-  let material: MaterialDiff, score: number = 0;
+  let material: MaterialDiff, checks: ChecksData, score: number = 0;
   if (d.pref.showCaptured) {
     let pieces = cgState ? cgState.pieces : fenRead(plyStep(ctrl.data, ctrl.ply).fen);
     material = util.getMaterialDiff(pieces);
     score = util.getScore(pieces) * (bottomColor === 'white' ? 1 : -1);
   } else material = emptyMaterialDiff;
+
+  if (d.player.checks || d.opponent.checks) {
+    checks = util.getChecks(ctrl.data.steps, ctrl.ply);
+  } else checks = emptyChecksData;
+
   return ctrl.nvui ? ctrl.nvui.render(ctrl) : h('div.round.cg-512', [
     h('div.lichess_game.gotomove.variant_' + d.game.variant.key + (ctrl.data.pref.blindfold ? '.blindfold' : ''), {
       hook: {
@@ -65,9 +75,9 @@ export function main(ctrl: RoundController): VNode {
         promotion.view(ctrl)
       ]),
       h('div.lichess_ground', [
-        crazyView(ctrl, topColor, 'top') || renderMaterial(material[topColor], -score, d.player.checks),
+        crazyView(ctrl, topColor, 'top') || renderMaterial(material[topColor], -score, checks[topColor]),
         renderTable(ctrl),
-        crazyView(ctrl, bottomColor, 'bottom') || renderMaterial(material[bottomColor], score, d.opponent.checks)
+        crazyView(ctrl, bottomColor, 'bottom') || renderMaterial(material[bottomColor], score, checks[bottomColor])
       ])
     ]),
     h('div.underboard', [


### PR DESCRIPTION
This is a quick fix, just to recalculate how many checks have been played while rewinding a 3 check game in order to display the number of kings in pocket correctly.