### PR TITLE
Inactive player should become provisional in 365 days

### DIFF
--- a/modules/rating/src/main/Glicko.scala
+++ b/modules/rating/src/main/Glicko.scala
@@ -68,8 +68,8 @@ case object Glicko {
   // past this, it might not stabilize ever again
   val maxVolatility = 0.1d
 
-  // Chosen so a typical player's RD goes from 60 -> 110 in 1 year
-  val ratingPeriodsPerDay = 0.21436d
+  // Chosen so a typical player's RD goes from minimum -> provisional in 365 days
+  val ratingPeriodsPerDay = 0.24210d
 
   val tau = 0.75d
   val system = new RatingCalculator(default.volatility, tau, ratingPeriodsPerDay)

--- a/modules/rating/src/test/GlickoTest.scala
+++ b/modules/rating/src/test/GlickoTest.scala
@@ -1,0 +1,17 @@
+package lila.rating
+
+import org.joda.time.DateTime
+import org.specs2.mutable.Specification
+
+class GlickoTest extends Specification {
+
+  "rating deviation" should {
+    "provisional in 1 year" in {
+      val now = new DateTime
+      val glicko = Glicko(1500d, Glicko.minDeviation, 0.06d)
+      val perf = Perf(glicko, 0, Nil, now.some)
+      Glicko.system.previewDeviation(perf.toRating, now plusDays 365, false) must be_>=(Glicko.provisionalDeviation.toDouble)
+    }
+  }
+
+}


### PR DESCRIPTION
This isn't the highest-priority ratings issue (perhaps tuning tau and/or volatility so it isn't so easy to hit the RD minimum might be a good idea), but seems easily understood:

A player who hasn't played any rated games in a year should have a provisional rating.  (We just reduced the rating floor from 60 -> 50 but this parameter wasn't updated.)