### PR TITLE
Make cursor the default when hovering variants title in the hook list

### DIFF
--- a/ui/lobby/css/app/_hook-list.scss
+++ b/ui/lobby/css/app/_hook-list.scss
@@ -26,6 +26,7 @@
       background: none;
       text-transform: uppercase;
       letter-spacing: 3px;
+      cursor: default;
     }
   }
   th {


### PR DESCRIPTION
Currently, when hovering over the "Variants" subheading in the lobby hooks list, it shows the cursor as if it is a clickable link when it is not. This commit makes it so when hovering over the subheading, it shows the default cursor.