### PR TITLE
backToGame orientation

### DIFF
--- a/ui/analyse/src/view.ts
+++ b/ui/analyse/src/view.ts
@@ -329,7 +329,7 @@ export default function(ctrl: AnalyseCtrl): VNode {
             (!ctrl.synthetic && playable(ctrl.data)) ? h('div.back-to-game',
               h('a.button.button-empty.text', {
                 attrs: {
-                  href: router.game(ctrl.data),
+                  href: router.game(ctrl.data, ctrl.data.player.color),
                   'data-icon': 'i'
                 }
               }, ctrl.trans.noarg('backToGame'))


### PR DESCRIPTION
When spectating a game from Black's point of view, going to analysis board and hitting "back to game" changes point of view to White.
Fix that.