### PR TITLE
Keyboard shortcut fixes

### DIFF
--- a/ui/chat/src/main.ts
+++ b/ui/chat/src/main.ts
@@ -35,5 +35,9 @@ export default function LichessChat(element: Element, opts: ChatOpts): {
     return false;
   });
 
+  window.Mousetrap(container).bind('esc', () => {
+    (container.querySelector('.mchat__say') as HTMLElement).blur();
+  });
+
   return ctrl;
 };

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -701,14 +701,14 @@ export default class RoundController {
           return msg;
         });
 
-        if (!this.nvui) {
+        if (!this.nvui && d.pref.submitMove) {
           window.Mousetrap.bind('esc', () => {
             this.submitMove(false);
             this.chessground.cancelMove();
           });
           window.Mousetrap.bind('return', () => this.submitMove(true));
-          cevalSub.subscribe(this);
         }
+        cevalSub.subscribe(this);
       }
 
       if (!this.nvui) keyboard.init(this);


### PR DESCRIPTION
- add Escape to unfocus round chat
- don't bind esc/enter unless submit move is on.  this bind
  breaks escape in the command box so avoid it when possible.

The escape added for chat is scoped to the container so will not
break other escape binds on the page