### PR TITLE
Remove permanent scrollbar

### DIFF
--- a/ui/common/css/base/_elements.scss
+++ b/ui/common/css/base/_elements.scss
@@ -13,10 +13,6 @@ body {
   background: $c-bg-page linear-gradient(to bottom, $c-body-gradient, $c-bg-page 116px) no-repeat;
   color: $c-font;
   overflow-x: hidden;
-  &.fixed-scroll {
-    /* prevents scroll bar flicker when dragging a piece out */
-    overflow-y: scroll;
-  }
 }
 
 a {


### PR DESCRIPTION
The scrollbar is ugly.
The flickering issue should be solved another way (e.g. temporary scrollbar persistence if a user is dragging offscreen).