### PR TITLE
Resume Howler's AudioContext when suspended

### DIFF
--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -615,7 +615,12 @@
         if (!enabled()) return;
         if (!text || !api.say(text)) {
           Howler.volume(api.getVolume());
-          collection(name).play();
+          var sound = collection(name);
+          if (Howler.ctx.state == "suspended") {
+            Howler.ctx.resume().then(function() { sound.play() });
+          } else {
+            sound.play();
+          }
         }
       }
     });

--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -617,7 +617,7 @@
           Howler.volume(api.getVolume());
           var sound = collection(name);
           if (Howler.ctx.state == "suspended") {
-            Howler.ctx.resume().then(function() { sound.play() });
+            Howler.ctx.resume().then(() => sound.play());
           } else {
             sound.play();
           }


### PR DESCRIPTION
On Chrome, it sometimes (and irregularly) happens that the AudioContext is not allowed to start on the first sound. It has to be explicitly resumed after a "user gesture" (such as a click) on the page.

If we don't have any resume() calls, then a silenced Chrome page would just stay silenced. Attempting to resume whenever the AudioContext is suspended will ensure that a blocked AudioContext can still start after a user clicks on the page.