### PR TITLE
Add question to FAQ linking to Lichess derivatives

### DIFF
--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -36,6 +36,11 @@ object faq {
           "How can I contribute to Lichess?",
           p("Lichess is powered by donations from patrons and the efforts of a team of volunteers."),
           p("You can find out more about ", a(href := routes.Plan.index())("being a patron"), " (including a ", a(href := routes.Main.costs())("breakdown of our costs"), "). If you want to help Lichess by volunteering your time and skills, there are many ", a(href := routes.Page.help())("other ways to help"), ".")
+        ),        
+        question(
+          "sites_inspired_by_Lichess",
+          "Are there open-source sites inspired by Lichess?",
+          p("Absolutely. Lichess has indeed inspired other sites that use Lichess's ", a(href := "https://lichess.org/api")("API"), " and/or ", a(href := "https://database.lichess.org/")("database"), ". These include ", a(href := "https://blitztactics.com/about")("Blitz Tactics"), " and ", a(href := "https://tailuge.github.io/chess-o-tron/html/blunder-bomb.html?p=P")("Blunder Bomb"), ". Please credit Lichess when you create derivative works.")
         ),
         h2("Fair Play"),
         question(

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -38,9 +38,10 @@ object faq {
           p("You can find out more about ", a(href := routes.Plan.index())("being a patron"), " (including a ", a(href := routes.Main.costs())("breakdown of our costs"), "). If you want to help Lichess by volunteering your time and skills, there are many ", a(href := routes.Page.help())("other ways to help"), ".")
         ),        
         question(
-          "sites_inspired_by_Lichess",
-          "Are there open-source sites inspired by Lichess?",
-          p("Absolutely. Lichess has indeed inspired other sites that use Lichess's ", a(href := "https://lichess.org/api")("API"), " and/or ", a(href := "https://database.lichess.org/")("database"), ". These include ", a(href := "https://blitztactics.com/about")("Blitz Tactics"), " and ", a(href := "https://tailuge.github.io/chess-o-tron/html/blunder-bomb.html?p=P")("Blunder Bomb"), ". Please credit Lichess when you create derivative works.")
+          "sites_based_on_Lichess",
+          "Are there websites based on Lichess?",
+          p("Absolutely. Lichess has indeed inspired other open-source sites that use Lichess's code, ", a(href := "https://lichess.org/api")("API,"), " and/or ", a(href := "https://database.lichess.org/")("database"), ". These include ", a(href := "https://blitztactics.com/about")("Blitz Tactics"), " and ", a(href := "https://tailuge.github.io/chess-o-tron/html/blunder-bomb.html?p=P")("Blunder Bomb"), "."),
+          p("You can download, read, use and modify every bit of source code. Please credit Lichess when you create derivative works.")
         ),
         h2("Fair Play"),
         question(


### PR DESCRIPTION
Because Lichess is open-source, some users have created their own open-source sites based off aspects of Lichess. This pull request adds a question to the FAQ linking to examples of these derivatives.

I see two benefits for Lichess users:

- These sites _supplement_ Lichess features. Although they are not part of Lichess, they might nevertheless be useful to certain Lichess users. (For example, _Blitz Tactics_ takes Lichess puzzles, and adds additional timing options.)
- Programmers might be inspired to create similar sites based off Lichess if those sites would not fit the core theme of Lichess at present. (For example, other more esoteric chess variants.)

I do not think Lichess would be hurt by linking sites like these in the FAQ, or see a reduction in users. In the future, if more people create chess sites based off Lichess, there could even be a list of the best derivatives.