### PR TITLE
Fix permission in configSave in Practice controller

### DIFF
--- a/app/controllers/Practice.scala
+++ b/app/controllers/Practice.scala
@@ -101,7 +101,7 @@ object Practice extends LilaController {
     } yield Ok(html.practice.config(struct, form))
   }
 
-  def configSave = SecureBody(_.StreamConfig) { implicit ctx => me =>
+  def configSave = SecureBody(_.PracticeConfig) { implicit ctx => me =>
     implicit val req = ctx.body
     env.api.config.form.flatMap { form =>
       FormFuResult(form) { err =>


### PR DESCRIPTION
I'm pretty sure StreamConfig is not the correct permission to change Practice configuration.

(After this, StreamConfig can just be removed, right? There don't seem to be any other uses, I think this permission comes from the time where all streamers were stored in that big list)