### PR TITLE
Allow a node with `forceVariation` to be promoted when it's first child

### DIFF
--- a/ui/tree/src/tree.ts
+++ b/ui/tree/src/tree.ts
@@ -168,6 +168,9 @@ export function build(root: Tree.Node): TreeWrapper {
         ops.removeChild(parent, node.id);
         parent.children.unshift(node);
         if (!toMainline) break;
+      } else if (node.forceVariation) {
+        node.forceVariation = false;
+        if (!toMainline) break;
       }
     }
   }


### PR DESCRIPTION
On the analysis board, if the first child of a node has `forceVariation`, this change allows "Promote variation" and "Make main line" to work as expected.