### PR TITLE
issues-4890: increase rematch button height to fix blinking

### DIFF
--- a/public/stylesheets/board.css
+++ b/public/stylesheets/board.css
@@ -845,7 +845,7 @@ div.control .button.disabled {
 }
 .lichess_ground .rematch.button {
   padding: 0;
-  height: 54px;
+  height: 56px;
   font-size: 1.2em;
   display: flex;
   justify-content: center;


### PR DESCRIPTION
Possible and easiest fix for #4890 
If rematch button height is required to stay 54px, let me know :) 