### PR TITLE
Make giphy images embeddable in forum posts

### DIFF
--- a/modules/common/src/main/base/RawHtml.scala
+++ b/modules/common/src/main/base/RawHtml.scala
@@ -164,9 +164,11 @@ final object RawHtml {
   }
 
   private[this] val imgurRegex = """https?://(?:i\.)?imgur\.com/(\w+)(?:\.jpe?g|\.png|\.gif)?""".r
+  private[this] val giphyRegex = """https://(?:media\.giphy\.com/media/|giphy\.com/gifs/(?:\w+-)*)(\w+)(?:/giphy\.gif)?""".r
 
   private[this] def imgUrl(url: String): Option[String] = (url match {
     case imgurRegex(id) => Some(s"""https://i.imgur.com/$id.jpg""")
+    case giphyRegex(id) => Some(s"""https://media.giphy.com/media/$id/giphy.gif""")
     case _ => None
   }) map { img => s"""<img class="embed" src="$img" alt="$url"/>""" }
 

--- a/modules/common/src/test/RawHtmlTest.scala
+++ b/modules/common/src/test/RawHtmlTest.scala
@@ -40,6 +40,24 @@ class RawHtmlTest extends Specification {
       addLinks(s"""link to $url here""") must_==
         s"""link to <a rel="nofollow" href="$url" target="_blank">$url</a> here"""
     }
+    "detect direct giphy gif URL" in {
+      val url = "https://media.giphy.com/media/s0mE1d/giphy.gif"
+      val picUrl = "https://media.giphy.com/media/s0mE1d/giphy.gif"
+      addLinks(s"""img to $url here""") must_==
+        s"""img to <img class="embed" src="$picUrl" alt="$url"/> here"""
+    }
+    "detect indirect without tags giphy gif URL" in {
+      val url = "https://giphy.com/gifs/s0mE1d"
+      val picUrl = "https://media.giphy.com/media/s0mE1d/giphy.gif"
+      addLinks(s"""img to $url here""") must_==
+        s"""img to <img class="embed" src="$picUrl" alt="$url"/> here"""
+    }
+    "detect indirect with tags giphy gif URL" in {
+      val url = "https://giphy.com/gifs/some-text-1-s0mE1d"
+      val picUrl = "https://media.giphy.com/media/s0mE1d/giphy.gif"
+      addLinks(s"""img to $url here""") must_==
+        s"""img to <img class="embed" src="$picUrl" alt="$url"/> here"""
+    }
     "detect imgur image URL" in {
       val url = "https://imgur.com/NXy19Im"
       val picUrl = "https://i.imgur.com/NXy19Im.jpg"


### PR DESCRIPTION
This change will allow users to make posts with giphy images on forums by supplying a link in any of these formats:

- https://giphy.com/gifs/some-optional-tags-TheGifID
- https://giphy.com/gifs/TheGifID
- https://media.giphy.com/media/TheGifId/giphy.gif

Fixes #4888