### PR TITLE
Reduce established (leaderboard) RD threshold

### DIFF
--- a/modules/rating/src/main/Glicko.scala
+++ b/modules/rating/src/main/Glicko.scala
@@ -20,11 +20,9 @@ case class Glicko(
   def intervalMax = (rating + deviation * 2).toInt
   def interval = intervalMin -> intervalMax
 
-  // Established ratings are used for top player ranking
-  // Provisional ratings display with a question mark
-  def established = deviation <= Glicko.establishedDeviation
+  def rankable = deviation <= Glicko.rankableDeviation
   def provisional = deviation >= Glicko.provisionalDeviation
-
+  def established = !provisional
   def establishedIntRating = established option intRating
 
   def refund(points: Int) = copy(rating = rating + points)
@@ -63,7 +61,7 @@ case object Glicko {
   val defaultIntRating = default.rating.toInt
 
   val minDeviation = 60
-  val establishedDeviation = 80
+  val rankableDeviation = 80
   val provisionalDeviation = 110
   val maxDeviation = 350
 

--- a/modules/rating/src/main/Glicko.scala
+++ b/modules/rating/src/main/Glicko.scala
@@ -20,8 +20,10 @@ case class Glicko(
   def intervalMax = (rating + deviation * 2).toInt
   def interval = intervalMin -> intervalMax
 
+  // Established ratings are used for top player ranking
+  // Provisional ratings display with a question mark
+  def established = deviation <= Glicko.establishedDeviation
   def provisional = deviation >= Glicko.provisionalDeviation
-  def established = !provisional
 
   def establishedIntRating = established option intRating
 
@@ -61,6 +63,7 @@ case object Glicko {
   val defaultIntRating = default.rating.toInt
 
   val minDeviation = 60
+  val establishedDeviation = 80
   val provisionalDeviation = 110
   val maxDeviation = 350
 

--- a/modules/rating/src/main/Perf.scala
+++ b/modules/rating/src/main/Perf.scala
@@ -65,6 +65,7 @@ case class Perf(
   def isEmpty = nb == 0
   def nonEmpty = !isEmpty
 
+  def rankable = glicko.rankable
   def provisional = glicko.provisional
   def established = glicko.established
 }

--- a/modules/user/src/main/RankingApi.scala
+++ b/modules/user/src/main/RankingApi.scala
@@ -29,7 +29,7 @@ final class RankingApi(
       "perf" -> perfType.id,
       "rating" -> perf.intRating,
       "prog" -> perf.progress,
-      "stable" -> perf.established,
+      "stable" -> perf.rankable,
       "expiresAt" -> DateTime.now.plusDays(7)
     ),
       upsert = true).void


### PR DESCRIPTION
As @ProgramFOX points out, most players on the leaderboard already have an RD of 60.

Leaders who play like https://lichess.org/@/EpicEffects/search?perf=6 or https://lichess.org/@/Zaffelare/search?perf=11 (1 game per week against a much lower-rated opponent) or new accounts who boost like https://lichess.org/@/TheRacingApprentice will have to earn established ratings, just like anyone else on the leaderboard.