### PR TITLE
Fix text-to-speech bug 

### DIFF
--- a/ui/speech/src/main.ts
+++ b/ui/speech/src/main.ts
@@ -23,7 +23,8 @@ function renderSan(san: San) {
 function hackFix(msg: string): string {
 
   return msg
-    .replace(/^A /, "A, "); // "A takes" & "A 3" are mispronounced
+    .replace(/^A /, "A, ") // "A takes" & "A 3" are mispronounced
+    .replace(/(\d) E (\d)/, "$1,E $2"); // Strings such as 1E5 are treated as scientific notation
 }
 
 export function say(text: string, cut: boolean) {
@@ -32,6 +33,6 @@ export function say(text: string, cut: boolean) {
   window.lichess.sound.say(msg);
 }
 
-export function step(s: { san?: San}, cut: boolean) {
+export function step(s: { san?: San }, cut: boolean) {
   say(s.san ? renderSan(s.san) : 'Game start', cut);
 }


### PR DESCRIPTION
Closes #5094.

Hacky fix to prevent a bug where SAN such as `R1e5` has its substring `1e5` being parsed by the `SpeechSynthesiser` as a number in scientific notation.