### PR TITLE
Players can only cancel takeback offers on their turn

### DIFF
--- a/modules/round/src/main/Takebacker.scala
+++ b/modules/round/src/main/Takebacker.scala
@@ -30,7 +30,7 @@ private[round] final class Takebacker(
   }
 
   def no(situation: Round.TakebackSituation)(pov: Pov)(implicit proxy: GameProxy): Fu[(Events, Round.TakebackSituation)] = pov match {
-    case Pov(game, color) if pov.player.isProposingTakeback => proxy.save {
+    case Pov(game, color) if pov.player.isProposingTakeback && pov.isMyTurn => proxy.save {
       messenger.system(game, _.takebackPropositionCanceled)
       Progress(game) map { g => g.updatePlayer(color, _.removeTakebackProposition) }
     } inject {


### PR DESCRIPTION
Canceling a takeback offer might be rude.  Canceling it on your opponent's turn (after you moved, while their clock is ticking) is unsportsmanlike.  I don't know, maybe moving should cancel your offer in case you weren't serious about it.

(Declining an opponent's takeback offer is always fair game.)