### PR TITLE
session ids with 128 bits of entropy (fixes #5033)

### DIFF
--- a/modules/security/src/main/SecurityApi.scala
+++ b/modules/security/src/main/SecurityApi.scala
@@ -72,12 +72,12 @@ final class SecurityApi(
     UserRepo mustConfirmEmail userId flatMap {
       case true => fufail(SecurityApi MustConfirmEmail userId)
       case false =>
-        val sessionId = Random secureString 12
+        val sessionId = Random secureString 22
         Store.save(sessionId, userId, req, apiVersion, up = true, fp = none) inject sessionId
     }
 
   def saveSignup(userId: User.ID, apiVersion: Option[ApiVersion], fp: Option[FingerPrint])(implicit req: RequestHeader): Funit = {
-    val sessionId = Random secureString 8
+    val sessionId = Random secureString 22
     Store.save(s"SIG-$sessionId", userId, req, apiVersion, up = false, fp = fp)
   }
 


### PR DESCRIPTION
n chosen such that (10 + 26 + 26)^n >= 2^128, as recommended by [owasp](https://www.owasp.org/index.php/Insufficient_Session-ID_Length)