### PR TITLE
Fix leaderboard and winners box top text align

### DIFF
--- a/ui/lobby/css/_box.scss
+++ b/ui/lobby/css/_box.scss
@@ -62,6 +62,10 @@
       text-align: right;
       padding-right: .7em;
     }
+
+    .lobby__box__top:first-child {
+      padding-left: .1em;
+    }
   }
   &__forum .lobby__box__top,
   &__blog .lobby__box__top {


### PR DESCRIPTION
Fixes the fact that the top of the Leaderboard and Tournament winners box is out of line with the rest of the box.