### PR TITLE
Remove leading zeroes

### DIFF
--- a/ui/analyse/css/_explorer.scss
+++ b/ui/analyse/css/_explorer.scss
@@ -151,7 +151,7 @@
       padding: 3px 5px;
       margin-left: 5px;
       border-radius: 3px;
-      font-size: 0.9em;
+      font-size: .9em;
     }
   }
   .toconf {

--- a/ui/analyse/css/gamebook/_play.scss
+++ b/ui/analyse/css/gamebook/_play.scss
@@ -96,7 +96,7 @@
       }
     }
     &.play {
-      font-size: 0.8em;
+      font-size: .8em;
       text-align: left;
     }
     &.play strong {

--- a/ui/analyse/css/practice/_side.scss
+++ b/ui/analyse/css/practice/_side.scss
@@ -18,7 +18,7 @@
       margin: 0;
     }
     em {
-      font-size: 0.9em;
+      font-size: .9em;
       opacity: 0.9;
     }
   }

--- a/ui/analyse/css/study/_player.scss
+++ b/ui/analyse/css/study/_player.scss
@@ -60,7 +60,7 @@ $player-height: 1.6rem;
     margin-left: 10px;
   }
   .elo {
-    margin-left: 0.5em;
+    margin-left: .5em;
     font-weight: normal;
   }
 }

--- a/ui/chat/css/_discussion.scss
+++ b/ui/chat/css/_discussion.scss
@@ -23,7 +23,7 @@
       display: block;
       opacity: 0.8;
       font-style: italic;
-      font-size: 0.9em;
+      font-size: .9em;
       margin-left: 0;
       text-align: center;
     }

--- a/ui/common/css/component/_slist.scss
+++ b/ui/common/css/component/_slist.scss
@@ -16,7 +16,7 @@
     padding: 1rem;
     .label {
       font-family: monospace;
-      font-size: 0.8rem;
+      font-size: .8rem;
     }
   }
   tbody tr:nth-child(even) {

--- a/ui/common/css/component/_subnav.scss
+++ b/ui/common/css/component/_subnav.scss
@@ -18,7 +18,7 @@
       align-items: center;
       color: $c-font;
       padding: .6rem 0 .6rem .5rem;
-      letter-spacing: -0.06em;
+      letter-spacing: -.06em;
       background: $c-bg-high;
       &:hover {
         color: $c-link;

--- a/ui/common/css/form/_form3.scss
+++ b/ui/common/css/form/_form3.scss
@@ -42,7 +42,7 @@ textarea.form-control {
 .form3 .error,
 .form-help {
   font-size: 90%;
-  margin-top: 0.25rem;
+  margin-top: .25rem;
 }
 .form3 .error {
   color: $c-error;
@@ -56,7 +56,7 @@ textarea.form-control {
 }
 
 .form-check-input {
-  margin-right: 0.5rem;
+  margin-right: .5rem;
 }
 
 .form-check .form-label {

--- a/ui/common/css/header/_topnav-visible.scss
+++ b/ui/common/css/header/_topnav-visible.scss
@@ -23,7 +23,7 @@
         display: block;
         height: var(--nav-section);
         line-height: $site-header-height;
-        padding: 0 0.7rem;
+        padding: 0 .7rem;
         text-transform: uppercase;
         border-left: 2px solid transparent;
         @media (hover: none) {

--- a/ui/dasher/css/_dasher.scss
+++ b/ui/dasher/css/_dasher.scss
@@ -131,7 +131,7 @@
 
   .background {
     .image p {
-      font-size: 0.9em;
+      font-size: .9em;
       padding: 5px;
     }
     input {

--- a/ui/dasher/css/_dasher.scss
+++ b/ui/dasher/css/_dasher.scss
@@ -12,7 +12,7 @@
   .status {
     display: block;
     position: relative;
-    padding: 0.8rem;
+    padding: .8rem;
     border-top: $border;
     signal {
       position: absolute;
@@ -71,10 +71,10 @@
   }
   .selector {
     flex: 1 1 100%;
-    margin: 0.5rem 0;
+    margin: .5rem 0;
     a {
       display: block;
-      padding: 0.7rem 1rem;
+      padding: .7rem 1rem;
       @include transition(background);
       &:hover {
         background: $c-dasher-light;

--- a/ui/dasher/css/_link.scss
+++ b/ui/dasher/css/_link.scss
@@ -8,7 +8,7 @@
   .subs .sub {
     @extend %nowrap-hidden;
     display: block;
-    padding: 0.5rem 1rem;
+    padding: .5rem 1rem;
   }
   .links a:hover,
   .links a:hover::before,
@@ -34,7 +34,7 @@
     &::before {
       float: right;
       font-size: 80%;
-      margin-top: 0.25rem;
+      margin-top: .25rem;
       color: $c-dasher;
     }
     &:hover::before {

--- a/ui/insight/css/_insight.scss
+++ b/ui/insight/css/_insight.scss
@@ -262,7 +262,7 @@
     ul > li label.optgroup {
       border-top: $border;
       margin-top: 5px;
-      text-indent: 0em;
+      text-indent: 0;
       text-transform: uppercase;
       font-weight: normal;
       opacity: 0.6;

--- a/ui/lobby/css/_forum.scss
+++ b/ui/lobby/css/_forum.scss
@@ -1,6 +1,6 @@
 .lobby__forum {
   li {
-    margin: 0.6em 0;
+    margin: .6em 0;
     padding-left: 9px;
     line-height: 14px;
     white-space: nowrap;

--- a/ui/round/css/_nvui.scss
+++ b/ui/round/css/_nvui.scss
@@ -9,7 +9,7 @@
 .nvui {
   h2 {
     font-weight: bold;
-    margin-top: 0.5em;
+    margin-top: .5em;
   }
   .moves {
     max-height: 140px;

--- a/ui/round/css/_user.scss
+++ b/ui/round/css/_user.scss
@@ -17,7 +17,7 @@
   }
   rating {
     flex: 0 0 auto;
-    margin: 0 0.25em 0 0.3em;
+    margin: 0 .25em 0 .3em;
     color: $c-font-dim;
     letter-spacing: -0.5px;
   }
@@ -34,7 +34,7 @@
     animation: connecting 0.9s ease-in-out infinite;
   }
   .rp {
-    margin-right: 0.2em;
+    margin-right: .2em;
   }
 
   @include breakpoint($mq-col2) {

--- a/ui/site/css/_account.scss
+++ b/ui/site/css/_account.scss
@@ -43,7 +43,7 @@
     padding: 10px 20px;
     background: rgba(128,128,128,0.1);
     td {
-      padding: 0.5em 1em;
+      padding: .5em 1em;
       font-family: monospace;
     }
   }
@@ -57,7 +57,7 @@
 
   h2 {
     font-size: 1.2em;
-    margin: -1em 0 0.5em 0;
+    margin: -1em 0 .5em 0;
   }
   .scopes {
     margin-bottom: 4em;

--- a/ui/site/css/_blog.scss
+++ b/ui/site/css/_blog.scss
@@ -67,7 +67,7 @@
     .block-img + p > em:first-child {
       margin-top: -20px;
       display: block;
-      font-size: 0.8em;
+      font-size: .8em;
       text-align: center;
     }
     ol,  ul {

--- a/ui/site/css/_contact.scss
+++ b/ui/site/css/_contact.scss
@@ -2,7 +2,7 @@
   margin-top: 3em;
   h2 {
     margin-bottom: 1em;
-    padding-bottom: 0.3em;
+    padding-bottom: .3em;
     border-bottom: $border;
   }
   .node {

--- a/ui/site/css/_importer.scss
+++ b/ui/site/css/_importer.scss
@@ -17,7 +17,7 @@ main.importer {
     textarea {
       width: 98%;
       height: 20vh!important;
-      padding: 0.5em;
+      padding: .5em;
     }
 
     .analyse > span {

--- a/ui/site/css/_page.scss
+++ b/ui/site/css/_page.scss
@@ -12,11 +12,11 @@
     }
     ul li {
       list-style: disc outside;
-      margin: 0.5em 0 0 1.5em;
+      margin: .5em 0 0 1.5em;
     }
     ol li {
       list-style: decimal inside;
-      margin: 0.5em 0;
+      margin: .5em 0;
     }
     li {
       margin-left: 2em;

--- a/ui/site/css/_plan.scss
+++ b/ui/site/css/_plan.scss
@@ -52,7 +52,7 @@
   }
 
   .payments {
-    font-size: 0.9em;
+    font-size: .9em;
     th {
       text-align: left;
       font-weight: bold;

--- a/ui/site/css/_swag.scss
+++ b/ui/site/css/_swag.scss
@@ -7,7 +7,7 @@
     }
     ul li {
       list-style: disc inside;
-      margin: 0.5em 0;
+      margin: .5em 0;
     }
   }
   .page-menu__content {

--- a/ui/site/css/_video.scss
+++ b/ui/site/css/_video.scss
@@ -92,14 +92,14 @@
     }
     .author {
       display: block;
-      margin-bottom: 0.8em;
+      margin-bottom: .8em;
       opacity: 0.8;
     }
     .target {
       text-transform: uppercase;
       text-align: center;
       display: block;
-      margin-bottom: 0.8em;
+      margin-bottom: .8em;
     }
     .tags span {
       display: block;

--- a/ui/site/css/forum/_completion.scss
+++ b/ui/site/css/forum/_completion.scss
@@ -6,7 +6,7 @@
   li {
     list-style: none;
     border-top: 1px solid #dfdfdf;
-    padding: 0.5em;
+    padding: .5em;
     min-width: 100px;
     font-size: 1.2em;
     font-weight: bold;

--- a/ui/site/css/forum/_post.scss
+++ b/ui/site/css/forum/_post.scss
@@ -66,7 +66,7 @@
 
   .edit-buttons {
     text-align: right;
-    margin-top: 0.5em;
+    margin-top: .5em;
   }
   .edit-buttons a {
     margin-right: 1em;

--- a/ui/site/css/mod/_communication.scss
+++ b/ui/site/css/mod/_communication.scss
@@ -26,10 +26,10 @@
   .public_chats,
   .notes,
   .history {
-    margin-top: 0.5em;
+    margin-top: .5em;
     max-height: 150px;
     overflow-y: auto;
-    padding-bottom: 0.5em;
+    padding-bottom: .5em;
     border-bottom: 1px solid $border;
   }
   .player_chats {

--- a/ui/site/css/mod/_inquiry.scss
+++ b/ui/site/css/mod/_inquiry.scss
@@ -74,7 +74,7 @@ body.no-inquiry {
     flex: 4 1 auto;
   }
   .counter {
-    margin-left: 0.3em;
+    margin-left: .3em;
     flex: 0 0 auto;
   }
   .docs .expendable {
@@ -108,9 +108,9 @@ body.no-inquiry {
     margin: 0;
   }
   .report .atom {
-    margin-bottom: 0.8em;
+    margin-bottom: .8em;
     border-bottom: 1px solid #777;
-    padding-bottom: 0.8em;
+    padding-bottom: .8em;
   }
   .report .atom:last-child {
     margin-bottom: 0;
@@ -120,9 +120,9 @@ body.no-inquiry {
     display: inline-block;
     white-space: nowrap;
     font-weight: bold;
-    font-size: 0.9em;
-    padding: 0.1em 0.5em;
-    border-radius: 0.3em;
+    font-size: .9em;
+    padding: .1em .5em;
+    border-radius: .3em;
   }
   .score.green {
     /* actually blue */
@@ -202,7 +202,7 @@ body.no-inquiry {
   }
   .cancel button {
     margin-left: 5px;
-    font-size: 0.8em;
+    font-size: .8em;
     padding: 0 8px;
   }
   .accuracy {

--- a/ui/site/css/mod/_practice.scss
+++ b/ui/site/css/mod/_practice.scss
@@ -31,12 +31,12 @@
       margin: 0;
     }
     li li li {
-      font-size: 0.9em;
+      font-size: .9em;
     }
     em {
       display: block;
       font-style: italic;
-      font-size: 0.9em;
+      font-size: .9em;
     }
   }
   textarea.practice_text {

--- a/ui/site/css/mod/_report.scss
+++ b/ui/site/css/mod/_report.scss
@@ -21,7 +21,7 @@ $c-report-high-over: white;
       @extend %roboto, %flex-column;
       color: $c-font-dim;
       text-transform: uppercase;
-      padding: 0.5rem 1.4rem;
+      padding: .5rem 1.4rem;
       align-items: center;
       justify-content: center;
       &.new {

--- a/ui/site/css/mod/_report.scss
+++ b/ui/site/css/mod/_report.scss
@@ -35,7 +35,7 @@ $c-report-high-over: white;
         color: $c-report-high-over;
       }
       count {
-        font-size: 0.8em;
+        font-size: .8em;
         display: block;
         height: 1.2em;
       }
@@ -49,8 +49,8 @@ $c-report-high-over: white;
     white-space: nowrap;
     font-weight: bold;
     font-size: 1.2em;
-    padding: 0.3em 0.5em;
-    border-radius: 0.3em;
+    padding: .3em .5em;
+    border-radius: .3em;
   }
   .score.green {
     /* actually blue */
@@ -80,11 +80,11 @@ $c-report-high-over: white;
       font-size: 1.4em;
     }
     .button-thin {
-      font-size: 0.8em;
+      font-size: .8em;
     }
   }
   .atoms .atom {
-    font-size: 0.9em;
+    font-size: .9em;
     margin-bottom: 1em;
   }
   .atoms .atom:last-child {
@@ -94,29 +94,29 @@ $c-report-high-over: white;
     display: block;
   }
   .atoms .atom .score {
-    font-size: 0.9em;
-    padding: 0.1em 0.4em;
+    font-size: .9em;
+    padding: .1em .4em;
   }
   table.see .perfs {
-    font-size: 0.9em;
+    font-size: .9em;
     white-space: nowrap;
   }
   table.see .text {
     max-height: 100px;
     overflow: hidden;
-    font-size: 0.9em;
+    font-size: .9em;
   }
   table.see .text.large {
-    font-size: 0.8em;
+    font-size: .8em;
   }
   tr.new td:first-child {
     border-left: 4px solid $c-report-high;
   }
   .user_marks i {
-    font-size: 0.9em;
+    font-size: .9em;
     background: #dc322f70;
-    padding: 0.1em 0.4em;
-    border-radius: 0.3em;
-    margin: 0 0.2em;
+    padding: .1em .4em;
+    border-radius: .3em;
+    margin: 0 .2em;
   }
 }

--- a/ui/site/css/mod/_user.scss
+++ b/ui/site/css/mod/_user.scss
@@ -139,7 +139,7 @@
 }
 .mod-zone strong {
   display: block;
-  margin-top: 0.5em;
+  margin-top: .5em;
 }
 .mod-zone strong.inline {
   display: inline;
@@ -188,7 +188,7 @@
   text-transform: uppercase;
 }
 #mz_assessments .percentage {
-  font-size: 0.9em;
+  font-size: .9em;
 }
 #mz_assessments .legend {
   text-align: center;
@@ -278,7 +278,7 @@
   animation: brain-glow 1.5s ease-in-out infinite;
 }
 #mz_irwin header .infos {
-  font-size: 0.9em;
+  font-size: .9em;
 }
 #mz_irwin header strong {
   display: block;
@@ -294,9 +294,9 @@
   font-size: 1.6em;
 }
 #mz_irwin table em {
-  font-size: 0.8em;
+  font-size: .8em;
   line-height: 1em;
-  margin-top: -0.1em;
+  margin-top: -.1em;
   display: block;
 }
 #mz_irwin .moves {
@@ -344,9 +344,9 @@
   display: inline-block;
   white-space: nowrap;
   font-weight: bold;
-  font-size: 0.9em;
-  padding: 0.1em 0.5em;
-  border-radius: 0.3em;
+  font-size: .9em;
+  padding: .1em .5em;
+  border-radius: .3em;
 }
 .mz_reports .score.green {
   /* actually blue */

--- a/ui/site/css/relay/_index.scss
+++ b/ui/site/css/relay/_index.scss
@@ -15,7 +15,7 @@
       text-transform: uppercase;
       text-align: center;
       line-height: 2em;
-      letter-spacing: 0.1em;
+      letter-spacing: .1em;
       border-bottom: $border;
     }
   }

--- a/ui/site/css/streamer/_form.scss
+++ b/ui/site/css/streamer/_form.scss
@@ -60,7 +60,7 @@ $mq-picture: $mq-large;
     font-family: 'lichess';
     content: 'E';
     font-size: 1.5em;
-    margin-right: 0.5em;
+    margin-right: .5em;
     vertical-align: middle;
     opacity: 0.8;
   }

--- a/ui/site/css/streamer/_header.scss
+++ b/ui/site/css/streamer/_header.scss
@@ -60,7 +60,7 @@
   .service svg {
     width: 1.4em;
     height: 1.4em;
-    margin-right: 0.4em;
+    margin-right: .4em;
   }
   a.service:hover svg path {
     fill: $c-link;

--- a/ui/site/css/streamer/_list.scss
+++ b/ui/site/css/streamer/_list.scss
@@ -84,7 +84,7 @@ $mq-picture: $mq-medium;
     svg {
       width: 1.4em;
       height: 1.4em;
-      margin-right: 0.4em;
+      margin-right: .4em;
       opacity: 0.7;
     }
   }

--- a/ui/site/css/streamer/_show.scss
+++ b/ui/site/css/streamer/_show.scss
@@ -74,7 +74,7 @@ $mq-picture: $mq-large;
       margin-bottom: 1em;
       &::before {
         font-size: 1.6em;
-        margin-right: 0.1em;
+        margin-right: .1em;
       }
     }
   }

--- a/ui/site/css/team/_list.scss
+++ b/ui/site/css/team/_list.scss
@@ -13,7 +13,7 @@
     }
   }
   .info {
-    font-size: 0.9em;
+    font-size: .9em;
     white-space: nowrap;
     display: none;
     @include breakpoint($mq-x-small) {

--- a/ui/site/css/user/_activity.scss
+++ b/ui/site/css/user/_activity.scss
@@ -78,7 +78,7 @@ $c-contours: mix($c-brag, $c-shade, 80%);
   }
   score {
     float: right;
-    font-size: 0.7em;
+    font-size: .7em;
     margin-top: 2px;
     > * {
       margin-left: 8px;

--- a/ui/site/css/user/_list.scss
+++ b/ui/site/css/user/_list.scss
@@ -52,7 +52,7 @@ $user-list-width: 30ch;
         font-size: 1.45em;
         line-height: 2.5em;
         letter-spacing: -1px;
-        padding-left: 0.8rem;
+        padding-left: .8rem;
         text-transform: uppercase;
         margin: 0;
         background: $c-lead;

--- a/ui/site/css/user/_number-menu.scss
+++ b/ui/site/css/user/_number-menu.scss
@@ -8,7 +8,7 @@
     color: $c-font;
     text-align: center;
     line-height: 1.4em;
-    padding: 0.5em 5px;
+    padding: .5em 5px;
     text-transform: capitalize;
     white-space: normal;
     font-size: .9em;
@@ -19,7 +19,7 @@
   &--tabs .nm-item {
     @extend %box-radius-top;
     margin-top: .7em;
-    padding-bottom: 0.8em;
+    padding-bottom: .8em;
     @include transition();
     border-bottom: $border;
     &:first-child {

--- a/ui/site/css/user/_sub-rating.scss
+++ b/ui/site/css/user/_sub-rating.scss
@@ -53,7 +53,7 @@
       display: none;
     }
     .shy {
-      font-size: 0.8em;
+      font-size: .8em;
       opacity: 0.6;
       line-height: 1em;
     }

--- a/ui/tournament/css/_app-header.scss
+++ b/ui/tournament/css/_app-header.scss
@@ -71,7 +71,7 @@
   }
   .shy {
     line-height: 20px;
-    font-size: 0.9em;
+    font-size: .9em;
     font-weight: bold;
     text-transform: uppercase;
     opacity: 0.6;

--- a/ui/tournament/css/_app-standing.scss
+++ b/ui/tournament/css/_app-standing.scss
@@ -15,7 +15,7 @@
   }
   .user-link .rating {
     font-style: italic;
-    font-size: 0.8em;
+    font-size: .8em;
   }
   tr.long .user-link .rating {
     display: block;
@@ -43,18 +43,18 @@
   }
   td.rank {
     @extend %roboto;
-    padding: 1em 0.5em 1em 10px;
+    padding: 1em .5em 1em 10px;
     width: 1px; /* helps keeping it as small as possible */
     i {
-      opacity: 0.4;
-      font-size: 0.8em;
+      opacity: .4;
+      font-size: .8em;
     }
   }
   .sheet {
     text-align: right;
     padding-right: 0;
     padding-left: 0;
-    letter-spacing: 0.1em;
+    letter-spacing: .1em;
     & > * {
       display: inline-block;
     }
@@ -64,11 +64,11 @@
   }
   tr.long .sheet {
     font-size: .9rem;
-    letter-spacing: 0.06em;
+    letter-spacing: .06em;
   }
   tr.xlong .sheet {
     font-size: .85rem;
-    letter-spacing: 0.04em;
+    letter-spacing: .04em;
   }
   double {
     color: $c-brag;

--- a/ui/tournament/css/_duel.scss
+++ b/ui/tournament/css/_duel.scss
@@ -54,16 +54,16 @@
   }
   .rank {
     @extend %box-radius;
-    padding: 0.1em 0.5em;
+    padding: .1em .5em;
     background: $c-brag;
     color: #fff;
   }
   .b .title,
   .b .rank {
-    margin-right: 0.3em;
+    margin-right: .3em;
   }
   .a .title,
   .a .rank {
-    margin-left: 0.3em;
+    margin-left: .3em;
   }
 }

--- a/ui/tournament/css/_leaderboard.scss
+++ b/ui/tournament/css/_leaderboard.scss
@@ -15,7 +15,7 @@ $user-list-width: 35ch;
     @extend %metal, %box-shadow;
     font-size: 1.45em;
     line-height: 2.5em;
-    padding-left: 0.8rem;
+    padding-left: .8rem;
     text-transform: uppercase;
     margin: 0;
     white-space: nowrap;

--- a/ui/tournament/css/_podium.scss
+++ b/ui/tournament/css/_podium.scss
@@ -50,8 +50,8 @@
     letter-spacing: -1px;
   }
   .stats {
-    margin: 0.5em auto 0 auto;
-    font-size: 0.7em;
+    margin: .5em auto 0 auto;
+    font-size: .7em;
   }
   .stats th {
     letter-spacing: -1px;
@@ -62,7 +62,7 @@
     text-align: right;
   }
   .third .stats {
-    font-size: 0.8em;
+    font-size: .8em;
   }
 }
 .tour .big_top {

--- a/ui/tournament/css/_side.scss
+++ b/ui/tournament/css/_side.scss
@@ -45,8 +45,8 @@
     }
     .defender::before {
       font-size: 1.6em;
-      vertical-align: -0.26em;
-      margin: 0 0.15em 0 -0.15em;
+      vertical-align: -.26em;
+      margin: 0 .15em 0 -.15em;
     }
     &.conditions {
       &::before {

--- a/ui/tree/css/_tree.scss
+++ b/ui/tree/css/_tree.scss
@@ -16,7 +16,7 @@
     padding: 0 2px;
   }
   &-inline move {
-    padding: 0.25em 0.17em;
+    padding: .25em .17em;
     white-space: nowrap;
     font-weight: bold;
   }
@@ -72,7 +72,7 @@
     padding-left: 0;
   }
   &-inline move index {
-    padding-right: 0.2em;
+    padding-right: .2em;
     line-height: 111.11%
   }
   line move {
@@ -92,19 +92,19 @@
     @extend %roboto;
     flex: 3 0 auto;
     text-align: right;
-    font-size: 0.8em;
+    font-size: .8em;
     color: $c-font-dim;
   }
   glyph {
     @extend %base-font;
-    margin-left: 0.08em;
+    margin-left: .08em;
     vertical-align: bottom;
   }
   &-column > move glyph {
     flex: 0 1 auto;
     text-align: center;
     overflow: hidden;
-    font-size: 0.82em;
+    font-size: .82em;
   }
   &-column > index {
     flex: 0 0 13%;
@@ -134,16 +134,16 @@
   &-inline comment {
     vertical-align: 45%;
     word-wrap: break-word;
-    margin: 0 0.2em 0 0.1em;
-    font-size: 0.9em;
+    margin: 0 .2em 0 .1em;
+    font-size: .9em;
   }
   comment .by {
     @extend %nowrap-ellipsis, %roboto;
     display: inline-block;
-    vertical-align: -0.3em;
-    font-size: 0.9em;
+    vertical-align: -.3em;
+    font-size: .9em;
     opacity: 0.8;
-    margin-right: 0.4em;
+    margin-right: .4em;
     max-width: 9em;
   }
   &-column comment.white {
@@ -183,7 +183,7 @@
     display: block;
     margin-top: 2px;
     margin-left: 6px;
-    margin-bottom: 0.8em;
+    margin-bottom: .8em;
     border-left: 2px solid $c-border;
   }
   > interrupt > lines {
@@ -217,7 +217,7 @@
     height: 6px;
   }
   lines line::before {
-    margin-top: 0.65em;
+    margin-top: .65em;
     margin-left: -8px;
     content: ' ';
     border-top: 2px solid $c-border;
@@ -231,14 +231,14 @@
   inline {
     display: inline;
     font-style: italic;
-    font-size: 0.9em;
+    font-size: .9em;
     opacity: 0.8;
   }
   inline::before,
   inline::after {
-    vertical-align: 0.4em;
+    vertical-align: .4em;
     opacity: 0.7;
-    font-size: 0.9em;
+    font-size: .9em;
   }
   inline::before {
     content: '(';
@@ -250,7 +250,7 @@
   }
   &-inline inline::before,
   &-inline inline::after {
-    vertical-align: 0.7em;
+    vertical-align: .7em;
   }
   .conceal {
     opacity: 0.4;


### PR DESCRIPTION
Removes the leading zeroes of, for example, `padding: 0.1em` and changes it to `padding: .1em`

This follows the recommended Google CSS guidelines outlined here:
https://google.github.io/styleguide/htmlcssguide.html#Leading_0s