### PR TITLE
Clear input after reading clock times (fix #5056)

### DIFF
--- a/ui/round/src/plugins/keyboardMove.ts
+++ b/ui/round/src/plugins/keyboardMove.ts
@@ -49,6 +49,7 @@ window.lichess.keyboardMove = function(opts: any) {
     } else if (v.length > 0 && 'clock'.startsWith(v.toLowerCase())) {
       if ('clock' === v.toLowerCase()) {
         readClocks(opts.ctrl.clock());
+        clear();
       }
     } else if (submitOpts.yourMove && v.length > 1) {
       setTimeout(window.lichess.sound.error, 500);


### PR DESCRIPTION
Sorry @niklasf , I lost this `clear();` between coding and testing iterations.  Adding it clears the input text.