### PR TITLE
Track training progress on rating chart

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ lazy val api = module("api", moduleCPDeps)
   ) aggregate (moduleRefs: _*)
 
 lazy val puzzle = module("puzzle", Seq(
-  common, memo, hub, db, user, rating, pref, tree, game
+  common, memo, hub, history, db, user, rating, pref, tree, game
 )).settings(
   libraryDependencies ++= provided(play.api, reactivemongo.driver)
 )

--- a/modules/history/src/main/HistoryApi.scala
+++ b/modules/history/src/main/HistoryApi.scala
@@ -16,6 +16,15 @@ final class HistoryApi(coll: Coll) {
 
   import History._
 
+  def add_puzzle(user: User, completedAt: DateTime, rating: Integer): Funit = {
+    val days = daysBetween(user.createdAt, completedAt)
+    coll.update(
+      $id(user.id),
+      $doc($set(BSONElement(s"puzzle.$days", $int(rating)))),
+      upsert = true
+    ).void
+  }
+
   def add(user: User, game: Game, perfs: Perfs): Funit = {
     val isStd = game.ratingVariant.standard
     val changes = List(

--- a/modules/history/src/main/HistoryApi.scala
+++ b/modules/history/src/main/HistoryApi.scala
@@ -16,15 +16,11 @@ final class HistoryApi(coll: Coll) {
 
   import History._
 
-  def add_puzzle(user: User, completedAt: DateTime, perf: Perf): Funit = {
+  def addPuzzle(user: User, completedAt: DateTime, perf: Perf): Funit = {
     val days = daysBetween(user.createdAt, completedAt)
     coll.update(
       $id(user.id),
-      $doc(BSONDocument(
-        "$set" -> (
-          BSONDocument(s"puzzle.$days" -> $int(perf.intRating))
-        )
-      )),
+      $set(s"puzzle.$days" -> $int(perf.intRating)),
       upsert = true
     ).void
   }

--- a/modules/history/src/main/HistoryApi.scala
+++ b/modules/history/src/main/HistoryApi.scala
@@ -9,18 +9,22 @@ import scala.concurrent.duration._
 import chess.Speed
 import lila.db.dsl._
 import lila.game.Game
-import lila.rating.PerfType
+import lila.rating.{ Perf, PerfType }
 import lila.user.{ User, Perfs }
 
 final class HistoryApi(coll: Coll) {
 
   import History._
 
-  def add_puzzle(user: User, completedAt: DateTime, rating: Integer): Funit = {
+  def add_puzzle(user: User, completedAt: DateTime, perf: Perf): Funit = {
     val days = daysBetween(user.createdAt, completedAt)
     coll.update(
       $id(user.id),
-      $doc($set(BSONElement(s"puzzle.$days", $int(rating)))),
+      $doc(BSONDocument(
+        "$set" -> (
+          BSONDocument(s"puzzle.$days" -> $int(perf.intRating))
+        )
+      )),
       upsert = true
     ).void
   }

--- a/modules/puzzle/src/main/Env.scala
+++ b/modules/puzzle/src/main/Env.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.Config
 final class Env(
     config: Config,
     renderer: ActorSelection,
+    historyApi: lila.history.HistoryApi,
     lightUserApi: lila.user.LightUserApi,
     asyncCache: lila.memo.AsyncCache.Builder,
     system: ActorSystem,
@@ -43,6 +44,7 @@ final class Env(
   )
 
   lazy val finisher = new Finisher(
+    historyApi = historyApi,
     api = api,
     puzzleColl = puzzleColl,
     bus = system.lilaBus
@@ -94,6 +96,7 @@ object Env {
   lazy val current: Env = "puzzle" boot new Env(
     config = lila.common.PlayApp loadConfig "puzzle",
     renderer = lila.hub.Env.current.renderer,
+    historyApi = lila.history.Env.current.api,
     lightUserApi = lila.user.Env.current.lightUserApi,
     asyncCache = lila.memo.Env.current.asyncCache,
     system = lila.common.PlayApp.system,

--- a/modules/puzzle/src/main/Finisher.scala
+++ b/modules/puzzle/src/main/Finisher.scala
@@ -33,7 +33,7 @@ private[puzzle] final class Finisher(
             rating = formerUserRating,
             ratingDiff = userPerf.intRating - formerUserRating
           )
-          historyApi.add_puzzle(user = user, completedAt = date, perf = userPerf)
+          historyApi.addPuzzle(user = user, completedAt = date, perf = userPerf)
           (api.round upsert round) >> {
             puzzleColl.update(
               $id(puzzle.id),

--- a/modules/puzzle/src/main/Finisher.scala
+++ b/modules/puzzle/src/main/Finisher.scala
@@ -10,11 +10,12 @@ import lila.user.{ User, UserRepo }
 
 private[puzzle] final class Finisher(
     api: PuzzleApi,
+    historyApi: lila.history.HistoryApi,
     puzzleColl: Coll,
     bus: lila.common.Bus
 ) {
 
-  def apply(puzzle: Puzzle, user: User, result: Result, mobile: Boolean): Fu[(Round, Mode)] = {
+  def apply(historyApi: lila.history.HistoryApi, puzzle: Puzzle, user: User, result: Result, mobile: Boolean): Fu[(Round, Mode)] = {
     val formerUserRating = user.perfs.puzzle.intRating
     api.head.find(user) flatMap {
       case Some(PuzzleHead(_, Some(c), _)) if c == puzzle.id || mobile =>

--- a/modules/puzzle/src/main/Finisher.scala
+++ b/modules/puzzle/src/main/Finisher.scala
@@ -15,7 +15,7 @@ private[puzzle] final class Finisher(
     bus: lila.common.Bus
 ) {
 
-  def apply(historyApi: lila.history.HistoryApi, puzzle: Puzzle, user: User, result: Result, mobile: Boolean): Fu[(Round, Mode)] = {
+  def apply(puzzle: Puzzle, user: User, result: Result, mobile: Boolean): Fu[(Round, Mode)] = {
     val formerUserRating = user.perfs.puzzle.intRating
     api.head.find(user) flatMap {
       case Some(PuzzleHead(_, Some(c), _)) if c == puzzle.id || mobile =>
@@ -33,6 +33,7 @@ private[puzzle] final class Finisher(
             rating = formerUserRating,
             ratingDiff = userPerf.intRating - formerUserRating
           )
+          historyApi.add_puzzle(user = user, completedAt = date, perf = userPerf)
           (api.round upsert round) >> {
             puzzleColl.update(
               $id(puzzle.id),


### PR DESCRIPTION
Why?
---
I have been talking to @c-mac for a few weeks about adding a training line to the rating chart on the profile page. We looked back at issues and found that others had asked for the same feature (oldest one I could find was https://github.com/ornicar/lila/issues/77, but more recently https://github.com/ornicar/lila/issues/4540).


How?
---
Let me start off by saying I've never written any Scala before, so I am totally open to this being the wrong approach. I noticed that the rating chart drew from the history collection, and that it was already attempting to pull puzzle entries off of that table, but there were none! I'm not sure when that change got made, but since the infrastructure was all there I thought that the easiest way to make this change would be to write to the history collection with a puzzle entry every time the user solved a puzzle. I added a function to do this because the previous function `HistoryApi.add` takes a game, and AFAIK puzzles are just *different* than games. At first I tried to adapt that function, but it was difficult and felt off. I added an `add_puzzle` method to the `HistoryApi` that gets called when the user finishes a puzzle. It has been working well locally, but I'm super open to hearing thoughts about the implementation!

List of Changes
---
- Set the `puzzle` module to depend on the `history` module
- Add an `addPuzzle` method to the `HistoryApi` which takes a `PuzzlePerf`, a
  user, and a datetime and records a row in the `history` collection
- Add the `HistoryApi` to the puzzle `Env`.
- Call the `addPuzzle` method when the user solves a puzzle

Future work
---
- This will only record data going forward, so maybe it would be worth it to write a migration to capture historical data?
- It was really difficult to get up and running with puzzles locally, I've composed some thoughts on that in [a gist](https://gist.github.com/jcmorrow/2933638dd69695ca89b235312029d4c9) but I'd like to make it even easier by adding a setup script or writing a how-to.
