### PR TITLE
Improve typescript sourcemaps

### DIFF
--- a/ui/ceval/tsconfig.json
+++ b/ui/ceval/tsconfig.json
@@ -1,9 +1,8 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../tsconfig_module.base.json",
   "include": ["src/*.ts", "test/*.ts"],
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": ".",
-    "declaration": true
   }
 }

--- a/ui/chat/tsconfig.json
+++ b/ui/chat/tsconfig.json
@@ -1,9 +1,8 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../tsconfig_module.base.json",
   "include": ["src/*.ts"],
   "compilerOptions": {
     "outDir": "./dist",
-    "declaration": true,
     "noEmitOnError": false
   }
 }

--- a/ui/chess/tsconfig.json
+++ b/ui/chess/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../tsconfig_module.base.json",
   "include": ["src/*.ts"],
   "compilerOptions": {
     "outDir": "./dist",
-    "declaration": true
   }
 }

--- a/ui/common/tsconfig.json
+++ b/ui/common/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../tsconfig_module.base.json",
   "include": ["src/*.ts"],
   "compilerOptions": {
     "outDir": "./",
-    "declaration": true
   }
 }

--- a/ui/game/tsconfig.json
+++ b/ui/game/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../tsconfig_module.base.json",
   "include": ["src/**/*.ts"],
   "compilerOptions": {
     "outDir": "./",
-    "declaration": true
   }
 }

--- a/ui/nvui/tsconfig.json
+++ b/ui/nvui/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../tsconfig_module.base.json",
   "include": ["src/*.ts"],
   "compilerOptions": {
     "outDir": "./",
-    "declaration": true
   }
 }

--- a/ui/tree/tsconfig.json
+++ b/ui/tree/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../tsconfig_module.base.json",
   "include": ["src/*.ts"],
   "compilerOptions": {
     "outDir": "./dist",
-    "declaration": true
   }
 }

--- a/ui/tsconfig_module.base.json
+++ b/ui/tsconfig_module.base.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "inlineSourceMap": true,
+    "inlineSources": true
+  }
+}


### PR DESCRIPTION
Inline sources allows browserify to sourcemap
back to original typescript. If you add the ui
folder to chrome, you can then edit ts files
and set ts breakpoints directly in the browser!