### PR TITLE
Updated renderSan()

### DIFF
--- a/ui/speech/src/main.ts
+++ b/ui/speech/src/main.ts
@@ -4,19 +4,17 @@ function renderSan(san: San) {
   let move: string;
   if (san.includes('O-O-O')) move = 'long castle';
   else if (san.includes('O-O')) move = 'short castle';
-  else move = san.replace(/[\+#]/, '').split('').map(c => {
+  else move = san.split('').map(c => {
     if (c == 'x') return 'takes';
     if (c == '+') return 'check';
     if (c == '#') return 'checkmate';
-    if (c == '=') return 'promotion';
+    if (c == '=') return 'promotes to';
     if (c == '@') return 'at';
     const code = c.charCodeAt(0);
     if (code > 48 && code < 58) return c; // 1-8
     if (code > 96 && code < 105) return c.toUpperCase();
     return roles[c] || c;
   }).join(' ');
-  if (san.includes('+')) move += ' check';
-  if (san.includes('#')) move += ' checkmate';
   return move;
 }
 


### PR DESCRIPTION
If the replace function is removed, the if statements for adding "check" and "checkmate" to the string are no longer required.  Also, changed "promotion" to "promotes to".  I thought "f8 promotes to queen" sounded better than "f8 promotion queen".

Sorry for so many edits to this file!  I hope this will be the last one it needs for a long time.