### PR TITLE
Improve move-dest dot

### DIFF
--- a/ui/common/css/vendor/chessground/_chessground.scss
+++ b/ui/common/css/vendor/chessground/_chessground.scss
@@ -15,11 +15,11 @@ square {
   height: 12.5%;
   pointer-events: none;
   &.move-dest {
-    background: radial-gradient(rgba(20, 85, 30, 0.5) 19%, #208530 0, rgba(0, 0, 0, 0.3) 0, rgba(0, 0, 0, 0) 0);
+    background: radial-gradient(rgba(20, 85, 30, 0.5) 19%, rgba(0, 0, 0, 0) 20%);
     pointer-events: auto;
   }
   &.premove-dest {
-    background: radial-gradient(rgba(20, 30, 85, 0.5) 19%, #203085 0, rgba(0, 0, 0, 0.3) 0, rgba(0, 0, 0, 0) 0);
+    background: radial-gradient(rgba(20, 30, 85, 0.5) 19%, rgba(0, 0, 0, 0) 20%);
     pointer-events: auto;
   }
   &.oc.move-dest {


### PR DESCRIPTION
This fixes edge artifacts (at least at 4k) of the dot

Before
![Selection_169](https://user-images.githubusercontent.com/700546/57214570-fe6c9680-6faf-11e9-92c6-86d3ea0eee5f.png)

After
![Selection_170](https://user-images.githubusercontent.com/700546/57214563-fa407900-6faf-11e9-9b6b-66a756fd7607.png)
