### PR TITLE
Record incomplete game for Abort

### DIFF
--- a/modules/playban/src/main/PlaybanApi.scala
+++ b/modules/playban/src/main/PlaybanApi.scala
@@ -136,7 +136,7 @@ final class PlaybanApi(
   def completionRate(userId: User.ID): Fu[Option[Double]] =
     coll.primitiveOne[List[Outcome]]($id(userId), "o").map(~_) map { outcomes =>
       outcomes.collect {
-        case Outcome.RageQuit | Outcome.Sitting | Outcome.NoPlay => false
+        case Outcome.RageQuit | Outcome.Sitting | Outcome.NoPlay | Outcome.Abort => false
         case Outcome.Good => true
       } match {
         case c if c.size >= 5 => Some(c.count(identity).toDouble / c.size)


### PR DESCRIPTION
A considerate player doesn't frequently abort or provoke their opponent (into aborting).
Unscheduled maintenance causing aborts should be infrequent.

https://lichess.org/forum/lichess-feedback/again-blocked-9-minutes-by-lichess-because-i-refuse-to-play-with-people-not-ending-their-games