### PR TITLE
Only attempt to resume suspended Howler.ctx if it already exists

### DIFF
--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -622,7 +622,7 @@
         if (!text || !api.say(text)) {
           Howler.volume(api.getVolume());
           var sound = collection(name);
-          if (Howler.ctx.state == "suspended") {
+          if (Howler.ctx && Howler.ctx.state == "suspended") {
             Howler.ctx.resume().then(() => sound.play());
           } else {
             sound.play();


### PR DESCRIPTION
Fixes #5295
If Howler.ctx is undefined or null, just play the sound -- that was also the behavior prior to the introduction of the resume() call.