### PR TITLE
Remove redundant cheat assessment

### DIFF
--- a/modules/evaluation/src/main/Assessible.scala
+++ b/modules/evaluation/src/main/Assessible.scala
@@ -81,7 +81,6 @@ case class Assessible(analysed: Analysed, color: Color) {
     val flags = mkFlags
     val assessment = flags match {
       //               SF1 SF2 BLR1 BLR2 HCMT MCMT NFM Holds
-      case PlayerFlags(T, T, T, T, T, T, T, T) => Cheating // all T, obvious cheat
       case PlayerFlags(T, _, T, _, _, _, T, _) => Cheating // high accuracy, high blurs, no fast moves
       case PlayerFlags(T, _, _, T, _, _, _, _) => Cheating // high accuracy, moderate blurs
       case PlayerFlags(T, _, _, _, T, _, _, _) => Cheating // high accuracy, highly consistent move times


### PR DESCRIPTION
Anything caught by this line would be also caught by the line right below. I'm not an expert in cheating behavior, but also seems unlikely that all flags are true at once.