### PR TITLE
[Testing needed] Add streamer URLs to user API, for #4948

### DIFF
--- a/modules/api/src/main/Env.scala
+++ b/modules/api/src/main/Env.scala
@@ -19,6 +19,7 @@ final class Env(
     getTourAndRanks: lila.game.Game => Fu[Option[lila.tournament.TourAndRanks]],
     crosstableApi: lila.game.CrosstableApi,
     prefApi: lila.pref.PrefApi,
+    streamerApi: lila.streamer.StreamerApi,
     playBanApi: lila.playban.PlaybanApi,
     gamePgnDump: lila.game.PgnDump,
     gameCache: lila.game.Cached,
@@ -95,7 +96,8 @@ final class Env(
     isPlaying = isPlaying,
     isOnline = userEnv.onlineUserIdMemo.get,
     recentTitledUserIds = () => userEnv.recentTitledUserIdMemo.keys,
-    prefApi = prefApi
+    prefApi = prefApi,
+    streamerApi = streamerApi
   )(system)
 
   val gameApi = new GameApi(
@@ -174,6 +176,7 @@ object Env {
     crosstableApi = lila.game.Env.current.crosstableApi,
     playBanApi = lila.playban.Env.current.api,
     prefApi = lila.pref.Env.current.api,
+    streamerApi = lila.streamer.Env.current.api,
     gamePgnDump = lila.game.Env.current.pgnDump,
     gameCache = lila.game.Env.current.cached,
     system = lila.common.PlayApp.system,

--- a/modules/api/src/main/UserApi.scala
+++ b/modules/api/src/main/UserApi.scala
@@ -115,8 +115,16 @@ private[api] final class UserApi(
                   "following" -> relation.has(true),
                   "blocking" -> relation.has(false),
                   "followsYou" -> isFollowed,
-                  "twitchStream" -> streamer.flatMap(_.twitch.map(_.minUrl)),
-                  "youTubeStream" -> streamer.flatMap(_.youTube.map(_.minUrl))
+                  "stream" -> streamer.map { s =>
+                    Json.obj(
+                     "twitch" -> s.twitch.map { t =>
+                        Json.obj("url" -> t.minUrl)
+                      },
+                    "youTube" -> s.youTube.map {y =>
+                      Json.obj("url" -> y.minUrl)
+                    }
+                    )
+                  }
                 ))
             }.noNull
         }


### PR DESCRIPTION
This curl works for non-streamer. `curl http://localhost:9663/api/user/gbfgbfgbf | json_pp`

It seems like I cannot make a streamer on my dev server. When I try, I get:
```
CommandError[code=2, errmsg=cannot use 'w' > 1 when a host is not replicated, doc: {
  ok: BSONDouble(0.0),
  errmsg: "cannot use 'w' > 1 when a host is not replicated",
  code: BSONInteger(2),
  codeName: "BadValue"
}]
```