### PR TITLE
Make nginx error pages responsive

### DIFF
--- a/public/oops/disabled.html
+++ b/public/oops/disabled.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="refresh" content="10">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Temporary disabled</title>
     <style type="text/css">
       @font-face {
@@ -17,6 +18,9 @@
         background: #000;
         color: #ebd488;
         text-align: center;
+        width: 100%;
+        margin: 0; 
+        padding: 0;
       }
       h1 {
         font-size: 30px;
@@ -24,6 +28,21 @@
       a {
         color: #fff;
       }
+
+      @media (max-width: 1024px) {
+        img {
+          margin: 0 auto;
+          width: 90%;
+          height: auto;
+        }
+
+        body {
+          padding: 0 10px;
+          box-sizing: border-box;
+        }
+      }
+      
+
     </style>
     <meta content="noindex, nofollow" name="robots">
   </head>

--- a/public/oops/scheduled-maintenance.html
+++ b/public/oops/scheduled-maintenance.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>lichess - maintenance in progress</title>
     <style type="text/css">
       body {
@@ -14,6 +15,7 @@
         margin: 0;
         padding: 0;
         height: 100%;
+        width: 100%;
       }
       h1 { font-size: 3em; margin: 0.8em 0 0 0; font-weight: normal }
       h2 { font-size: 1.2em; font-style: italic; font-weight: normal; margin: 0; }
@@ -37,6 +39,37 @@
         text-align: left;
       }
       .game { margin: 1em 0; }
+
+      @media (max-width: 767px) {
+
+        .explain {
+          padding: 1.5em 10px;
+          box-sizing: border-box;
+        }
+
+        .more {
+          text-align: center;
+          margin: 0;
+        }
+
+        .panels {
+          flex-direction: column-reverse;
+        }
+
+        .twitter {
+          margin-top: 20px;
+        }
+
+        .game {
+          display: none;
+        }
+
+        .hide-for-mobile {
+          display: none;
+        }
+      }
+
+
     </style>
     <meta content="noindex, nofollow" name="robots">
     <link href="https://fonts.googleapis.com/css?family=Noto+Sans:400,700|Roboto:300" rel="stylesheet">
@@ -55,7 +88,7 @@
         To get updates on the maintenance,<br />
         join <a href="https://twitter.com/lichess">@lichess on twitter</a> or
         <a href="https://discord.gg/hy5jqSs">the lichess discord</a>.<br />
-        To pass the time, try out this minigame:
+        <div class="hide-for-mobile">To pass the time, try out this minigame:</div>
         <div class="game">
           <iframe
             src="//lichess1.org/assets/vendor/ChessPursuit/bin-release/index.html"

--- a/public/oops/servererror.html
+++ b/public/oops/servererror.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>lichess is down</title>
     <style type="text/css">
       @font-face {
@@ -16,6 +17,9 @@
         background: #000;
         color: #ebd488;
         text-align: center;
+        width: 100%;
+        margin: 0;
+        padding: 0;
       }
       h1 {
         font-size: 30px;
@@ -32,6 +36,22 @@
         width: 1000px;
         height: 958px;
       }
+      
+      @media (max-width: 1024px) {
+        img#robot {
+          margin: 0 auto;
+          width: 90%;
+          height: auto;
+        }
+
+        body {
+          padding: 0 10px;
+          box-sizing: border-box;
+        }
+      }
+
+
+
     </style>
     <meta content="noindex, nofollow" name="robots">
   </head>
@@ -55,7 +75,7 @@
         tick();
       }
 
-      if (location.host == 'lichess.org') fadeIn(document.getElementById('robot'));
+      if (location.host !== 'lichess.org') fadeIn(document.getElementById('robot'));
     </script>
   </body>
 </html>

--- a/public/oops/servererror.html
+++ b/public/oops/servererror.html
@@ -75,7 +75,7 @@
         tick();
       }
 
-      if (location.host !== 'lichess.org') fadeIn(document.getElementById('robot'));
+      if (location.host == 'lichess.org') fadeIn(document.getElementById('robot'));
     </script>
   </body>
 </html>

--- a/public/oops/timeout.html
+++ b/public/oops/timeout.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>lichess - timeout</title>
     <style type="text/css">
       @font-face {
@@ -16,10 +17,28 @@
         background: #000;
         color: #ebd488;
         text-align: center;
+        width: 100%;
+        margin: 0;
+        padding: 0;
       }
       h1 {
         font-size: 30px;
       }
+
+      @media (max-width: 1024px) {
+        img {
+          margin: 0 auto;
+          width: 90%;
+          height: auto;
+        }
+
+        body {
+          padding: 0 10px;
+          box-sizing: border-box;
+        }
+      }
+
+
     </style>
     <meta content="noindex, nofollow" name="robots">
   </head>

--- a/public/oops/toomanyrequests.html
+++ b/public/oops/toomanyrequests.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>lichess - too many requests</title>
     <style type="text/css">
       html, body, a {
@@ -11,6 +12,33 @@
         text-align: center;
         line-height: 1.6em;
       }
+
+      html, body {
+        width: 100%;
+        margin: 0; 
+        padding: 0;
+      }
+
+
+      @media (max-width: 767px) {
+        .game {
+          display: none;
+        }
+
+        .hide-for-mobile {
+          display: none;
+        }
+
+        body {
+          padding: 0 10px;
+          box-sizing: border-box;
+        }
+      }
+
+      
+
+
+
     </style>
     <meta content="noindex, nofollow" name="robots">
   </head>
@@ -18,7 +46,7 @@
     <h1>lichess.org - too many requests</h1>
     <p>
       Your network has sent too many requests! Try again later.<br />
-      In the meantime, try out that fun little game:
+      <div class="hide-for-mobile">In the meantime, try out that fun little game:</div>
     </p>
     <div class="game">
       <iframe


### PR DESCRIPTION
PR to address issue #5034 

This PR makes the nginx error pages (contained within public > oops) responsive using the viewport meta and css media queries, making them readable without zooming or scrolling. The queries also include some logic to hide the _Chess Pursuit_ game for when the display is not wide enough (in the case of mobile displays), but remains visible for tablet displays. 

### Screenshots:

<img width="150" alt="Screen Shot 2019-05-19 at 2 38 04 AM" src="https://user-images.githubusercontent.com/14301342/57975214-9f147a80-79e2-11e9-8729-a4683fe95a8c.png">
<img width="150" alt="Screen Shot 2019-05-19 at 2 38 42 AM" src="https://user-images.githubusercontent.com/14301342/57975215-9fad1100-79e2-11e9-971f-bd9c76f1284e.png">
<img width="300" alt="Screen Shot 2019-05-19 at 2 43 03 AM" src="https://user-images.githubusercontent.com/14301342/57975217-9fad1100-79e2-11e9-9759-680b15de1ed8.png">



