### PR TITLE
Simplify Rapid game requirement preconditions

### DIFF
--- a/modules/tournament/src/main/Schedule.scala
+++ b/modules/tournament/src/main/Schedule.scala
@@ -260,22 +260,13 @@ object Schedule {
 
       val nbRatedGame = (s.freq, s.speed) match {
 
-        case (_, UltraBullet) => 0
+        case (Hourly | Daily | Eastern, HyperBullet | Bullet) => 20
+        case (Hourly | Daily | Eastern, HippoBullet | SuperBlitz | Blitz) => 15
+        case (Hourly | Daily | Eastern, Rapid) => 10
 
-        case (Hourly, UltraBullet | HyperBullet | Bullet) => 20
-        case (Hourly, HippoBullet | SuperBlitz | Blitz) => 15
-        case (Hourly, Rapid) => 10
-
-        case (Daily | Eastern, UltraBullet | HyperBullet | Bullet) => 20
-        case (Daily | Eastern, HippoBullet | SuperBlitz | Blitz) => 15
-        case (Daily | Eastern, Rapid) => 15
-
-        case (Weekly | Monthly | Shield, UltraBullet | HyperBullet | Bullet) => 30
-        case (Weekly | Monthly | Shield, HippoBullet | SuperBlitz | Blitz) => 20
-        case (Weekly | Monthly | Shield, Rapid) => 15
-
-        case (Weekend, UltraBullet | HyperBullet | Bullet) => 30
-        case (Weekend, HippoBullet | SuperBlitz | Blitz) => 20
+        case (Weekly | Weekend | Monthly | Shield, HyperBullet | Bullet) => 30
+        case (Weekly | Weekend | Monthly | Shield, HippoBullet | SuperBlitz | Blitz) => 20
+        case (Weekly | Weekend | Monthly | Shield, Rapid) => 15
 
         case _ => 0
       }


### PR DESCRIPTION
Reduce Daily and Eastern precondition to same as Hourly (15 -> 10)
Increase Weekend precondition to same as Weekly (0 -> 15)

I hope as cheat detection improves, preconditions can be reduced to make the site more friendly to new players.