### PR TITLE
Promotion keyboard support

### DIFF
--- a/ui/round/src/keyboardMove.ts
+++ b/ui/round/src/keyboardMove.ts
@@ -4,6 +4,7 @@ import * as cg from 'chessground/types';
 import { Step, Redraw } from './interfaces';
 import RoundController from './ctrl';
 import { valid as crazyValid } from './crazy/crazyCtrl';
+import { sendPromotion } from './promotion'
 
 export type KeyboardMoveHandler = (fen: Fen, dests?: cg.Dests) => void;
 
@@ -12,7 +13,8 @@ interface SanMap {
 }
 
 export interface KeyboardMove {
-  drop(orig: cg.Key, piece: string): void
+  drop(key: cg.Key, piece: string): void
+  promote(orig: cg.Key, piece: string): void
   update(step: Step): void;
   registerHandler(h: KeyboardMoveHandler): void
   hasFocus(): boolean;
@@ -29,6 +31,7 @@ export function ctrl(root: RoundController, step: Step, redraw: Redraw): Keyboar
   let handler: KeyboardMoveHandler | undefined;
   let preHandlerBuffer = step.fen;
   const cgState = root.chessground.state;
+  const sanMap = sanToRole as SanMap;
   const select = function(key: cg.Key): void {
     if (cgState.selected === key) root.chessground.cancelMove();
     else root.chessground.selectSquare(key, true);
@@ -36,17 +39,24 @@ export function ctrl(root: RoundController, step: Step, redraw: Redraw): Keyboar
   let usedSan = false;
   return {
     drop(key, piece) {
-      const role = (sanToRole as SanMap)[piece];
+      const role = sanMap[piece];
       const crazyData = root.data.crazyhouse;
       const color = root.data.player.color;
-      // Piece not in Pocket
-      if (!role || !crazyData || !crazyData.pockets[color === 'white' ? 0 : 1][role]) return;
       // Square occupied
-      if (cgState.pieces[key]) return;
+      if (!role || !crazyData || cgState.pieces[key]) return;
+      // Piece not in Pocket
+      if (!crazyData.pockets[color === 'white' ? 0 : 1][role]) return;
       if (!crazyValid(root.data, role, key)) return;
       root.chessground.cancelMove();
       root.chessground.newPiece({ role, color }, key);
       root.sendNewPiece(role, key, false);
+    },
+    promote(dest, piece) {
+      const role = sanMap[piece];
+      if (!role || role == 'pawn') return;
+      root.chessground.cancelMove();
+      const orig = dest.replace(/1/, '2').replace(/8/,'7');
+      sendPromotion(root, orig as cg.Key, dest, role, {premove: false});
     },
     update(step) {
       if (handler) handler(step.fen, cgState.movable.dests);
@@ -93,7 +103,8 @@ export function render(ctrl: KeyboardMove) {
               hasSelected: ctrl.hasSelected,
               confirmMove: ctrl.confirmMove,
               san: ctrl.san,
-              drop: ctrl.drop
+              drop: ctrl.drop,
+              promote: ctrl.promote
             }));
           });
         }

--- a/ui/round/src/keyboardMove.ts
+++ b/ui/round/src/keyboardMove.ts
@@ -14,7 +14,7 @@ interface SanMap {
 
 export interface KeyboardMove {
   drop(key: cg.Key, piece: string): void
-  promote(orig: cg.Key, piece: string): void
+  promote(dest: cg.Key, piece: string): void
   update(step: Step): void;
   registerHandler(h: KeyboardMoveHandler): void
   hasFocus(): boolean;

--- a/ui/round/src/keyboardMove.ts
+++ b/ui/round/src/keyboardMove.ts
@@ -13,10 +13,10 @@ interface SanMap {
 }
 
 export interface KeyboardMove {
-  drop(key: cg.Key, piece: string): void
-  promote(dest: cg.Key, piece: string): void
+  drop(key: cg.Key, piece: string): void;
+  promote(orig: cg.Key, dest: cg.Key, piece: string): void;
   update(step: Step): void;
-  registerHandler(h: KeyboardMoveHandler): void
+  registerHandler(h: KeyboardMoveHandler): void;
   hasFocus(): boolean;
   setFocus(v: boolean): void;
   san(orig: cg.Key, dest: cg.Key): void;
@@ -51,12 +51,11 @@ export function ctrl(root: RoundController, step: Step, redraw: Redraw): Keyboar
       root.chessground.newPiece({ role, color }, key);
       root.sendNewPiece(role, key, false);
     },
-    promote(dest, piece) {
+    promote(orig, dest, piece) {
       const role = sanMap[piece];
       if (!role || role == 'pawn') return;
       root.chessground.cancelMove();
-      const orig = dest.replace(/1/, '2').replace(/8/,'7');
-      sendPromotion(root, orig as cg.Key, dest, role, {premove: false});
+      sendPromotion(root, orig, dest, role, {premove: false});
     },
     update(step) {
       if (handler) handler(step.fen, cgState.movable.dests);

--- a/ui/round/src/plugins/keyboardMove.ts
+++ b/ui/round/src/plugins/keyboardMove.ts
@@ -30,9 +30,9 @@ window.lichess.keyboardMove = function(opts: any) {
     } else if (sans && v.match(fileRegex)) {
       // do nothing
     } else if (sans && v.match(promotionRegex)) {
-      const foundUci = sanToUci(v.slice(0,- 2), sans);
+      const foundUci = sanToUci(v.slice(0, -2), sans);
       if (!foundUci) return;
-      opts.promote(foundUci.slice(0,2), foundUci.slice(2), v.slice(-1).toUpperCase());
+      opts.promote(foundUci.slice(0, 2), foundUci.slice(2), v.slice(-1).toUpperCase());
       clear();
     } else if (v.match(crazyhouseRegex)) {
       if (v.length === 3) v = 'P' + v;

--- a/ui/round/src/plugins/keyboardMove.ts
+++ b/ui/round/src/plugins/keyboardMove.ts
@@ -4,7 +4,8 @@ import { DecodedDests } from '../interfaces';
 const keyRegex = /^[a-h][1-8]$/;
 const fileRegex = /^[a-h]$/;
 const crazyhouseRegex = /^\w?@[a-h][1-8]$/;
-const promotionRegex = /^[a-h](1|8)=\w$/;
+const ambiguousPromotionRegex = /^([a-h]x?)?[a-h](1|8)$/;
+const promotionRegex = /^([a-h]x?)?[a-h](1|8)=\w$/;
 
 window.lichess.keyboardMove = function(opts: any) {
   if (opts.input.classList.contains('ready')) return;
@@ -19,8 +20,8 @@ window.lichess.keyboardMove = function(opts: any) {
       if (v.toLowerCase() === 'o-o' && sans['O-O-O'] && !force) return;
       // ambiguous UCI
       if (v.match(keyRegex) && opts.hasSelected()) opts.select(v);
-      // ambiguous promotion (must be a pawn move at this point)
-      if (v.match(/^[a-h](1|8)$/) && !force) return;
+      // ambiguous promotion (also check sans[v] here because bc8 could mean Bc8)
+      if (v.match(ambiguousPromotionRegex) && sans[v] && !force) return;
       else opts.san(foundUci.slice(0, 2), foundUci.slice(2));
       clear();
     } else if (sans && v.match(keyRegex)) {
@@ -29,7 +30,9 @@ window.lichess.keyboardMove = function(opts: any) {
     } else if (sans && v.match(fileRegex)) {
       // do nothing
     } else if (sans && v.match(promotionRegex)) {
-      opts.promote(v.slice(0,2), v.slice(3).toUpperCase());
+      const foundUci = sanToUci(v.slice(0,- 2), sans);
+      if (!foundUci) return;
+      opts.promote(foundUci.slice(0,2), foundUci.slice(2), v.slice(-1).toUpperCase());
       clear();
     } else if (v.match(crazyhouseRegex)) {
       if (v.length === 3) v = 'P' + v;

--- a/ui/round/src/plugins/keyboardMove.ts
+++ b/ui/round/src/plugins/keyboardMove.ts
@@ -19,8 +19,7 @@ window.lichess.keyboardMove = function(opts: any) {
       if (v.toLowerCase() === 'o-o' && sans['O-O-O'] && !force) return;
       // ambiguous UCI
       if (v.match(keyRegex) && opts.hasSelected()) opts.select(v);
-      // promotion -- wait for more information
-      // (at this point it must be a pawn move since no piece was selected)
+      // ambiguous promotion (must be a pawn move at this point)
       if (v.match(/^[a-h](1|8)$/) && !force) return;
       else opts.san(foundUci.slice(0, 2), foundUci.slice(2));
       clear();

--- a/ui/round/src/plugins/keyboardMove.ts
+++ b/ui/round/src/plugins/keyboardMove.ts
@@ -4,6 +4,7 @@ import { DecodedDests } from '../interfaces';
 const keyRegex = /^[a-h][1-8]$/;
 const fileRegex = /^[a-h]$/;
 const crazyhouseRegex = /^\w?@[a-h][1-8]$/;
+const promotionRegex = /^[a-h](1|8)=\w$/;
 
 window.lichess.keyboardMove = function(opts: any) {
   if (opts.input.classList.contains('ready')) return;
@@ -18,6 +19,9 @@ window.lichess.keyboardMove = function(opts: any) {
       if (v.toLowerCase() === 'o-o' && sans['O-O-O'] && !force) return;
       // ambiguous UCI
       if (v.match(keyRegex) && opts.hasSelected()) opts.select(v);
+      // promotion -- wait for more information
+      // (at this point it must be a pawn move since no piece was selected)
+      if (v.match(/^[a-h](1|8)$/) && !force) return;
       else opts.san(foundUci.slice(0, 2), foundUci.slice(2));
       clear();
     } else if (sans && v.match(keyRegex)) {
@@ -25,8 +29,10 @@ window.lichess.keyboardMove = function(opts: any) {
       clear();
     } else if (sans && v.match(fileRegex)) {
       // do nothing
+    } else if (sans && v.match(promotionRegex)) {
+      opts.promote(v.slice(0,2), v.slice(3).toUpperCase());
+      clear();
     } else if (v.match(crazyhouseRegex)) {
-      // Crazyhouse
       if (v.length === 3) v = 'P' + v;
       opts.drop(v.slice(2), v[0].toUpperCase());
       clear();

--- a/ui/round/src/promotion.ts
+++ b/ui/round/src/promotion.ts
@@ -16,7 +16,7 @@ interface Promoting {
 let promoting: Promoting | undefined;
 let prePromotionRole: cg.Role | undefined;
 
-function sendPromotion(ctrl: RoundController, orig: cg.Key, dest: cg.Key, role: cg.Role, meta: cg.MoveMetadata): boolean {
+export function sendPromotion(ctrl: RoundController, orig: cg.Key, dest: cg.Key, role: cg.Role, meta: cg.MoveMetadata): boolean {
   ground.promote(ctrl.chessground, dest, role);
   ctrl.sendMove(orig, dest, role, meta);
   return true;


### PR DESCRIPTION
Fixes #4621 

Keyboard inputs like `b8=Q` or `b8=N` will now be valid. A user can force the selection dropdown to appear by typing for example `b8` and then pressing `ENTER`.

Update: inputs like `axb8=B` and `cb8=R` now also work