### PR TITLE
Remove unneeded transition arguments

### DIFF
--- a/ui/analyse/css/study/panel/_multiboard.scss
+++ b/ui/analyse/css/study/panel/_multiboard.scss
@@ -36,7 +36,7 @@
       @extend %box-radius;
       color: $c-font;
       padding: .4em;
-      @include transition(background);
+      @include transition();
       background: fade-out($c-bg-box, 0.6);
       overflow: hidden;
       &:nth-child(even) {

--- a/ui/challenge/css/_challenge.scss
+++ b/ui/challenge/css/_challenge.scss
@@ -18,7 +18,7 @@
     @extend %box-radius-force, %dropdown-shadow;
     background: $c-bg-header-dropdown;
     margin-bottom: 5px;
-    @include transition(height);
+    @include transition();
     transition-delay: #{$transition-duration * 2 / 3};
     position: relative;
     height: 67px;
@@ -40,7 +40,7 @@
       top: 62px;
       left: 0px;
       width: 100%;
-      @include transition(opacity);
+      @include transition();
       transition-delay: 0ms;
     }
     &:hover .buttons {

--- a/ui/cli/css/_clinput.scss
+++ b/ui/cli/css/_clinput.scss
@@ -9,7 +9,7 @@
     border: 0;
     width: 0;
     @include breakpoint($mq-x-large) {
-      @include transition(width);
+      @include transition();
     }
     body.clinput & {
       width: 20ch;

--- a/ui/common/css/component/_mselect.scss
+++ b/ui/common/css/component/_mselect.scss
@@ -22,7 +22,7 @@ $c-mselect: $c-primary;
     }
   }
   &__toggle:checked ~ .mselect__label {
-    @include transition(opacity);
+    @include transition();
     opacity: 0;
   }
   &__list {
@@ -35,7 +35,7 @@ $c-mselect: $c-primary;
     background: $c-bg-popup;
     transform: scale(1, 0);
     transform-origin: top;
-    @include transition(transform);
+    @include transition();
     .current {
       background: $c-bg-zebra;
       @extend %flex-between-nowrap;

--- a/ui/common/css/component/_now-playing.scss
+++ b/ui/common/css/component/_now-playing.scss
@@ -9,7 +9,7 @@
     @extend %box-radius;
     color: $c-font;
     padding: .3em;
-    @include transition(background);
+    @include transition();
     background: fade-out($c-bg-box, 0.6);
     &:hover {
       background: fade-out($c-link, 0.6);

--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -36,7 +36,7 @@
   background-color: $c-font-dimmer;
 }
 .cmn-toggle:hover + label::before {
-  @include transition(background);
+  @include transition();
 }
 .cmn-toggle + label::after {
   @extend %metal;
@@ -46,7 +46,7 @@
 }
 .cmn-toggle:hover + label::after {
   @extend %metal-hover;
-  @include transition(margin);
+  @include transition();
 }
 .cmn-toggle:checked + label::before {
   background-color: $c-good;

--- a/ui/common/css/header/_topnav-hidden.scss
+++ b/ui/common/css/header/_topnav-hidden.scss
@@ -108,7 +108,7 @@
       text-decoration: none;
       padding: .7em 0;
       opacity: 0;
-      @include transition(opacity);
+      @include transition();
     }
 
     section {

--- a/ui/dasher/css/_dasher.scss
+++ b/ui/dasher/css/_dasher.scss
@@ -75,7 +75,7 @@
     a {
       display: block;
       padding: .7rem 1rem;
-      @include transition(background);
+      @include transition();
       &:hover {
         background: $c-dasher-light;
       }
@@ -89,7 +89,7 @@
         justify-content: center;
         align-items: center;
         opacity: 0;
-        @include transition(opacity);
+        @include transition();
       }
       &:hover::before {
         opacity: 1;

--- a/ui/game/css/_row.scss
+++ b/ui/game/css/_row.scss
@@ -5,7 +5,7 @@
   padding: .5em 1em;
   border-bottom: $border;
   position: relative;
-  @include transition(background);
+  @include transition();
   &:nth-child(odd) {
     background: $c-bg-zebra;
   }

--- a/ui/insight/css/_insight.scss
+++ b/ui/insight/css/_insight.scss
@@ -331,7 +331,7 @@
     grid-template-columns: repeat(auto-fit, minmax(200px, 25%));
     a {
       @extend %box-radius;
-      @include transition(background);
+      @include transition();
       color: $c-font;
       padding: .4em;
       span {

--- a/ui/lobby/css/_about.scss
+++ b/ui/lobby/css/_about.scss
@@ -8,7 +8,7 @@
     font-weight: bold;
     margin-right: 1.2em;
     white-space: nowrap;
-    @include transition(color);
+    @include transition();
     &:hover{
       color: $c-link;
     }

--- a/ui/lobby/css/_table.scss
+++ b/ui/lobby/css/_table.scss
@@ -44,7 +44,7 @@
     }
     a {
       color: $c-font-page;
-      @include transition(color);
+      @include transition();
       &:hover {
         color: $c-link;
       }

--- a/ui/notify/css/_notify.scss
+++ b/ui/notify/css/_notify.scss
@@ -15,7 +15,7 @@
   }
 
   .notifications {
-    @include transition(opacity);
+    @include transition();
   }
   .notifications.scrolling {
     opacity: 0.5;

--- a/ui/puzzle/css/_history.scss
+++ b/ui/puzzle/css/_history.scss
@@ -17,7 +17,7 @@
     }
   }
   a {
-    @include transition(background);
+    @include transition();
     &:hover {
       color: #fff;
       opacity: 1;

--- a/ui/tournament/css/_player.scss
+++ b/ui/tournament/css/_player.scss
@@ -47,7 +47,7 @@
     width: 100%;
     tr {
       cursor: pointer;
-      @include transition(background-color);
+      @include transition();
       &:nth-child(odd) {
         background: $c-bg-zebra;
       }


### PR DESCRIPTION
Seems like I missed some of the transitions when I searched last time. So this pull request *should* remove all of the unneeded arguments in the `@include transition();` calls.