### PR TITLE
authenticationFailed: redirect to login

### DIFF
--- a/app/controllers/LilaController.scala
+++ b/app/controllers/LilaController.scala
@@ -348,7 +348,7 @@ private[controllers] trait LilaController
     negotiate(
       html = fuccess {
         implicit val req = ctx.req
-        Redirect(routes.Auth.signup) withCookies LilaCookie.session(Env.security.api.AccessUri, req.uri)
+        Redirect(routes.Auth.login) withCookies LilaCookie.session(Env.security.api.AccessUri, req.uri)
       },
       api = _ => ensureSessionId(ctx.req) {
         Unauthorized(jsonError("Login required"))


### PR DESCRIPTION
Instead of redirecting to signup. That's more logical - and how almost all websites do this.

(thanks to MMichael in the Lichess discord for reporting this)