### PR TITLE
Preserve months when re-enabling plan (fix #5297)

### DIFF
--- a/modules/user/src/main/Plan.scala
+++ b/modules/user/src/main/Plan.scala
@@ -17,6 +17,7 @@ case class Plan(
   def disable = copy(active = false)
 
   def enable = copy(
+    months = months max 1,
     active = true,
     since = since orElse DateTime.now.some
   )

--- a/modules/user/src/main/Plan.scala
+++ b/modules/user/src/main/Plan.scala
@@ -18,7 +18,6 @@ case class Plan(
 
   def enable = copy(
     active = true,
-    months = months max 1,
     since = since orElse DateTime.now.some
   )
 
@@ -32,7 +31,7 @@ case class Plan(
 object Plan {
 
   val empty = Plan(0, false, none)
-  def start = Plan(1, true, DateTime.now.some)
+  def start = empty.incMonths
 
   import lila.db.dsl._
   private[user] val planBSONHandler = reactivemongo.bson.Macros.handler[Plan]

--- a/modules/user/src/test/PlanTest.scala
+++ b/modules/user/src/test/PlanTest.scala
@@ -1,0 +1,39 @@
+package lila.user
+
+import org.specs2.mutable.Specification
+
+class PlanTest extends Specification {
+
+  "empty" in {
+    Plan.empty.isEmpty must beTrue
+  }
+
+  "new patron" in {
+    Plan.start.isEmpty must beFalse
+    Plan.start.months == 1 must beTrue
+  }
+
+  "continuing patron" in {
+    val plan = Plan.start.incMonths
+    plan.isEmpty must beFalse
+    plan.months == 2 must beTrue
+  }
+
+  "lapsed patron" in {
+    val oneMonthPlan = Plan.start.disable
+    oneMonthPlan.isEmpty must beFalse
+    oneMonthPlan.months == 1 must beTrue
+    val twoMonthPlan = Plan.start.incMonths.disable
+    twoMonthPlan.isEmpty must beFalse
+    twoMonthPlan.months == 2 must beTrue
+  }
+
+  "returning patron" in {
+    val twoMonthPlan = Plan.start.disable.incMonths
+    twoMonthPlan.isEmpty must beFalse
+    twoMonthPlan.months == 2 must beTrue
+    val threeMonthPlan = Plan.start.incMonths.disable.incMonths
+    threeMonthPlan.isEmpty must beFalse
+    threeMonthPlan.months == 3 must beTrue
+  }
+}


### PR DESCRIPTION
Only tested via unit tests; unsure if there's some path through code where `incMonths` is called too many times.

Also I do not know if we have a way of restoring uncounted months (from donation history).