### PR TITLE
Tournament name in winners box same as open tournament names

### DIFF
--- a/app/views/lobby/bits.scala
+++ b/app/views/lobby/bits.scala
@@ -48,7 +48,7 @@ object bits {
           tournamentWinners take 10 map { w =>
             tr(
               td(userIdLink(w.userId.some)),
-              td(a(title := w.tourName, href := routes.Tournament.show(w.tourId))(scheduledTournamentNameShortHtml(w.tourName)))
+              td(cls := "name")(a(title := w.tourName, href := routes.Tournament.show(w.tourId))(scheduledTournamentNameShortHtml(w.tourName)))
             )
           }
         ))


### PR DESCRIPTION
This makes the name of the tournament in the "Tournament Winners" box be styled the same as the name of the tournament in the "Open Tournaments" box