### PR TITLE
Remove unnecessary transition args

### DIFF
--- a/ui/analyse/css/_explorer.scss
+++ b/ui/analyse/css/_explorer.scss
@@ -32,7 +32,7 @@
     height: 100%;
   }
   tr {
-    @include transition(background-color);
+    @include transition();
     &:nth-child(even) {
       background: $c-bg-zebra;
     }

--- a/ui/analyse/css/_explorer.scss
+++ b/ui/analyse/css/_explorer.scss
@@ -228,7 +228,7 @@
         padding: 5px 0;
         text-align: center;
         cursor: pointer;
-        @include transition('background');
+        @include transition();
         border: $border;
         border-width: 1px 0 1px 1px;
         text-transform: capitalize;

--- a/ui/analyse/css/_explorer.scss
+++ b/ui/analyse/css/_explorer.scss
@@ -20,7 +20,7 @@
     display: block;
   }
   tbody {
-    @include transition(opacity);
+    @include transition();
   }
   &.loading tbody {
     opacity: 0.4;


### PR DESCRIPTION
This pull request removes unnecessary arguments from the "@include transition();" commands in the scss files.