### PR TITLE
Makes the titles colour the actual colour of c-brag

### DIFF
--- a/ui/tournamentSchedule/css/_side.scss
+++ b/ui/tournamentSchedule/css/_side.scss
@@ -34,9 +34,6 @@
     @extend %ellipsis;
     margin: 0 5px 0 -3px;
   }
-  span {
-    opacity: 0.7;
-  }
 }
 
 .tour__links {


### PR DESCRIPTION
On the tournamentSchedule page, titles are a darker colour due to the opacity being set to 0.7 for the title. It doesn't make sense for it to be like this, and it should be the same as it is everywhere else.