### PR TITLE
Fix the animation of the arrow in the sub-ratings list

### DIFF
--- a/ui/site/css/user/_sub-rating.scss
+++ b/ui/site/css/user/_sub-rating.scss
@@ -44,6 +44,8 @@
     i {
       font-size: .75em;
       opacity: .2;
+      color: $c-font-dim;
+      @include transition();
     }
     &:hover i {
       color: $c-link;


### PR DESCRIPTION
This pull request fixes the fact that the arrows in the sub-ratings list on the user page aren't animated when hovered while the sub-ratings icons are.