### PR TITLE
Fix the box alignment without breaking other boxes

### DIFF
--- a/ui/lobby/css/_box.scss
+++ b/ui/lobby/css/_box.scss
@@ -4,7 +4,7 @@
     &__top {
       @extend %metal, %flex-between;
       flex: 0 0 auto;
-      padding: .3em .5em .3em .6em;
+      padding: .3em .5em;
       .more {
         color: $c-font-dim;
         @include transition();
@@ -26,6 +26,7 @@
       overflow-y: auto;
     }
     .user-link {
+      padding-left: -1em;
       font-weight: bold;
       color: $c-font-dim;
     }


### PR DESCRIPTION
My previous pull request regarding the alignment of the lobby boxes (#5414), while aligning the Leaderboard and Tournament Winners boxes, actually misaligned the Open Tournaments boxes. I have since worked out what the actual cause for the misalignment in the Leaderboard and the Tournament Winners boxes was (it was that the user-links had padding on the left) and now in this commit it is **actually** fixed.