### PR TITLE
pgn import to accept fractional seconds

### DIFF
--- a/modules/study/src/main/CommentParser.scala
+++ b/modules/study/src/main/CommentParser.scala
@@ -2,6 +2,7 @@ package lila.study
 
 import chess.Centis
 import chess.Pos
+import lila.common.Maths
 import lila.tree.Node.{ Shape, Shapes }
 
 private[study] object CommentParser {
@@ -33,15 +34,20 @@ private[study] object CommentParser {
   private def readCentis(hours: String, minutes: String, seconds: String): Option[Centis] = for {
     h <- parseIntOption(hours)
     m <- parseIntOption(minutes)
-    s <- parseIntOption(seconds)
-  } yield Centis(h * 360000 + m * 6000 + s * 100)
+    cs <- parseDoubleOption(seconds) match {
+      case Some(s) => Some(Maths.roundAt(s * 100, 0).toInt)
+      case _ => none
+    }
+  } yield Centis(h * 360000 + m * 6000 + cs)
 
   private val clockHourMinuteRegex = """^(\d++):(\d+)$""".r
   private val clockHourMinuteSecondRegex = """^(\d++):(\d++)[:\.](\d+)$""".r
+  private val clockHourMinuteFractionalSecondRegex = """^(\d++):(\d++):(\d++\.\d+)$""".r
 
   def readCentis(str: String): Option[Centis] = str match {
     case clockHourMinuteRegex(hours, minutes) => readCentis(hours, minutes, "0")
     case clockHourMinuteSecondRegex(hours, minutes, seconds) => readCentis(hours, minutes, seconds)
+    case clockHourMinuteFractionalSecondRegex(hours, minutes, seconds) => readCentis(hours, minutes, seconds)
     case _ => none
   }
 

--- a/modules/study/src/test/CommentParserTest.scala
+++ b/modules/study/src/test/CommentParserTest.scala
@@ -67,6 +67,12 @@ class CommentParserTest extends Specification {
       C("d=29, pd=Bb7, mt=00:01:01, tl=00:37:47, s=27938 kN/s, n=1701874274, pv=e4 Bb7 exf5 exf5 d5 Qf6 Rab1 Rae8 g3 Bc8 Kg2 Rxe1 Rxe1, tb=0, R50=49, wv=0.45,").clock must_==
         Some(Centis(100 * 47 + 37 * 60 * 100))
     }
+    "fractional second" in {
+      C("Hello there [%clk 10:40:33.55] something else").clock must_== Some(Centis(3843355))
+    }
+    "fractional second rounded to centisecond" in {
+      C("Hello there [%clk 10:40:33.556] something else").clock must_== Some(Centis(3843356))
+    }
   }
   "parse shapes" should {
     "empty" in {


### PR DESCRIPTION
This change allows users to import pgn with fractional seconds ` [%clk 0:09:59.45]`
fractional seconds are rounded to centiseconds

Fixes  #5074