### PR TITLE
Remove filter numbers and colour the filter button icon instead

### DIFF
--- a/ui/common/css/theme/_default.scss
+++ b/ui/common/css/theme/_default.scss
@@ -42,6 +42,8 @@ $c-secondary-over: #fff; /* text over secondary background */
 
 /* Accent: orange */
 $c-accent: hsl(22, 100%, 42%);
+$c-accent-dim: c-dimmer($c-accent);
+$c-accent-clear: c-clearer($c-accent);
 $c-accent-over: #fff; /* text over accent background */
 
 /* Brag: gold */

--- a/ui/lobby/css/app/_app.scss
+++ b/ui/lobby/css/app/_app.scss
@@ -51,7 +51,7 @@
     }
   }
 
-  .toggle[filtered='yes'] {
+  .gamesFiltered {
     color: $c-accent;
     @include transition();
     &:hover {

--- a/ui/lobby/css/app/_app.scss
+++ b/ui/lobby/css/app/_app.scss
@@ -44,10 +44,21 @@
     font-size: 1.3em;
     &.toggle-filter {
       right: 0;
+      &[filtered='Y'] {
+        color: $c-link;
+      }
     }
     @include transition();
     &:hover {
       color: $c-accent;
+    }
+  }
+
+  .toggle[filtered='yes'] {
+    color: $c-accent;
+    @include transition();
+    &:hover {
+      color: $c-accent-dim;
     }
   }
 }

--- a/ui/lobby/css/app/_app.scss
+++ b/ui/lobby/css/app/_app.scss
@@ -44,9 +44,6 @@
     font-size: 1.3em;
     &.toggle-filter {
       right: 0;
-      &[filtered='Y'] {
-        color: $c-link;
-      }
     }
     @include transition();
     &:hover {

--- a/ui/lobby/src/view/realTime/filter.ts
+++ b/ui/lobby/src/view/realTime/filter.ts
@@ -66,9 +66,10 @@ export function toggle(ctrl: LobbyController, nbFiltered: number) {
     hook: bind('mousedown', ctrl.toggleFilter, ctrl.redraw),
     attrs: {
       'data-icon': ctrl.filterOpen ? 'L' : '%',
-      title: ctrl.trans.noarg('filterGames')
+      title: ctrl.trans.noarg('filterGames'),
+      'filtered': nbFiltered > 0 ? 'yes' : 'no'
     }
-  }, nbFiltered > 0 ? '' + nbFiltered : '');
+  });
 }
 
 export interface FilterNode extends HTMLElement {

--- a/ui/lobby/src/view/realTime/filter.ts
+++ b/ui/lobby/src/view/realTime/filter.ts
@@ -62,12 +62,11 @@ function initialize(ctrl: LobbyController, el) {
 
 export function toggle(ctrl: LobbyController, nbFiltered: number) {
   return h('i.toggle.toggle-filter', {
-    class: { active: ctrl.filterOpen },
+    class: { gamesFiltered: nbFiltered > 0, active: ctrl.filterOpen },
     hook: bind('mousedown', ctrl.toggleFilter, ctrl.redraw),
     attrs: {
       'data-icon': ctrl.filterOpen ? 'L' : '%',
-      title: ctrl.trans.noarg('filterGames'),
-      'filtered': nbFiltered > 0 ? 'yes' : 'no'
+      title: ctrl.trans.noarg('filterGames')
     }
   });
 }


### PR DESCRIPTION
This removes the filter numbers from the hooks list in the lobby and colours the settings icon as c-accent when there are games being filtered instead.