### PR TITLE
Fix ratings showing differently in TV when updated dynamically

### DIFF
--- a/ui/round/src/boot.ts
+++ b/ui/round/src/boot.ts
@@ -22,7 +22,7 @@ export default function(opts: RoundOpts): void {
             o.player ? [
               o.player.title,
               o.player.name,
-              '(' + o.player.rating + ')'
+              o.player.rating
             ].filter(x => x).join('&nbsp') : 'Anonymous');
         },
         end() {


### PR DESCRIPTION
Currently, when ratings are updated dynamically (without refreshing) in the TV, the format of the updated ratings is different than the format generated by the backend.

E.g. check Rapid, Antichess, Bullet, and Bot ratings on the screenshots below:

Before refresh | After refresh
--- | ---
![image](https://user-images.githubusercontent.com/5276727/62419937-0feb3a80-b694-11e9-88b7-5edb54df8e68.png) | ![image](https://user-images.githubusercontent.com/5276727/62419938-15e11b80-b694-11e9-9d73-24959efefcdf.png)

Note that I haven't tested if the PR actually works, but it seemed simple enough.. :smiley: 