### PR TITLE
Fix Quit data race

### DIFF
--- a/modules/socket/src/main/Handler.scala
+++ b/modules/socket/src/main/Handler.scala
@@ -68,11 +68,7 @@ object Handler {
       // this will only be called after Internet is restored,
       // and it can be called after a reconnection (using same uid) was performed,
       // effectively quitting the reconnected client.
-      .map(_ => {
-        // TODO: This is a data race, because
-        // member.ended is set on a different thread.
-        if (!member.ended) socket ! Quit(uid)
-      })
+      .map(_ => socket ! Quit(uid, member))
   }
 
   def recordUserLagFromPing(member: SocketMember, ping: JsObject) = for {

--- a/modules/socket/src/main/SocketMember.scala
+++ b/modules/socket/src/main/SocketMember.scala
@@ -7,14 +7,9 @@ trait SocketMember {
   protected val channel: JsChannel
   val userId: Option[String]
 
-  var ended = false
-
   def isAuth = userId.isDefined
 
   def push(msg: JsValue) = channel push msg
 
-  def end = {
-    ended = true
-    channel.end
-  }
+  def end = channel.end
 }

--- a/modules/socket/src/main/SocketTrouper.scala
+++ b/modules/socket/src/main/SocketTrouper.scala
@@ -58,7 +58,9 @@ abstract class SocketTrouper[M <: SocketMember](
     case Broom => broom
 
     // when a member quits
-    case Quit(uid) => withMember(uid) { quit(uid, _) }
+    case Quit(uid, member) => withMember(uid) { m =>
+      if (m == member) quit(uid, m)
+    }
 
     case Resync(uid) => resync(uid)
 

--- a/modules/socket/src/main/actorApi.scala
+++ b/modules/socket/src/main/actorApi.scala
@@ -7,7 +7,7 @@ case class Connected(enumerator: JsEnumerator, member: SocketMember)
 case class BotConnected(color: chess.Color, v: Boolean)
 
 private[socket] case object Broom
-private[socket] case class Quit(uid: Socket.Uid)
+private[socket] case class Quit(uid: Socket.Uid, member: SocketMember)
 
 case class SocketEnter(uid: Socket.Uid, member: SocketMember)
 case class SocketLeave(uid: Socket.Uid, member: SocketMember)


### PR DESCRIPTION
Improve our reconnect race bandaid. The first version
of the bandaid uses a boolean flag which might not have been
set yet, because the new Socket might be in a message queue
instead of fully initiated. With the first version, we could
end up queueing a Quit message that gets processed after
the socket is reconnected.

This version does the check on the actor thread.