### PR TITLE
Include global errors on team creation form

### DIFF
--- a/app/views/team/form.scala.html
+++ b/app/views/team/form.scala.html
@@ -9,6 +9,7 @@ formCss = true) {
   <div class="content_box small_box team_box">
     <h1>@trans.newTeam()</h1>
     <form class="form3" action="@routes.Team.create()" method="POST">
+      @form3.globalError(form)
       @form3.group(form("name"), trans.name.frag())(form3.input(_))
       @form3.group(form("open"), trans.joiningPolicy.frag()) { f =>
       @form3.select(form("open"), Seq(0 -> trans.aConfirmationIsRequiredToJoin.txt(), 1 -> trans.anyoneCanJoin.txt()))


### PR DESCRIPTION
This will also include global errors on the form for team creation. Now users will correctly by notified their chosen team name already exists.

Perhaps a better solution would be to not have this be a global error but a field error related to the 'team name' field.

Fixes #4958