### PR TITLE
Change [hidden] to ??? in training puzzles

### DIFF
--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -9,7 +9,7 @@ function strong(txt) {
 }
 
 function hidden() {
-  return '<span class="hidden">[hidden]</span>';
+  return '<span class="hidden">???</span>';
 }
 
 export function puzzleBox(ctrl: Controller) {


### PR DESCRIPTION
I think it would make sense to change the rating from [hidden] to ??? in puzzles to ensure consistency between the Lichess website and the Lichess app.