### PR TITLE
Replace U1500 schedule with U1400

### DIFF
--- a/modules/tournament/src/main/TournamentScheduler.scala
+++ b/modules/tournament/src/main/TournamentScheduler.scala
@@ -327,7 +327,7 @@ Thank you all, you rock!"""
           case _ => Rapid
         }
         List(
-          1500 -> 0,
+          1400 -> 0,
           1700 -> 1,
           2000 -> 2
         ).flatMap {


### PR DESCRIPTION
Perhaps 1400-1499 players (10% of the player base) can play in the U1700 events and give the lower 40% of players a chance in U1400 events.

Or perhaps we could introduce another under-X section although the lower the cap is, the greater the risk of sandbagging.