### PR TITLE
Add onGame to watcherJson

### DIFF
--- a/modules/round/src/main/JsonView.scala
+++ b/modules/round/src/main/JsonView.scala
@@ -163,8 +163,8 @@ final class JsonView(
                 "version" -> socket.version.value,
                 "spectator" -> true
               )
-            },
-            "opponent" -> commonWatcherJson(game, opponent, opponentUser, withFlags),
+            }.add("onGame" -> (player.isAi || socket.onGame(player.color))),
+            "opponent" -> commonWatcherJson(game, opponent, opponentUser, withFlags).add("onGame" -> (opponent.isAi || socket.onGame(opponent.color))),
             "orientation" -> pov.color.name,
             "url" -> Json.obj(
               "socket" -> s"/$gameId/${color.name}/socket/v$apiVersion",


### PR DESCRIPTION
Fixes #4362

Because watcherJson doesn't have onGame data, spectators would always see the players as offline after a 'reload' event, such as a takeback.