### PR TITLE
No sit counter for Antichess or Horde

### DIFF
--- a/modules/playban/src/main/PlaybanApi.scala
+++ b/modules/playban/src/main/PlaybanApi.scala
@@ -43,9 +43,10 @@ final class PlaybanApi(
     }
 
   private def roughWinEstimate(game: Game, color: Color) = {
-    game.chess.board.materialImbalance match {
-      case a if a >= 5 => 1
-      case a if a <= -5 => -1
+    (game.chess.board.materialImbalance, game.variant) match {
+      case (_, chess.variant.Antichess) => 0
+      case (a, _) if a >= 5 => 1
+      case (a, _) if a <= -5 => -1
       case _ => 0
     }
   } * (if (color == Color.White) 1 else -1)

--- a/modules/playban/src/main/PlaybanApi.scala
+++ b/modules/playban/src/main/PlaybanApi.scala
@@ -44,7 +44,7 @@ final class PlaybanApi(
 
   private def roughWinEstimate(game: Game, color: Color) = {
     (game.chess.board.materialImbalance, game.variant) match {
-      case (_, chess.variant.Antichess) | (_, chess.variant.Horde) => 0
+      case (_, chess.variant.Antichess) | (_, chess.variant.Horde) | (_, chess.variant.Crazyhouse) => 0
       case (a, _) if a >= 5 => 1
       case (a, _) if a <= -5 => -1
       case _ => 0

--- a/modules/playban/src/main/PlaybanApi.scala
+++ b/modules/playban/src/main/PlaybanApi.scala
@@ -44,7 +44,7 @@ final class PlaybanApi(
 
   private def roughWinEstimate(game: Game, color: Color) = {
     (game.chess.board.materialImbalance, game.variant) match {
-      case (_, chess.variant.Antichess) => 0
+      case (_, chess.variant.Antichess) | (_, chess.variant.Horde) => 0
       case (a, _) if a >= 5 => 1
       case (a, _) if a <= -5 => -1
       case _ => 0

--- a/modules/playban/src/main/PlaybanApi.scala
+++ b/modules/playban/src/main/PlaybanApi.scala
@@ -3,6 +3,7 @@ package lila.playban
 import reactivemongo.bson._
 
 import chess.{ Status, Color }
+import chess.variant._
 import lila.common.PlayApp.{ startedSinceMinutes, isDev }
 import lila.db.BSON._
 import lila.db.dsl._
@@ -44,7 +45,7 @@ final class PlaybanApi(
 
   private def roughWinEstimate(game: Game, color: Color) = {
     (game.chess.board.materialImbalance, game.variant) match {
-      case (_, chess.variant.Antichess) | (_, chess.variant.Horde) | (_, chess.variant.Crazyhouse) => 0
+      case (_, Antichess | Crazyhouse | Horde) => 0
       case (a, _) if a >= 5 => 1
       case (a, _) if a <= -5 => -1
       case _ => 0


### PR DESCRIPTION
In all other variants, it's fair enough to use material difference for a rough win estimate. In Antichess or Horde, it makes little sense.