### PR TITLE
Changed the colour of the names of the tourneys and simuls on homepage

### DIFF
--- a/ui/lobby/css/_box.scss
+++ b/ui/lobby/css/_box.scss
@@ -37,6 +37,14 @@
       &:first-child {
         padding-left: .7em;
       }
+      &.name a {
+        font-weight: bold;
+        color: $c-font;
+        @include transition(color);
+        &:hover {
+          color: $c-link;
+        }
+      }
     }
     tr:nth-child(even) {
       background: $c-bg-zebra;


### PR DESCRIPTION
Changed the colour of the names of the open tournaments and open simul exhibitions to bold $c-font on the home page, and when you hover over them they become $c-link.