### PR TITLE
Remove number filtered from hooks-list

### DIFF
--- a/ui/lobby/src/view/realTime/filter.ts
+++ b/ui/lobby/src/view/realTime/filter.ts
@@ -60,7 +60,7 @@ function initialize(ctrl: LobbyController, el) {
   });
 }
 
-export function toggle(ctrl: LobbyController, nbFiltered: number) {
+export function toggle(ctrl: LobbyController) {
   return h('i.toggle.toggle-filter', {
     class: { active: ctrl.filterOpen },
     hook: bind('mousedown', ctrl.toggleFilter, ctrl.redraw),
@@ -68,7 +68,7 @@ export function toggle(ctrl: LobbyController, nbFiltered: number) {
       'data-icon': ctrl.filterOpen ? 'L' : '%',
       title: ctrl.trans.noarg('filterGames')
     }
-  }, nbFiltered > 0 ? '' + nbFiltered : '');
+  });
 }
 
 export interface FilterNode extends HTMLElement {

--- a/ui/lobby/src/view/realTime/main.ts
+++ b/ui/lobby/src/view/realTime/main.ts
@@ -5,22 +5,20 @@ import * as filterView from './filter';
 import LobbyController from '../../ctrl';
 
 export default function(ctrl: LobbyController) {
-  let filterBody, body, nbFiltered, modeToggle, res;
+  let filterBody, body, modeToggle, res;
   if (ctrl.filterOpen) filterBody = filterView.render(ctrl);
   switch (ctrl.mode) {
     case 'chart':
       res = filter(ctrl, ctrl.data.hooks);
-      nbFiltered = res.hidden;
       body = filterBody || chart.render(ctrl, res.visible);
       modeToggle = ctrl.filterOpen ? null : chart.toggle(ctrl);
       break;
     default:
       res = filter(ctrl, ctrl.stepHooks);
-      nbFiltered = res.hidden;
       body = filterBody || list.render(ctrl, res.visible);
       modeToggle = ctrl.filterOpen ? null : list.toggle(ctrl);
   }
-  const filterToggle = filterView.toggle(ctrl, nbFiltered);
+  const filterToggle = filterView.toggle(ctrl);
   return [
     filterToggle,
     modeToggle,


### PR DESCRIPTION
This pull request removes the number next to the filters button that is showing how many games you are hiding. I believe this should be remove as

**a)** few people actually know what this number means. I even asked in the Lichess Discord server and it wasn't until Sazed said what it meant that anyone actually knew
**b)** is it really useful to know how many games you're filtering? Why would you want to or need to know this?
**c)** it is diminishing from the look of the front page. It is actually misaligned and looks a bit silly. Perhaps we could show the number of hidden games elsewhere, but I don't believe this is a good place for it.