### PR TITLE
Keep track of what positions people tend to sit or disconnect in

### DIFF
--- a/app/controllers/User.scala
+++ b/app/controllers/User.scala
@@ -275,10 +275,11 @@ object User extends LilaController {
           Env.mod.logApi.userHistory(user.id).logTimeIfGt(s"$username logApi.userHistory", 2 seconds) zip
             Env.plan.api.recentChargesOf(user).logTimeIfGt(s"$username plan.recentChargesOf", 2 seconds) zip
             Env.report.api.byAndAbout(user, 20).logTimeIfGt(s"$username report.byAndAbout", 2 seconds) zip
-            Env.pref.api.getPref(user).logTimeIfGt(s"$username pref.getPref", 2 seconds) flatMap {
-              case history ~ charges ~ reports ~ pref =>
+            Env.pref.api.getPref(user).logTimeIfGt(s"$username pref.getPref", 2 seconds) zip
+            Env.playban.api.getSitAndDcCounter(user) flatMap {
+              case history ~ charges ~ reports ~ pref ~ sitAndDcCounter =>
                 Env.user.lightUserApi.preloadMany(reports.userIds).logTimeIfGt(s"$username lightUserApi.preloadMany", 2 seconds) inject
-                  html.user.mod.parts(user, history, charges, reports, pref).some
+                  html.user.mod.parts(user, history, charges, reports, pref, sitAndDcCounter).some
             }
         val actions = UserRepo.isErased(user) map { erased =>
           html.user.mod.actions(user, emails, erased).some

--- a/app/views/user/mod.scala
+++ b/app/views/user/mod.scala
@@ -124,10 +124,11 @@ object mod {
       )
     )
 
-  def parts(u: User, history: List[lila.mod.Modlog], charges: List[lila.plan.Charge], reports: lila.report.Report.ByAndAbout, pref: lila.pref.Pref)(implicit ctx: Context) = frag(
+  def parts(u: User, history: List[lila.mod.Modlog], charges: List[lila.plan.Charge], reports: lila.report.Report.ByAndAbout, pref: lila.pref.Pref, sitAndDcCounter: Int)(implicit ctx: Context) = frag(
     roles(u),
     prefs(u, pref),
     plan(u, charges),
+    sitDcCounter(sitAndDcCounter),
     modLog(u, history),
     reportLog(u, reports)
   )
@@ -149,6 +150,13 @@ object mod {
         )
       )
     )
+  )
+
+  def sitDcCounter(sitAndDcCounter: Int)(implicit ctx: Context) = div(id := "mz_sitdccounter")(
+    strong(cls := "text inline")("Sit/disconnect counter: "),
+    span(cls := "text inline")(sitAndDcCounter.toString),
+    br,
+    span(cls := "text inline")("+1 for every sit/disconnect in 'winning' position, -1 for 'losing' position")
   )
 
   def plan(u: User, charges: List[lila.plan.Charge])(implicit ctx: Context) = charges.headOption.map { firstCharge =>

--- a/modules/playban/src/main/model.scala
+++ b/modules/playban/src/main/model.scala
@@ -6,12 +6,14 @@ import play.api.libs.json._
 case class UserRecord(
     _id: String,
     o: Option[List[Outcome]],
-    b: Option[List[TempBan]]
+    b: Option[List[TempBan]],
+    c: Option[Int]
 ) {
 
   def userId = _id
   def outcomes: List[Outcome] = ~o
   def bans: List[TempBan] = ~b
+  def sitAndDcCounter: Int = ~c
 
   def banInEffect = bans.lastOption.exists(_.inEffect)
 


### PR DESCRIPTION
Not used for anything else than mod zone display at the moment, if the value seems usable then it can be used in the punishment code.

The counter gets +1'd if you disconnect or sit in a winning position (material imbalance >= 5) and -1 of you disconnect or sit in a losing position (material imbalance <= -5).
The idea is that abusers will get a highly negative score and people with an unstable connection will have a score around zero.