### PR TITLE
Add types to round History

### DIFF
--- a/modules/round/src/main/RoundSocket.scala
+++ b/modules/round/src/main/RoundSocket.scala
@@ -184,7 +184,10 @@ private[round] final class RoundSocket(
         }
       }
       val events = version.fold(history.getRecentEvents(5).some) { v =>
-        history.getEventsSince(v, lila.mon.round.history(mobile).some)
+        history.getEventsSince(v, lila.mon.round.history(mobile).some) match {
+          case History.Types.Events(e) => e.some
+          case _ => None
+        }
       }
 
       val initialMsgs = events.fold(SocketTrouper.resyncMessage.some) {


### PR DESCRIPTION
Add case classes to getEventsSince to make the function more
readable. This also prepares for additional monitoring and
other refactors.