### PR TITLE
Fix auto-reloading of mod/public-chat

### DIFF
--- a/app/views/mod/publicChat.scala
+++ b/app/views/mod/publicChat.scala
@@ -20,29 +20,13 @@ object publicChat {
     ) {
         main(cls := "page-menu")(
           views.html.mod.menu("public-chat"),
-          div(id := "communication", cls := "page-menu__content public_chat box box-pad")(
-            h2("Tournament Chats"),
-            div(cls := "player_chats")(
-              tourChats.map {
-                case (tournament, chat) => div(cls := "game")(
-                  a(cls := "title", href := routes.Tournament.show(tournament.id))(tournament.name),
-                  div(cls := "chat")(
-                    chat.lines.filter(_.isVisible).map { line =>
-                      div(cls := "line")(
-                        userIdLink(line.author.toLowerCase.some, withOnline = false, withTitle = false), " ",
-                        richText(line.text)
-                      )
-                    }
-                  )
-                )
-              }
-            ),
-            div(
-              h2("Simul Chats"),
+          div(id := "comm-wrap")(
+            div(id := "communication", cls := "page-menu__content public_chat box box-pad")(
+              h2("Tournament Chats"),
               div(cls := "player_chats")(
-                simulChats.map {
-                  case (simul, chat) => div(cls := "game")(
-                    a(cls := "title", href := routes.Simul.show(simul.id))(simul.name),
+                tourChats.map {
+                  case (tournament, chat) => div(cls := "game")(
+                    a(cls := "title", href := routes.Tournament.show(tournament.id))(tournament.name),
                     div(cls := "chat")(
                       chat.lines.filter(_.isVisible).map { line =>
                         div(cls := "line")(
@@ -53,6 +37,24 @@ object publicChat {
                     )
                   )
                 }
+              ),
+              div(
+                h2("Simul Chats"),
+                div(cls := "player_chats")(
+                  simulChats.map {
+                    case (simul, chat) => div(cls := "game")(
+                      a(cls := "title", href := routes.Simul.show(simul.id))(simul.name),
+                      div(cls := "chat")(
+                        chat.lines.filter(_.isVisible).map { line =>
+                          div(cls := "line")(
+                            userIdLink(line.author.toLowerCase.some, withOnline = false, withTitle = false), " ",
+                            richText(line.text)
+                          )
+                        }
+                      )
+                    )
+                  }
+                )
               )
             )
           )

--- a/public/javascripts/public-chat.js
+++ b/public/javascripts/public-chat.js
@@ -38,7 +38,7 @@ $(function() {
     if (!autoRefreshEnabled || document.visibilityState === 'hidden' || autoRefreshOnHold) return;
 
     // Reload only the chat grid portions of the page
-    $("#lichess").load("/mod/public-chat #communication", onPageReload);
+    $("#comm-wrap").load("/mod/public-chat #communication", onPageReload);
 
   }, 4000);
 });


### PR DESCRIPTION
It has been broken for a while, since the $("#lichess") selector started returning null.

The #comm-wrap div is needed because not introducing a new element but using an existing one as replacement for $("#lichess") always resulted in a wrong layout after an auto-refresh. (The Git diff for publicChat.scala looks complicated but all it really does, is adding a #comm-wrap around #communication + reformat)

I'm seeing a Content Security Policy error every time .load happens. I don't think this is a big deal (everything works), but just mentioning it in case.