### PR TITLE
Changed the colour of the names of the open tournaments on homepage

### DIFF
--- a/ui/lobby/css/_box.scss
+++ b/ui/lobby/css/_box.scss
@@ -37,6 +37,13 @@
       &:first-child {
         padding-left: .7em;
       }
+      &.name .text {
+        font-weight: bold;
+        color: $c-font;
+        &:hover {
+          color: $c-link;
+        }
+      }
     }
     tr:nth-child(even) {
       background: $c-bg-zebra;


### PR DESCRIPTION
This pull request changes the colour of the names of the open tournaments from blue to bold $c-font, and then when you hover over them it changes to the $c-link blue.