### PR TITLE
Web push

### DIFF
--- a/app/Env.scala
+++ b/app/Env.scala
@@ -88,6 +88,7 @@ final class Env(
     _ <- Env.plan.api.cancel(user).nevermind
     _ <- Env.lobby.seekApi.removeByUser(user)
     _ <- Env.security.store.disconnect(user.id)
+    _ <- Env.push.webSubscriptionApi.unsubscribeByUser(user)
     _ <- Env.streamer.api.demote(user.id)
     _ <- Env.coach.api.remove(user.id)
     reports <- Env.report.api.processAndGetBySuspect(lila.report.Suspect(user))

--- a/app/controllers/Main.scala
+++ b/app/controllers/Main.scala
@@ -73,14 +73,6 @@ object Main extends LilaController {
     }
   }
 
-  def mobileRegister(platform: String, deviceId: String) = Auth { implicit ctx => me =>
-    Env.push.registerDevice(me, platform, deviceId)
-  }
-
-  def mobileUnregister = Auth { implicit ctx => me =>
-    Env.push.unregisterDevices(me)
-  }
-
   def jslog(id: String) = Open { ctx =>
     Env.round.selfReport(
       userId = ctx.userId,

--- a/app/controllers/Push.scala
+++ b/app/controllers/Push.scala
@@ -1,0 +1,32 @@
+package controllers
+
+import play.api.mvc._
+
+import lila.app._
+import lila.push.WebSubscription
+import lila.push.WebSubscription.readers._
+
+object Push extends LilaController {
+
+  def mobileRegister(platform: String, deviceId: String) = Auth { implicit ctx => me =>
+    Env.push.registerDevice(me, platform, deviceId)
+  }
+
+  def mobileUnregister = Auth { implicit ctx => me =>
+    Env.push.unregisterDevices(me)
+  }
+
+  def webSubscribe = AuthBody(BodyParsers.parse.json) { implicit ctx => me =>
+    ctx.body.body.validate[WebSubscription].fold(
+      err => BadRequest(err.toString).fuccess,
+      data => Env.push.webSubscribe(me, data) inject NoContent
+    )
+  }
+
+  def webUnsubscribe = AuthBody(BodyParsers.parse.json) { implicit ctx => me =>
+    ctx.body.body.validate[WebSubscription].fold(
+      err => BadRequest(err.toString).fuccess,
+      data => Env.push.webUnsubscribe(me, data) inject NoContent
+    )
+  }
+}

--- a/app/controllers/Push.scala
+++ b/app/controllers/Push.scala
@@ -17,16 +17,10 @@ object Push extends LilaController {
   }
 
   def webSubscribe = AuthBody(BodyParsers.parse.json) { implicit ctx => me =>
+    val currentSessionId = ~Env.security.api.reqSessionId(ctx.req)
     ctx.body.body.validate[WebSubscription].fold(
       err => BadRequest(err.toString).fuccess,
-      data => Env.push.webSubscribe(me, data) inject NoContent
-    )
-  }
-
-  def webUnsubscribe = AuthBody(BodyParsers.parse.json) { implicit ctx => me =>
-    ctx.body.body.validate[WebSubscription].fold(
-      err => BadRequest(err.toString).fuccess,
-      data => Env.push.webUnsubscribe(me, data) inject NoContent
+      data => Env.push.webSubscriptionApi.subscribe(me, data, currentSessionId) inject NoContent
     )
   }
 }

--- a/app/templating/AssetHelper.scala
+++ b/app/templating/AssetHelper.scala
@@ -15,6 +15,7 @@ trait AssetHelper { self: I18nHelper with SecurityHelper =>
   val siteDomain = lila.api.Env.current.Net.Domain
   val assetDomain = lila.api.Env.current.Net.AssetDomain
   val socketDomain = lila.api.Env.current.Net.SocketDomain
+  val vapidPublicKey = lila.push.Env.current.WebVapidPublicKey
 
   val sameAssetDomain = siteDomain == assetDomain
 

--- a/app/views/base/layout.scala
+++ b/app/views/base/layout.scala
@@ -82,6 +82,8 @@ object layout {
   private val spaceRegex = """\s{2,}+""".r
   private def spaceless(html: String) = raw(spaceRegex.replaceAllIn(html.replace("\\n", ""), ""))
 
+  private val dataDev = attr("data-dev")
+  private val dataVapid = attr("data-vapid")
   private val dataUser = attr("data-user")
   private val dataSoundSet = attr("data-sound-set")
   private val dataSocketDomain = attr("data-socket-domain")
@@ -151,6 +153,7 @@ object layout {
           "coords-out" -> (ctx.pref.coords == Pref.Coords.OUTSIDE)
         ),
         dataDev := (!isProd).option("true"),
+        dataVapid := vapidPublicKey,
         dataUser := ctx.userId,
         dataSoundSet := ctx.currentSoundSet.toString,
         dataSocketDomain := socketDomain,

--- a/app/views/base/layout.scala
+++ b/app/views/base/layout.scala
@@ -82,7 +82,6 @@ object layout {
   private val spaceRegex = """\s{2,}+""".r
   private def spaceless(html: String) = raw(spaceRegex.replaceAllIn(html.replace("\\n", ""), ""))
 
-  private val dataDev = attr("data-dev")
   private val dataVapid = attr("data-vapid")
   private val dataUser = attr("data-user")
   private val dataSoundSet = attr("data-sound-set")

--- a/app/views/base/layout.scala
+++ b/app/views/base/layout.scala
@@ -153,7 +153,7 @@ object layout {
           "coords-out" -> (ctx.pref.coords == Pref.Coords.OUTSIDE)
         ),
         dataDev := (!isProd).option("true"),
-        dataVapid := vapidPublicKey,
+        dataVapid := (ctx.userId.isDefined && isGranted(_.Beta)) option vapidPublicKey,
         dataUser := ctx.userId,
         dataSoundSet := ctx.currentSoundSet.toString,
         dataSocketDomain := socketDomain,

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -280,8 +280,8 @@ push {
     subscription = push_subscription
   }
   web {
-    vapid_public_key = "BPkkWdmHc+QUy5WQNPaR+6+QDe/8No1G1XzTxWe3oEWafVW9ICAQHxTKmvHJR3jMdUoEMVujbmfo7iOAnPr/l2Q="
-    url = "http://127.0.0.1:9054"
+    vapid_public_key = "BNHCgAkTcPNY/+QTW2Ccoo+SHTQ9+cTVa8bQQOqFPIBFedYZxJ3ih+GWBaFI2XmMb4PtdGv0e2l+8kYy3sZUGuY="
+    url = "http://push.lichess.ovh:9054"
   }
   onesignal {
     url = "https://onesignal.com/api/v1/notifications"

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -275,7 +275,14 @@ perfStat {
   collection.perf_stat = "perf_stat"
 }
 push {
-  collection.device = push_device
+  collection {
+    device = push_device
+    subscription = push_subscription
+  }
+  web {
+    vapid_public_key = "BPkkWdmHc+QUy5WQNPaR+6+QDe/8No1G1XzTxWe3oEWafVW9ICAQHxTKmvHJR3jMdUoEMVujbmfo7iOAnPr/l2Q="
+    url = "http://127.0.0.1:9054"
+  }
   onesignal {
     url = "https://onesignal.com/api/v1/notifications"
     app_id = ""

--- a/conf/routes
+++ b/conf/routes
@@ -574,7 +574,6 @@ POST  /dev/settings/:id                controllers.Dev.settingsPost(id: String)
 POST  /mobile/register/:platform/:deviceId controllers.Push.mobileRegister(platform: String, deviceId: String)
 POST  /mobile/unregister               controllers.Push.mobileUnregister
 POST  /push/subscribe                  controllers.Push.webSubscribe
-POST  /push/unsubscribe                controllers.Push.webUnsubscribe
 
 # Pages
 GET   /thanks                          controllers.Page.thanks

--- a/conf/routes
+++ b/conf/routes
@@ -570,9 +570,11 @@ POST  /cli                             controllers.Dev.command
 GET   /dev/settings                    controllers.Dev.settings
 POST  /dev/settings/:id                controllers.Dev.settingsPost(id: String)
 
-# Mobile Push
-POST  /mobile/register/:platform/:deviceId controllers.Main.mobileRegister(platform: String, deviceId: String)
-POST  /mobile/unregister               controllers.Main.mobileUnregister
+# Push
+POST  /mobile/register/:platform/:deviceId controllers.Push.mobileRegister(platform: String, deviceId: String)
+POST  /mobile/unregister               controllers.Push.mobileUnregister
+POST  /push/subscribe                  controllers.Push.webSubscribe
+POST  /push/unsubscribe                controllers.Push.webUnsubscribe
 
 # Pages
 GET   /thanks                          controllers.Page.thanks

--- a/modules/push/src/main/Env.scala
+++ b/modules/push/src/main/Env.scala
@@ -22,12 +22,10 @@ final class Env(
   val WebVapidPublicKey = config getString "web.vapid_public_key"
 
   private lazy val deviceApi = new DeviceApi(db(CollectionDevice))
-  private lazy val webSubscriptionApi = new WebSubscriptionApi(db(CollectionSubscription))
+  lazy val webSubscriptionApi = new WebSubscriptionApi(db(CollectionSubscription))
 
   def registerDevice = deviceApi.register _
   def unregisterDevices = deviceApi.unregister _
-  def webSubscribe = webSubscriptionApi.subscribe _
-  def webUnsubscribe = webSubscriptionApi.unsubscribe _
 
   private lazy val oneSignalPush = new OneSignalPush(
     deviceApi.findLastManyByUserId("onesignal", 3) _,

--- a/modules/push/src/main/Env.scala
+++ b/modules/push/src/main/Env.scala
@@ -37,7 +37,7 @@ final class Env(
   )
 
   private lazy val webPush = new WebPush(
-    webSubscriptionApi.getSubscriptions _,
+    webSubscriptionApi.getSubscriptions(5) _,
     url = WebUrl,
     vapidPublicKey = WebVapidPublicKey
   )

--- a/modules/push/src/main/Env.scala
+++ b/modules/push/src/main/Env.scala
@@ -12,14 +12,22 @@ final class Env(
 ) {
 
   private val CollectionDevice = config getString "collection.device"
+  private val CollectionSubscription = config getString "collection.subscription"
+
   private val OneSignalUrl = config getString "onesignal.url"
   private val OneSignalAppId = config getString "onesignal.app_id"
   private val OneSignalKey = config getString "onesignal.key"
 
+  private val WebUrl = config getString "web.url"
+  val WebVapidPublicKey = config getString "web.vapid_public_key"
+
   private lazy val deviceApi = new DeviceApi(db(CollectionDevice))
+  private lazy val webSubscriptionApi = new WebSubscriptionApi(db(CollectionSubscription))
 
   def registerDevice = deviceApi.register _
   def unregisterDevices = deviceApi.unregister _
+  def webSubscribe = webSubscriptionApi.subscribe _
+  def webUnsubscribe = webSubscriptionApi.unsubscribe _
 
   private lazy val oneSignalPush = new OneSignalPush(
     deviceApi.findLastManyByUserId("onesignal", 3) _,
@@ -28,8 +36,15 @@ final class Env(
     key = OneSignalKey
   )
 
+  private lazy val webPush = new WebPush(
+    webSubscriptionApi.getSubscriptions _,
+    url = WebUrl,
+    vapidPublicKey = WebVapidPublicKey
+  )
+
   private lazy val pushApi = new PushApi(
     oneSignalPush,
+    webPush,
     getLightUser,
     bus = system.lilaBus,
     scheduler = scheduler

--- a/modules/push/src/main/PushApi.scala
+++ b/modules/push/src/main/PushApi.scala
@@ -9,12 +9,14 @@ import chess.format.Forsyth
 import lila.challenge.Challenge
 import lila.common.LightUser
 import lila.game.{ Game, GameRepo, Pov, Namer }
+import lila.user.User
 import lila.hub.actorApi.map.Tell
 import lila.hub.actorApi.round.{ MoveEvent, IsOnGame }
 import lila.message.{ Thread, Post }
 
 private final class PushApi(
     oneSignalPush: OneSignalPush,
+    webPush: WebPush,
     implicit val lightUser: LightUser.GetterSync,
     bus: lila.common.Bus,
     scheduler: lila.common.Scheduler
@@ -203,8 +205,8 @@ private final class PushApi(
 
   private type MonitorType = lila.mon.push.send.type => (String => Unit)
 
-  private def pushToAll(userId: String, monitor: MonitorType, data: PushApi.Data): Funit =
-    oneSignalPush(userId) {
+  private def pushToAll(userId: User.ID, monitor: MonitorType, data: PushApi.Data): Funit =
+    webPush(userId)(data) >> oneSignalPush(userId) {
       monitor(lila.mon.push.send)("onesignal")
       data
     }

--- a/modules/push/src/main/WebPush.scala
+++ b/modules/push/src/main/WebPush.scala
@@ -1,0 +1,43 @@
+package lila.push
+
+import play.api.libs.json._
+import play.api.libs.ws.WS
+import play.api.Play.current
+
+import lila.user.User
+
+private final class WebPush(
+    getSubscriptions: User.ID => Fu[List[WebSubscription]],
+    url: String,
+    vapidPublicKey: String
+) {
+
+  def apply(userId: User.ID)(data: => PushApi.Data): Funit =
+    getSubscriptions(userId) flatMap { subscriptions: List[WebSubscription] =>
+      subscriptions.map(send(_, data)).sequenceFu.void
+    }
+
+  private def send(sub: WebSubscription, data: PushApi.Data): Funit = {
+    WS.url(url)
+      .withHeaders("ContentType" -> "application/json")
+      .post(Json.obj(
+        "sub" -> Json.obj(
+          "endpoint" -> sub.endpoint,
+          "keys" -> Json.obj(
+            "p256dh" -> sub.p256dh,
+            "auth" -> sub.auth
+          )
+        ),
+        "payload" -> Json.obj(
+          "title" -> data.title,
+          "body" -> data.body,
+          "stacking" -> data.stacking.key,
+          "payload" -> data.payload
+        ).toString,
+        "ttl" -> 43200
+      )).flatMap {
+        case res if res.status == 204 => funit
+        case res => fufail(s"[push] web: ${res.status} ${res.body}")
+      }
+  }
+}

--- a/modules/push/src/main/WebPush.scala
+++ b/modules/push/src/main/WebPush.scala
@@ -1,5 +1,7 @@
 package lila.push
 
+import scalaz.NonEmptyList
+
 import play.api.libs.json._
 import play.api.libs.ws.WS
 import play.api.Play.current
@@ -13,29 +15,33 @@ private final class WebPush(
 ) {
 
   def apply(userId: User.ID)(data: => PushApi.Data): Funit =
-    getSubscriptions(userId) flatMap { subscriptions: List[WebSubscription] =>
-      WS.url(url)
-        .withHeaders("ContentType" -> "application/json")
-        .post(Json.obj(
-          "subs" -> JsArray(subscriptions.map { sub =>
-            Json.obj(
-              "endpoint" -> sub.endpoint,
-              "keys" -> Json.obj(
-                "p256dh" -> sub.p256dh,
-                "auth" -> sub.auth
-              )
-            )
-          }),
-          "payload" -> Json.obj(
-            "title" -> data.title,
-            "body" -> data.body,
-            "stacking" -> data.stacking.key,
-            "payload" -> data.payload
-          ).toString,
-          "ttl" -> 43200
-        ))
-    } flatMap {
-      case res if res.status == 200 => funit
-      case res => fufail(s"[push] web: ${res.status} ${res.body}")
+    getSubscriptions(userId) flatMap { subscriptions =>
+      subscriptions.toNel ?? send(data)
     }
+
+  private def send(data: => PushApi.Data)(subscriptions: NonEmptyList[WebSubscription]): Funit = {
+    WS.url(url)
+      .withHeaders("ContentType" -> "application/json")
+      .post(Json.obj(
+        "subs" -> JsArray(subscriptions.map { sub =>
+          Json.obj(
+            "endpoint" -> sub.endpoint,
+            "keys" -> Json.obj(
+              "p256dh" -> sub.p256dh,
+              "auth" -> sub.auth
+            )
+          )
+        }.toList),
+        "payload" -> Json.obj(
+          "title" -> data.title,
+          "body" -> data.body,
+          "stacking" -> data.stacking.key,
+          "payload" -> data.payload
+        ).toString,
+        "ttl" -> 43200
+      )) flatMap {
+        case res if res.status == 200 => funit
+        case res => fufail(s"[push] web: ${res.status} ${res.body}")
+      }
+  }
 }

--- a/modules/push/src/main/WebPush.scala
+++ b/modules/push/src/main/WebPush.scala
@@ -14,30 +14,28 @@ private final class WebPush(
 
   def apply(userId: User.ID)(data: => PushApi.Data): Funit =
     getSubscriptions(userId) flatMap { subscriptions: List[WebSubscription] =>
-      subscriptions.map(send(_, data)).sequenceFu.void
+      WS.url(url)
+        .withHeaders("ContentType" -> "application/json")
+        .post(Json.obj(
+          "subs" -> JsArray(subscriptions.map { sub =>
+            Json.obj(
+              "endpoint" -> sub.endpoint,
+              "keys" -> Json.obj(
+                "p256dh" -> sub.p256dh,
+                "auth" -> sub.auth
+              )
+            )
+          }),
+          "payload" -> Json.obj(
+            "title" -> data.title,
+            "body" -> data.body,
+            "stacking" -> data.stacking.key,
+            "payload" -> data.payload
+          ).toString,
+          "ttl" -> 43200
+        ))
+    } flatMap {
+      case res if res.status == 200 => funit
+      case res => fufail(s"[push] web: ${res.status} ${res.body}")
     }
-
-  private def send(sub: WebSubscription, data: PushApi.Data): Funit = {
-    WS.url(url)
-      .withHeaders("ContentType" -> "application/json")
-      .post(Json.obj(
-        "sub" -> Json.obj(
-          "endpoint" -> sub.endpoint,
-          "keys" -> Json.obj(
-            "p256dh" -> sub.p256dh,
-            "auth" -> sub.auth
-          )
-        ),
-        "payload" -> Json.obj(
-          "title" -> data.title,
-          "body" -> data.body,
-          "stacking" -> data.stacking.key,
-          "payload" -> data.payload
-        ).toString,
-        "ttl" -> 43200
-      )).flatMap {
-        case res if res.status == 204 => funit
-        case res => fufail(s"[push] web: ${res.status} ${res.body}")
-      }
-  }
 }

--- a/modules/push/src/main/WebSubscription.scala
+++ b/modules/push/src/main/WebSubscription.scala
@@ -1,0 +1,21 @@
+package lila.push
+
+final case class WebSubscription(
+    endpoint: String,
+    auth: String,
+    p256dh: String
+)
+
+object WebSubscription {
+
+  object readers {
+    import play.api.libs.json._
+    import play.api.libs.functional.syntax._
+
+    implicit val WebSubscriptionReads: Reads[WebSubscription] = (
+      (__ \ "endpoint").read[String] and
+      (__ \ "keys" \ "auth").read[String] and
+      (__ \ "keys" \ "p256dh").read[String]
+    )(WebSubscription.apply _)
+  }
+}

--- a/modules/push/src/main/WebSubscriptionApi.scala
+++ b/modules/push/src/main/WebSubscriptionApi.scala
@@ -24,7 +24,6 @@ final class WebSubscriptionApi(coll: Coll) {
 
   def subscribe(user: User, subscription: WebSubscription, sessionId: String): Funit = {
     coll.update($id(subscription.endpoint), $doc(
-      "_id" -> subscription.endpoint,
       "userId" -> user.id,
       "sessionId" -> sessionId,
       "auth" -> subscription.auth,

--- a/modules/push/src/main/WebSubscriptionApi.scala
+++ b/modules/push/src/main/WebSubscriptionApi.scala
@@ -1,0 +1,39 @@
+package lila.push
+
+import reactivemongo.bson._
+
+import lila.db.dsl._
+import lila.user.User
+
+private final class WebSubscriptionApi(coll: Coll) {
+
+  def getSubscriptions(userId: User.ID): Fu[List[WebSubscription]] =
+    // TODO: This query needs an index.
+    coll.find($doc(
+      "userId" -> userId
+    )).list[Bdoc](3).map { docs =>
+      docs.flatMap { doc =>
+        for {
+          endpoint <- doc.getAs[String]("_id")
+          auth <- doc.getAs[String]("auth")
+          p256dh <- doc.getAs[String]("p256dh")
+        } yield WebSubscription(endpoint, auth, p256dh)
+      }
+    }
+
+  def subscribe(user: User, subscription: WebSubscription): Funit = {
+    coll.update($id(subscription.endpoint), $doc(
+      "_id" -> subscription.endpoint,
+      "userId" -> user.id,
+      "auth" -> subscription.auth,
+      "p256dh" -> subscription.p256dh
+    ), upsert = true).void
+  }
+
+  def unsubscribe(user: User, subscription: WebSubscription): Funit = {
+    coll.remove($doc(
+      "_id" -> subscription.endpoint,
+      "userId" -> user.id
+    )).void
+  }
+}

--- a/modules/push/src/main/WebSubscriptionApi.scala
+++ b/modules/push/src/main/WebSubscriptionApi.scala
@@ -1,5 +1,7 @@
 package lila.push
 
+import org.joda.time.DateTime
+
 import reactivemongo.bson._
 
 import lila.db.dsl._
@@ -7,11 +9,11 @@ import lila.user.User
 
 private final class WebSubscriptionApi(coll: Coll) {
 
-  def getSubscriptions(userId: User.ID): Fu[List[WebSubscription]] =
+  def getSubscriptions(max: Int)(userId: User.ID): Fu[List[WebSubscription]] =
     // TODO: This query needs an index.
     coll.find($doc(
       "userId" -> userId
-    )).list[Bdoc](3).map { docs =>
+    )).sort($doc("seenAt" -> -1)).list[Bdoc](max).map { docs =>
       docs.flatMap { doc =>
         for {
           endpoint <- doc.getAs[String]("_id")
@@ -26,7 +28,8 @@ private final class WebSubscriptionApi(coll: Coll) {
       "_id" -> subscription.endpoint,
       "userId" -> user.id,
       "auth" -> subscription.auth,
-      "p256dh" -> subscription.p256dh
+      "p256dh" -> subscription.p256dh,
+      "seenAt" -> DateTime.now
     ), upsert = true).void
   }
 

--- a/public/javascripts/service-worker.js
+++ b/public/javascripts/service-worker.js
@@ -22,11 +22,27 @@ self.addEventListener('notificationclick', event => {
       includeUncontrolled: true
     });
   }).then(windowClients => {
-    var data = event.notification.data.userData;
-    if (data.fullId) return clients.openWindow('/' + data.fullId);
-    if (data.threadId) return clients.openWindow('/inbox/' + data.threadId + '#bottom');
-    if (data.challengeId) return clients.openWindow('/' + data.challengeId);
-    if (windowClients.length) windowClients[0].focus();
-    else return clients.openWindow('/');
+    // determine url
+    var data = event.notification.data.userData, url = '/';
+    if (data.fullId) url = '/' + data.fullId;
+    else if (data.threadId) url = '/inbox/' + data.threadId + '#bottom';
+    else if (data.challengeId) url = '/' + data.challengeId;
+
+    // focus open window with same url
+    for (var i = 0; i < windowClients.length; i++) {
+      var client = windowClients[i];
+      var clientUrl = new URL(client.url, self.location.href);
+      if (clientUrl.pathname === url && 'focus' in client) return client.focus();
+    }
+
+    // navigate from open homepage to url
+    for (var i = 0; i < windowClients.length; i++) {
+      var client = windowClients[i];
+      var clientUrl = new URL(client.url, self.location.href);
+      if (clientUrl.pathname === '/') return client.navigate(url);
+    }
+
+    // open new window
+    clients.openWindow(url);
   }));
 });

--- a/public/javascripts/service-worker.js
+++ b/public/javascripts/service-worker.js
@@ -1,0 +1,32 @@
+self.addEventListener('push', event => {
+  var data = event.data.json();
+  event.waitUntil(self.registration.getNotifications().then(notifications => {
+    notifications.forEach(notification => {
+      if (notification.tag === data.stack) notification.close();
+    });
+    return self.registration.showNotification(data.title, {
+      badge: 'https://lichess1.org/assets/images/logo.256.png',
+      icon: 'https://lichess1.org/assets/images/logo.256.png',
+      body: data.body,
+      tag: data.stack,
+      data: data.payload
+    });
+  }));
+});
+
+self.addEventListener('notificationclick', event => {
+  event.waitUntil(self.registration.getNotifications().then(notifications => {
+    notifications.forEach(notification => notification.close());
+    return clients.matchAll({
+      type: 'window',
+      includeUncontrolled: true
+    });
+  }).then(windowClients => {
+    var data = event.notification.data.userData;
+    if (data.fullId) return clients.openWindow('/' + data.fullId);
+    if (data.threadId) return clients.openWindow('/inbox/' + data.threadId + '#bottom');
+    if (data.challengeId) return clients.openWindow('/' + data.challengeId);
+    if (windowClients.length) windowClients[0].focus();
+    else return clients.openWindow('/');
+  }));
+});

--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -60,6 +60,7 @@ interface Lichess {
   hasTouchEvents: boolean;
   mousedownEvent: 'mousedown' | 'touchstart';
   isCol1(): boolean;
+  pushSubscribe(ask: boolean): void;
 }
 
 interface LichessSpeech {

--- a/ui/challenge/src/ctrl.ts
+++ b/ui/challenge/src/ctrl.ts
@@ -27,7 +27,8 @@ export default function(opts: ChallengeOpts, data: ChallengeData, redraw: () => 
           opts.show();
           li.sound.newChallenge();
         }
-        !('PushManager' in window) && c.challenger && notify(showUser(c.challenger) + ' challenges you!');
+        const pushSubsribed = parseInt(li.storage.get('push-subscribed') || '0', 10) + 86400000 < Date.now(); // 24h
+        !pushSubsribed && c.challenger && notify(showUser(c.challenger) + ' challenges you!');
         opts.pulse();
       }
     });

--- a/ui/challenge/src/ctrl.ts
+++ b/ui/challenge/src/ctrl.ts
@@ -27,7 +27,7 @@ export default function(opts: ChallengeOpts, data: ChallengeData, redraw: () => 
           opts.show();
           li.sound.newChallenge();
         }
-        c.challenger && notify(showUser(c.challenger) + ' challenges you!');
+        !('PushManager' in window) && c.challenger && notify(showUser(c.challenger) + ' challenges you!');
         opts.pulse();
       }
     });

--- a/ui/common/src/notification.ts
+++ b/ui/common/src/notification.ts
@@ -32,7 +32,10 @@ export default function(msg: string | (() => string)) {
     setTimeout(notify, 10 + Math.random() * 500, msg);
   } else if (Notification.permission !== 'denied') {
     Notification.requestPermission(function(p) {
-      if (p === 'granted') notify(msg);
+      if (p === 'granted') {
+        notify(msg);
+        window.lichess.pushSubscribe(false);
+      }
     });
   };
 }

--- a/ui/notify/src/ctrl.ts
+++ b/ui/notify/src/ctrl.ts
@@ -41,6 +41,7 @@ export default function ctrl(opts: NotifyOpts, redraw: Redraw): Ctrl {
     opts.pulse();
     if (!li.quietMode) li.sound.newPM();
     const text = asText(notif);
+    if ('PushManager' in window) return;
     if (text) notify(text);
   }
 

--- a/ui/notify/src/ctrl.ts
+++ b/ui/notify/src/ctrl.ts
@@ -41,8 +41,8 @@ export default function ctrl(opts: NotifyOpts, redraw: Redraw): Ctrl {
     opts.pulse();
     if (!li.quietMode) li.sound.newPM();
     const text = asText(notif);
-    if ('PushManager' in window) return;
-    if (text) notify(text);
+    const pushSubsribed = parseInt(li.storage.get('push-subscribed') || '0', 10) + 86400000 < Date.now(); // 24h
+    if (!pushSubsribed && text) notify(text);
   }
 
   function loadPage(page: number) {

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -110,7 +110,8 @@ export default class RoundController {
 
     setTimeout(this.showExpiration, 350);
 
-    setTimeout(this.showYourMoveNotification, 500);
+    if (!document.referrer || document.referrer.indexOf('/service-worker.js') === -1)
+      setTimeout(this.showYourMoveNotification, 500);
 
     // at the end:
     li.pubsub.on('jump', ply => { this.jump(parseInt(ply)); this.redraw(); });

--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -997,7 +997,7 @@
             })).then(res => {
               if (res.ok) storage.set('' + Date.now());
               else throw Error(response.statusText);
-            });
+            }).catch(err => console.log('push subscribe failed', err.message));
           }
         });
         else storage.remove();

--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -969,7 +969,8 @@
   // service worker //
   ////////////////////
 
-  if (document.body.getAttribute('data-vapid') && 'serviceWorker' in navigator && 'Notification' in window && 'PushManager' in window) {
+  var pushBeta = !!document.body.getAttribute('data-vapid');
+  if (pushBeta && 'serviceWorker' in navigator && 'Notification' in window && 'PushManager' in window) {
     var workerUrl = lichess.assetUrl('javascripts/service-worker.js', {noVersion: true, sameDomain: true});
     navigator.serviceWorker.register(workerUrl, {scope: '/'});
   }

--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -969,7 +969,7 @@
   // service worker //
   ////////////////////
 
-  if ('serviceWorker' in navigator && 'Notification' in window && 'PushManager' in window) {
+  if (document.body.getAttribute('data-vapid') && 'serviceWorker' in navigator && 'Notification' in window && 'PushManager' in window) {
     var workerUrl = lichess.assetUrl('javascripts/service-worker.js', {noVersion: true, sameDomain: true});
     navigator.serviceWorker.register(workerUrl, {scope: '/'});
   }
@@ -977,10 +977,10 @@
   lichess.pushSubscribe = function(ask) {
     if ('serviceWorker' in navigator && 'Notification' in window && 'PushManager' in window) {
       navigator.serviceWorker.ready.then(reg => {
+        var storage = lichess.storage.make('push-subscribed');
         var vapid = document.body.getAttribute('data-vapid');
         var allowed = (ask || Notification.permission === 'granted') && Notification.permission !== 'denied';
         if (vapid && allowed) return reg.pushManager.getSubscription().then(sub => {
-          var storage = lichess.storage.make('push-subscribed');
           var resub = parseInt(storage.get() || '0', 10) + 43200000 < Date.now(); // 12 hours
           var applicationServerKey = Uint8Array.from(atob(vapid), c => c.charCodeAt(0));
           if (!sub || resub) {
@@ -999,6 +999,7 @@
             });
           }
         });
+        else storage.remove();
       });
     }
   };


### PR DESCRIPTION
Implements #3360.

New version of #5009, this time using a new HTTP service to do the crypto and communication with push endpoints: https://github.com/niklasf/lila-push

Todo / open questions:
* [x] Conflicts with existing notifications. Current solution: Local notifications disabled, if web push appears to be supported
* [x] ~User interface / configuration (disable specific types of notifications?) / when to ask for permission~ Beta without UI
* [x] Expiration and resubscription
* [x] Improve notification click handler
* [ ] Index MongoDB collection by `userId` and by `sessionId`
* [x] What happens on logout? Subscription tied to session? Yes