### PR TITLE
Style the checkboxes

### DIFF
--- a/app/views/setup/filter.scala
+++ b/app/views/setup/filter.scala
@@ -80,6 +80,7 @@ object filter {
   ) = label(title := hint)(
     input(
       tpe := "checkbox",
+      cls := "regular-checkbox",
       name := s"${form(key).name}[$index]",
       st.value := value,
       checks.has(value) option checked

--- a/ui/common/css/abstract/_extends.scss
+++ b/ui/common/css/abstract/_extends.scss
@@ -99,7 +99,7 @@
   padding: 0.5em;
   &:checked {
     background: $c-primary;
-    border: 1px solid $c-primary;
+    border: 1px solid $c-primary-dim;
   }
 }
 %nowrap-hidden {

--- a/ui/common/css/abstract/_extends.scss
+++ b/ui/common/css/abstract/_extends.scss
@@ -92,13 +92,14 @@
 }
 %checkbox {
   -webkit-appearance: none;
-  background: $c-site-hue;
-  border: 1px solid $c-font-dim;
+  background: $c-bg-page;
+  border: 1px solid $c-bg-low;
   border-radius: 0.1em;
   display: inline-block;
   padding: 0.5em;
   &:checked {
     background: $c-primary;
+    border: 1px solid $c-primary;
   }
 }
 %nowrap-hidden {

--- a/ui/common/css/abstract/_extends.scss
+++ b/ui/common/css/abstract/_extends.scss
@@ -90,7 +90,9 @@
   outline: none;
   color: $c-font;
 }
-
+%checkbox {
+  -webkit-appearance: none;
+}
 %nowrap-hidden {
   white-space: nowrap;
   overflow: hidden;

--- a/ui/common/css/abstract/_extends.scss
+++ b/ui/common/css/abstract/_extends.scss
@@ -92,14 +92,13 @@
 }
 %checkbox {
   -webkit-appearance: none;
-  background-color: $c-site-hue;
+  background: $c-site-hue;
   border: 1px solid $c-font-dim;
   border-radius: 0.1em;
   display: inline-block;
   padding: 0.5em;
-  &:checked:after {
-    content: '\2714';
-    color: $c-font;
+  &:checked {
+    background: $c-primary;
   }
 }
 %nowrap-hidden {

--- a/ui/common/css/abstract/_extends.scss
+++ b/ui/common/css/abstract/_extends.scss
@@ -94,6 +94,9 @@
   -webkit-appearance: none;
   background-color: $c-site-hue;
   border: 1px solid $c-font-dim;
+  border-radius: 0.1em;
+  display: inline-block;
+  padding: 0.5em;
 }
 %nowrap-hidden {
   white-space: nowrap;

--- a/ui/common/css/abstract/_extends.scss
+++ b/ui/common/css/abstract/_extends.scss
@@ -92,6 +92,8 @@
 }
 %checkbox {
   -webkit-appearance: none;
+  background-color: $c-site-hue;
+  border: 1px solid $c-font-dim;
 }
 %nowrap-hidden {
   white-space: nowrap;

--- a/ui/common/css/abstract/_extends.scss
+++ b/ui/common/css/abstract/_extends.scss
@@ -97,6 +97,10 @@
   border-radius: 0.1em;
   display: inline-block;
   padding: 0.5em;
+  &:checked:after {
+    content: '\2714';
+    color: $c-font;
+  }
 }
 %nowrap-hidden {
   white-space: nowrap;

--- a/ui/common/css/abstract/_extends.scss
+++ b/ui/common/css/abstract/_extends.scss
@@ -94,7 +94,7 @@
   -webkit-appearance: none;
   background: $c-bg-page;
   border: 1px solid $c-bg-low;
-  border-radius: 0.1em;
+  border-radius: 0.2em;
   display: inline-block;
   padding: 0.5em;
   &:checked {

--- a/ui/lobby/css/app/_hook-filter.scss
+++ b/ui/lobby/css/app/_hook-filter.scss
@@ -22,6 +22,9 @@
       cursor: pointer;
     }
   }
+  .regular-checkbox {
+    @extend %checkbox;
+  }
   tr.variant td:last-child {
     display: flex;
     flex-flow: row wrap;


### PR DESCRIPTION
This pull request styles the checkboxes. The before and after pictures are shown below. This only styles the checkboxes in the lobby hooks-filters because I couldn't find the other files which I needed to change (i.e. to style the "Show Chat" checkbox), but you only need to add
```scss
.checkbox-class {
  @extend %checkbox;
}
```
to the CSS where `checkbox-class` is the class of the checkbox. Any changes to the styling you want, feel free to tell me and I can make the changes but for now I've just styled them how I would have them. P.S. the following "before" photos are system-dependent, due to them inheriting the system theme.

### **Dark Theme**
**Before**
![darkbefore](https://user-images.githubusercontent.com/1687121/62830130-94b5f580-bc4c-11e9-8d09-0d8d14d13725.png)

**After**
![darkafter](https://user-images.githubusercontent.com/1687121/62830131-97b0e600-bc4c-11e9-93d6-001412a123c4.png)

### **Light Theme**
**Before**
![lightbefore](https://user-images.githubusercontent.com/1687121/62830134-a7c8c580-bc4c-11e9-92e9-120c6ec4da11.png)

**After**
![lightafter](https://user-images.githubusercontent.com/1687121/62830141-c333d080-bc4c-11e9-853b-ddb526188165.png)

