### PR TITLE
server analysis determines judgements based on winning chances

### DIFF
--- a/modules/analyse/src/main/Advice.scala
+++ b/modules/analyse/src/main/Advice.scala
@@ -54,12 +54,10 @@ private[analyse] case class CpAdvice(
 
 private[analyse] object CpAdvice {
 
-  def rawWinningChances(cp: Double): Double = 2 / (1 + Math.exp(-0.004 * cp)) - 1
-
-  def cpWinningChances(cp: Double): Double = rawWinningChances(Math.min(Math.max(-1000, cp), 1000))
+  private def cpWinningChances(cp: Double): Double = 2 / (1 + Math.exp(-0.004 * cp)) - 1
 
   private val winningChanceJudgements = List(
-    .3 -> Advice.Judgement.Blunder,
+    .5 -> Advice.Judgement.Blunder,
     .2 -> Advice.Judgement.Mistake,
     .1 -> Advice.Judgement.Inaccuracy
 

--- a/modules/analyse/src/main/Advice.scala
+++ b/modules/analyse/src/main/Advice.scala
@@ -54,18 +54,25 @@ private[analyse] case class CpAdvice(
 
 private[analyse] object CpAdvice {
 
-  private val cpJudgements = List(
-    300 -> Advice.Judgement.Blunder,
-    100 -> Advice.Judgement.Mistake,
-    50 -> Advice.Judgement.Inaccuracy
+  def rawWinningChances(cp: Double): Double = 2 / (1 + Math.exp(-0.004 * cp)) - 1
+
+  def cpWinningChances(cp: Double): Double = rawWinningChances(Math.min(Math.max(-1000, cp), 1000))
+
+  private val winningChanceJudgements = List(
+    .3 -> Advice.Judgement.Blunder,
+    .2 -> Advice.Judgement.Mistake,
+    .1 -> Advice.Judgement.Inaccuracy
+
   )
 
   def apply(prev: Info, info: Info): Option[CpAdvice] = for {
     cp ← prev.cp map (_.ceiled.centipawns)
     infoCp ← info.cp map (_.ceiled.centipawns)
-    delta = (infoCp - cp) |> { d => info.color.fold(-d, d) }
-    judgment ← cpJudgements find { case (d, n) => d <= delta } map (_._2)
-  } yield CpAdvice(judgment, info, prev)
+    prevWinningChances = cpWinningChances(cp)
+    currentWinningChances = cpWinningChances(infoCp)
+    delta = (currentWinningChances - prevWinningChances) |> { d => info.color.fold(-d, d) }
+    judgement ← winningChanceJudgements find { case (d, n) => d <= delta } map (_._2)
+  } yield CpAdvice(judgement, info, prev)
 }
 
 private[analyse] sealed abstract class MateSequence(val desc: String)


### PR DESCRIPTION
Hi guys. My name Abe, I love lichess, use it everyday, and I hope to become a contributor. This change I don't think is ready to go to prod yet. I have a few issues with my change that I was hoping someone with greater experience could answer:

1. I copied the winning chance formulas from ui into Advice.scala. This seems like the wrong place for them to be and also does not adhere to DRY (Do Not Repeat Yourself) principles. Would it be better/possible for the UI and Server to share the winning chance formulas somehow? Should the formulas be copied to somewhere else and imported?

2. I have not created automated testing for this change. I checked the project structure. There is no test package for the analyse module which is why I skipped making automated tests for the change. (Some modules besides analyse have a test package, and I assume this is where any automated testing would live).

3. My selections of .1, .2, .3 as the delta thresholds in winning chance for inaccuracy, mistake, and blunder respectively are arbitrary. I originally tried .05, .1, .3, which more closely mirrored the centipawn delta thresholds, but felt that too many inaccuracies were proccing under that decision. After playing a few games against the machine, I decided these were reasonable but am not sure if they actually are. 

Let me know if I am on the right track with this change, if I need to go in another direction, or if I should just stop now and let someone with more experience handle it :). Thanks
-abe


resolves  #4705