### PR TITLE
Fix document.title when a game is aborted

### DIFF
--- a/ui/round/src/title.ts
+++ b/ui/round/src/title.ts
@@ -1,5 +1,5 @@
 import { isPlayerTurn } from 'game';
-import { finished } from 'game/status';
+import { aborted, finished } from 'game/status';
 import RoundController from './ctrl';
 
 const initialTitle = document.title;
@@ -41,7 +41,7 @@ export function init() {
 export function set(ctrl: RoundController, text?: string) {
   if (ctrl.data.player.spectator) return;
   if (!text) {
-    if (finished(ctrl.data)) {
+    if (aborted(ctrl.data) || finished(ctrl.data)) {
       text = ctrl.trans('gameOver');
     } else if (isPlayerTurn(ctrl.data)) {
       text = ctrl.trans('yourTurn');


### PR DESCRIPTION
When a game is aborted, document.title is "Waiting for opponent" (doesn't matter whose turn it is). It should be "game over".

(I couldn't get lila to build - apologies if the change is wrong.)