### PR TITLE
Store history events in ArrayDeque

### DIFF
--- a/modules/round/src/main/History.scala
+++ b/modules/round/src/main/History.scala
@@ -1,7 +1,6 @@
 package lila.round
 
 import java.util.ArrayDeque
-import scala.collection.mutable.ListBuffer
 import scala.collection.JavaConverters._
 
 import org.joda.time.DateTime
@@ -88,7 +87,7 @@ private final class History(
 
     removeTail(History.maxSize - xs.size)
     pruneEvents(date - History.expireAfterSeconds)
-    val veBuff = ListBuffer[VersionedEvent]()
+    val veBuff = List.newBuilder[VersionedEvent]
     xs.foldLeft(getVersion.inc) {
       case (vnext, e) =>
         val ve = VersionedEvent(e, vnext, date)

--- a/modules/round/src/main/History.scala
+++ b/modules/round/src/main/History.scala
@@ -33,8 +33,8 @@ private final class History(
 
   def versionDebugString: String = {
     waitForLoadedEvents
-    Option(events.peekFirst).fold("-:-") { h =>
-      s"${events.peekLast}:${h.version}@${h.date - nowSeconds}s"
+    Option(events.peekLast).fold("-:-") { l =>
+      s"${events.peekFirst}:${l.version}@${l.date - nowSeconds}s"
     }
   }
 

--- a/modules/round/src/main/History.scala
+++ b/modules/round/src/main/History.scala
@@ -28,7 +28,7 @@ private final class History(
 
   def getVersion: SocketVersion = {
     waitForLoadedEvents
-    Option(events.peekFirst).fold(SocketVersion(0))(_.version)
+    Option(events.peekLast).fold(SocketVersion(0))(_.version)
   }
 
   def versionDebugString: String = {

--- a/modules/round/src/main/History.scala
+++ b/modules/round/src/main/History.scala
@@ -89,7 +89,14 @@ private final class History(
 
   def getRecentEvents(maxEvents: Int): List[VersionedEvent] = {
     waitForLoadedEvents
-    events.asScala.takeRight(maxEvents).toList
+    val it = events.descendingIterator
+    var evs: List[VersionedEvent] = Nil
+    var count = maxEvents
+    while (count > 0 && it.hasNext) {
+      evs = it.next() :: evs
+      count -= 1
+    }
+    evs
   }
 
   def addEvents(xs: List[Event]): List[VersionedEvent] = {

--- a/modules/round/src/main/History.scala
+++ b/modules/round/src/main/History.scala
@@ -144,8 +144,8 @@ private object History {
     final case class Events(value: List[VersionedEvent]) extends EventResult
   }
 
-  private val maxSize = 25
-  private val expireAfterSeconds = 20
+  private final val maxSize = 25
+  private final val expireAfterSeconds = 20
 
   def apply(coll: Coll)(gameId: String, withPersistence: Boolean): History = new History(
     load = serverStarting ?? load(coll, gameId, withPersistence),
@@ -156,8 +156,8 @@ private object History {
   private def serverStarting = !lila.common.PlayApp.startedSinceMinutes(5)
 
   private def load(coll: Coll, gameId: String, withPersistence: Boolean): Fu[List[VersionedEvent]] =
-    coll.byId[Bdoc](gameId).map {
-      _.flatMap(_.getAs[List[VersionedEvent]]("e")) ?? identity
+    coll.byId[Bdoc](gameId).map { doc =>
+      ~doc.flatMap(_.getAs[List[VersionedEvent]]("e"))
     } addEffect {
       case events if events.nonEmpty && !withPersistence => coll.remove($id(gameId)).void
       case _ =>

--- a/modules/round/src/main/History.scala
+++ b/modules/round/src/main/History.scala
@@ -1,5 +1,9 @@
 package lila.round
 
+import java.util.ArrayDeque
+import scala.collection.mutable.ListBuffer
+import scala.collection.JavaConverters._
+
 import org.joda.time.DateTime
 import reactivemongo.api.commands.GetLastError
 import reactivemongo.bson._
@@ -14,23 +18,24 @@ import VersionedEvent.EpochSeconds
  * Designed for use within a sequential actor (or a Duct)
  */
 private final class History(
-    load: Fu[VersionedEvents],
-    persist: VersionedEvents => Unit,
+    load: Fu[List[VersionedEvent]],
+    persist: ArrayDeque[VersionedEvent] => Unit,
     withPersistence: Boolean
 ) {
   import History.Types._
 
-  private var events: VersionedEvents = _
+  // TODO: After scala 2.13, use scala's ArrayDeque
+  private[this] var events: ArrayDeque[VersionedEvent] = _
 
   def getVersion: SocketVersion = {
     waitForLoadedEvents
-    events.headOption.fold(SocketVersion(0))(_.version)
+    Option(events.peekFirst).fold(SocketVersion(0))(_.version)
   }
 
   def versionDebugString: String = {
-    waitForLoadedEvents
-    events.headOption.fold("-:-") { h =>
-      s"${events.last.version}:${h.version}@${h.date - nowSeconds}s"
+      waitForLoadedEvents
+    Option(events.peekLast).fold("-:-") { h =>
+      s"${Option(events.peekFirst).version}:${h.version}@${h.date - nowSeconds}s"
     }
   }
 
@@ -43,7 +48,8 @@ private final class History(
         m.getEventsDelta(version.value - v.value)
         m.getEventsCount()
       }
-      val filteredEvents = events.takeWhile(_.version > v).reverse
+      // TODO Ensure that version always goes up by 1, and simplify seeks
+      val filteredEvents = events.asScala.dropWhile(_.version <= v).toList
       filteredEvents match {
         case e :: _ if e.version == v.inc => Events(filteredEvents)
         case _ =>
@@ -64,7 +70,7 @@ private final class History(
    * versionCheck ping while the server sends an event,
    * we can get a false positive.
    * */
-  def versionCheck(v: SocketVersion): Option[VersionedEvents] =
+  def versionCheck(v: SocketVersion): Option[List[VersionedEvent]] =
     getEventsSince(v, none) match {
       case Events(evs) if evs.headOption.exists(_ hasSeconds 10) => Some(evs)
       case Events(_) | UpToDate => Some(Nil)
@@ -73,32 +79,50 @@ private final class History(
 
   def getRecentEvents(maxEvents: Int): List[VersionedEvent] = {
     waitForLoadedEvents
-    events.take(maxEvents).reverse
+    events.asScala.takeRight(maxEvents).toList
   }
 
-  def addEvents(xs: List[Event]): VersionedEvents = {
+  def addEvents(xs: List[Event]): List[VersionedEvent] = {
     waitForLoadedEvents
     val date = nowSeconds
-    val vevs = xs.foldLeft(List.empty[VersionedEvent] -> getVersion) {
-      case ((vevs, v), e) => (VersionedEvent(e, v.inc, date) :: vevs, v.inc)
-    }._1
-    events = slideEvents(vevs, events, date)
+
+    removeTail(History.maxSize - xs.size)
+    pruneEvents(date - History.expireAfterSeconds)
+    val veBuff = ListBuffer[VersionedEvent]()
+    xs.foldLeft(getVersion.inc) {
+      case (vnext, e) =>
+        val ve = VersionedEvent(e, vnext, date)
+        events.addLast(ve)
+        veBuff += ve
+        vnext.inc
+    }
     if (persistenceEnabled) persist(events)
-    vevs.reverse
+    veBuff.result
   }
 
-  private def slideEvents(newEvents: VersionedEvents, history: VersionedEvents, date: EpochSeconds): VersionedEvents = {
-    val expiration: EpochSeconds = date - History.expireAfterSeconds
-    var nb = events.size
-    newEvents ::: history.takeWhile { e =>
-      nb += 1
-      nb <= History.maxSize && e.date > expiration
+  private def removeTail(maxSize: Int) = {
+    if (maxSize <= 0) events.clear()
+    else {
+      var toRemove = events.size - maxSize
+      while (toRemove > 0) {
+        events.pollFirst
+        toRemove -= 1
+      }
     }
+  }
+
+  private def pruneEvents(minDate: EpochSeconds) = {
+    while ({
+      val e = events.peekFirst
+      (e ne null) && e.date < minDate
+    }) events.pollFirst
   }
 
   private def waitForLoadedEvents: Unit = {
     if (events == null) {
-      events = load awaitSeconds 3
+      val evs = load awaitSeconds 3
+      events = new ArrayDeque[VersionedEvent]
+      evs.foreach(events.add)
     }
   }
 
@@ -118,7 +142,7 @@ private object History {
     object VersionTooHigh extends EventResult
     object UpToDate extends EventResult
     object InsufficientHistory extends EventResult
-    final case class Events(value: VersionedEvents) extends EventResult
+    final case class Events(value: List[VersionedEvent]) extends EventResult
   }
 
   private val maxSize = 25
@@ -132,19 +156,19 @@ private object History {
 
   private def serverStarting = !lila.common.PlayApp.startedSinceMinutes(5)
 
-  private def load(coll: Coll, gameId: String, withPersistence: Boolean): Fu[VersionedEvents] =
+  private def load(coll: Coll, gameId: String, withPersistence: Boolean): Fu[List[VersionedEvent]] =
     coll.byId[Bdoc](gameId).map {
-      _.flatMap(_.getAs[VersionedEvents]("e")) ?? (_.reverse)
+      _.flatMap(_.getAs[List[VersionedEvent]]("e")) ?? identity
     } addEffect {
       case events if events.nonEmpty && !withPersistence => coll.remove($id(gameId)).void
       case _ =>
     }
 
-  private def persist(coll: Coll, gameId: String)(vevs: List[VersionedEvent]) =
-    if (vevs.nonEmpty) coll.update(
+  private def persist(coll: Coll, gameId: String)(vevs: ArrayDeque[VersionedEvent]) =
+    if (!vevs.isEmpty) coll.update(
       $doc("_id" -> gameId),
       $doc(
-        "$set" -> $doc("e" -> vevs.reverse),
+        "$set" -> $doc("e" -> vevs.toArray(Array[VersionedEvent]())),
         "$setOnInsert" -> $doc("d" -> DateTime.now)
       ),
       upsert = true,

--- a/modules/round/src/main/package.scala
+++ b/modules/round/src/main/package.scala
@@ -9,8 +9,6 @@ package object round extends PackageObject with WithSocket {
 
   private[round] type Events = List[Event]
 
-  private[round] type VersionedEvents = List[VersionedEvent]
-
   private[round] def logger = lila.log("round")
 }
 


### PR DESCRIPTION
Switch underlying data structure from List to java ArrayDeque,
which allows fast insert and deletion from head. Store events
in chronological order, consistent with the order on disk.

This change allows us to remove a bunch of reverse() calls. Once
we upgrade to scala 2.13 we could migrate to scala's ArrayDeque.

The other motivation for this patch is that I would like to store
more Events (changing History thresholds), to give clients a
better chance to catch up, especially on popular boards. This means
the events list gets larger and the choice of data structure becomes
more important.