### PR TITLE
Add space after anonymous in watching

### DIFF
--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -690,7 +690,7 @@
       if (data.users) {
         var tags = data.users.map($.userLink);
         if (data.anons === 1) tags.push('Anonymous');
-        else if (data.anons) tags.push('Anonymous(' + data.anons + ')');
+        else if (data.anons) tags.push('Anonymous (' + data.anons + ')');
         this.list.html(tags.join(', '));
       } else if (!this.number.length) this.list.html(data.nb + ' players in the chat');
       this.element.removeClass('none');


### PR DESCRIPTION
Adds a space after "Anonymous" in the tournament watching chat list, so that instead of "Anonymous(1)" it becomes "Anonymous (1)"