### PR TITLE
split email normalization and validation

### DIFF
--- a/app/controllers/Account.scala
+++ b/app/controllers/Account.scala
@@ -144,7 +144,7 @@ object Account extends LilaController {
           fuccess(html.account.email(me, err))
         } { data =>
           val email = Env.security.emailAddressValidator.validate(data.realEmail) err s"Invalid email ${data.email}"
-          val newUserEmail = lila.security.EmailConfirm.UserEmail(me.username, email)
+          val newUserEmail = lila.security.EmailConfirm.UserEmail(me.username, email.normalized)
           controllers.Auth.EmailConfirmRateLimit(newUserEmail, ctx.req) {
             Env.security.emailChange.send(me, newUserEmail.email) inject Redirect {
               s"${routes.Account.email}?check=1"

--- a/app/controllers/Mod.scala
+++ b/app/controllers/Mod.scala
@@ -147,7 +147,7 @@ object Mod extends LilaController {
         err => BadRequest(err.toString).fuccess,
         rawEmail => {
           val email = Env.security.emailAddressValidator.validate(EmailAddress(rawEmail)) err s"Invalid email ${rawEmail}"
-          modApi.setEmail(me.id, user.id, email) inject redirect(user.username, mod = true)
+          modApi.setEmail(me.id, user.id, email.normalized) inject redirect(user.username, mod = true)
         }
       )
     }
@@ -293,8 +293,8 @@ object Mod extends LilaController {
           case _ => fuccess(none)
         }
         email.?? { em =>
-          tryWith(em, em.value) orElse {
-            username ?? { tryWith(em, _) }
+          tryWith(em.normalized, em.normalized.value) orElse {
+            username ?? { tryWith(em.normalized, _) }
           }
         } getOrElse BadRequest(html.mod.emailConfirm(rawQuery, none, none)).fuccess
     }

--- a/modules/common/src/main/model.scala
+++ b/modules/common/src/main/model.scala
@@ -45,6 +45,18 @@ case class EmailAddress(value: String) extends AnyVal with StringValue {
     case Array(user, domain) => s"${user take 3}*****@${domain}"
     case _ => value
   }
+  def normalize = EmailAddress {
+    val lower = value.toLowerCase
+    lower.split('@') match {
+      case Array(name, domain) if domain == "gmail.com" || domain == "googlemail.com" => {
+        val normalizedName = name
+          .replace(".", "") // remove all dots
+          .takeWhile('+'!=) // skip everything after the first '+'
+        if (normalizedName.isEmpty) lower else s"$normalizedName@gmail.com"
+      }
+      case _ => lower
+    }
+  }
   def domain: Option[Domain] = value split '@' match {
     case Array(_, domain) => Domain(domain).some
     case _ => none

--- a/modules/common/src/test/EmailTest.scala
+++ b/modules/common/src/test/EmailTest.scala
@@ -1,0 +1,17 @@
+package lila.common
+
+import org.specs2.mutable.Specification
+
+class EmailTest extends Specification {
+
+  "normalize" should {
+    "handle gmail" in {
+      EmailAddress("Hello.World+suffix1+suffix2@gmail.com").normalize must_== EmailAddress("helloworld@gmail.com")
+      EmailAddress("foo.bar@googlemail.com").normalize must_== EmailAddress("foobar@gmail.com")
+    }
+    "lowercase emails" in {
+      EmailAddress("aBcDeFG@HOTMAIL.cOM").normalize must_== EmailAddress("abcdefg@hotmail.com")
+    }
+  }
+
+}

--- a/modules/mod/src/main/UserSearch.scala
+++ b/modules/mod/src/main/UserSearch.scala
@@ -24,10 +24,10 @@ final class UserSearch(
 
   private def searchUsername(username: String) = UserRepo named username map (_.toList)
 
-  private def searchEmail(email: EmailAddress): Fu[List[User]] =
-    emailValidator.validate(email) ?? { fixed =>
-      UserRepo.byEmail(fixed) flatMap { current =>
-        UserRepo.byPrevEmail(fixed) map current.toList.:::
-      }
+  private def searchEmail(email: EmailAddress): Fu[List[User]] = {
+    val normalized = email.normalize
+    UserRepo.byEmail(normalized) flatMap { current =>
+      UserRepo.byPrevEmail(normalized) map current.toList.:::
     }
+  }
 }

--- a/modules/security/src/main/EmailAddressValidator.scala
+++ b/modules/security/src/main/EmailAddressValidator.scala
@@ -14,32 +14,13 @@ final class EmailAddressValidator(
     dnsApi: DnsApi
 ) {
 
-  // email was already regex-validated at this stage
-  def validate(email: EmailAddress): Option[EmailAddress] =
+  private def isAcceptable(email: EmailAddress): Boolean =
+    email.domain.filter(_.value contains '.').exists { domain =>
+      !disposable.fromDomain(domain.value)
+    }
 
-    // start by lower casing the entire address
-    email.value.toLowerCase
-      // separate name from domain
-      .split('@') match {
-
-        // gmail addresses
-        case Array(name, domain) if gmailDomains(domain) => name
-        .replace(".", "") // remove all dots
-        .takeWhile('+'!=) // skip everything after the first +
-        .some.filter(_.nonEmpty) // make sure something remains
-        .map(radix => EmailAddress(s"$radix@$domain")) // okay
-
-        // disposable addresses
-        case Array(_, domain) if disposable fromDomain domain => none
-
-        // other valid addresses
-        case Array(name, domain) if domain contains "." => EmailAddress(s"$name@$domain").some
-
-        // invalid addresses
-        case _ => none
-      }
-
-  def isValid(email: EmailAddress) = validate(email).isDefined
+  def validate(email: EmailAddress): Option[EmailAddressValidator.Acceptable] =
+    isAcceptable(email) option EmailAddressValidator.Acceptable(email.normalize)
 
   /**
    * Returns true if an E-mail address is taken by another user.
@@ -56,19 +37,14 @@ final class EmailAddressValidator(
     }
 
   val acceptableConstraint = Constraint[String]("constraint.email_acceptable") { e =>
-    if (isValid(EmailAddress(e))) Valid
+    if (isAcceptable(EmailAddress(e))) Valid
     else Invalid(ValidationError("error.email_acceptable"))
   }
 
   def uniqueConstraint(forUser: Option[User]) = Constraint[String]("constraint.email_unique") { e =>
-    validate(EmailAddress(e)) match {
-      case None => Invalid(ValidationError("error.email_acceptable"))
-      case Some(email) => {
-        if (isTakenBySomeoneElse(email, forUser))
-          Invalid(ValidationError("error.email_unique"))
-        else Valid
-      }
-    }
+    if (isTakenBySomeoneElse(EmailAddress(e).normalize, forUser))
+      Invalid(ValidationError("error.email_unique"))
+    else Valid
   }
 
   def differentConstraint(than: Option[EmailAddress]) = Constraint[String]("constraint.email_different") { e =>
@@ -81,8 +57,8 @@ final class EmailAddressValidator(
   def preloadDns(e: EmailAddress): Funit = hasAcceptableDns(e).void
 
   // only compute valid and non-whitelisted email domains
-  private def hasAcceptableDns(e: EmailAddress): Fu[Boolean] = validate(e) ?? {
-    _.domain ?? { domain =>
+  private def hasAcceptableDns(e: EmailAddress): Fu[Boolean] =
+    if (isAcceptable(e)) e.domain ?? { domain =>
       if (DisposableEmailDomain whitelisted domain) fuccess(true)
       else {
         dnsApi.a(domain) >>| {
@@ -92,7 +68,7 @@ final class EmailAddressValidator(
         domains.nonEmpty && domains.forall { !disposable(_) }
       }
     }
-  }
+    else fuccess(false)
 
   // the DNS emails should have been preloaded
   private[security] val withAcceptableDns = Constraint[String]("constraint.email_acceptable") { e =>
@@ -103,6 +79,8 @@ final class EmailAddressValidator(
     if (ok) Valid
     else Invalid(ValidationError("error.email_acceptable"))
   }
+}
 
-  private val gmailDomains = Set("gmail.com", "googlemail.com")
+object EmailAddressValidator {
+  case class Acceptable(normalized: EmailAddress)
 }

--- a/modules/security/src/main/SecurityApi.scala
+++ b/modules/security/src/main/SecurityApi.scala
@@ -54,7 +54,7 @@ final class SecurityApi(
 
   def loadLoginForm(str: String): Fu[Form[LoginCandidate.Result]] = {
     emailValidator.validate(EmailAddress(str)) match {
-      case Some(email) => authenticator.loginCandidateByEmail(email)
+      case Some(EmailAddressValidator.Acceptable(email)) => authenticator.loginCandidateByEmail(email)
       case None if User.couldBeUsername(str) => authenticator.loginCandidateById(User normalize str)
       case _ => fuccess(none)
     }


### PR DESCRIPTION
Split email normalization and validation and add some types to show where normalization happens. Just a refactoring, almost (see comments) no functional change.

Before:
```
EmailAddressValidator.validate: EmailAddress => Option[EmailAddress]
```

After:
```
EmailAddress.normalize: EmailAddress => EmailAddress // infallible
EmailAddressValidator.validate: EmailAddress => Option[Acceptable(normalized: EmailAddress)]
```

Related: #2509, #4877