### PR TITLE
Recognize Prespes agreement

### DIFF
--- a/modules/user/src/main/Countries.scala
+++ b/modules/user/src/main/Countries.scala
@@ -165,7 +165,7 @@ object Countries {
     C("MF", "Saint Martin"),
     C("MG", "Madagascar"),
     C("MH", "Marshall Islands"),
-    C("MK", "Macedonia"),
+    C("MK", "North Macedonia"),
     C("ML", "Mali"),
     C("MM", "Myanmar"),
     C("MN", "Mongolia"),


### PR DESCRIPTION
> Last June 12, the two nations signed the Prespa Agreement, in which the Republic of Macedonia agreed to change its official name to the Republic of North Macedonia. In exchange, Greece dropped its opposition to the country’s accession to NATO and agreed to ratify “any of the Second Party’s accession agreement to International Organizations, of which the First Party is a member.”

https://www.dailysignal.com/2019/05/08/after-clearing-a-hellenic-hurdle-macedonias-bid-to-join-nato-heads-to-senate/
https://en.wikipedia.org/wiki/Prespa_agreement