### PR TITLE
Change the look of tournament schedule hover

### DIFF
--- a/ui/tournamentSchedule/css/_side.scss
+++ b/ui/tournamentSchedule/css/_side.scss
@@ -53,26 +53,28 @@
     &:hover {
       @extend %box-radius;
       padding-left: 3.2rem;
-      background: mix($c-brag, $c-bg-page, 20%);
+      background: mix($c-primary, $c-bg-page, 20%);
+      color: $c-font;
+      strong {
+      	color: $c-font;
+      }
       &::before {
         left: .5rem;
+        color: $c-font;
       }
     }
   }
   strong {
     color: $c-font-dim;
     display: block;
+    @include transition();
   }
   a::before {
-    @include transition();
     position: absolute;
     top: .3rem;
     left: 0;
     font-size: 2.2em;
-    opacity: 0.6;
-    color: $c-brag;
-  }
-  a:hover::before {
-    opacity: 1;
+    color: $c-font-dim;
+    @include transition();
   }
 }


### PR DESCRIPTION
This appearance change makes the tournament schedule more consistent with the rest of the site, by having the hover be a blue colour instead of an orange colour. It also includes other minor changes to make it look a little nicer. (Also please don't criticise my photo taking skills... thanks.)

Before commit:

![P90803-110132](https://user-images.githubusercontent.com/1687121/62405132-65fda680-b5de-11e9-98ec-facc8b415982.jpg)

After commit:

![P90803-110246](https://user-images.githubusercontent.com/1687121/62405136-6eee7800-b5de-11e9-978d-9e995d24e811.jpg)
