### PR TITLE
Align the username to the icon on the user page

### DIFF
--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -27,17 +27,19 @@ object header {
         table(
           td(if (u.isPatron) a(href := routes.Plan.index)(patronIcon) else i(cls := "line")),
           td(titleTag(u.title)),
-          td(u.username)
+          td(u.username),
+          td(
+            div(cls := List(
+              "trophies" -> true,
+              "packed" -> (info.countTrophiesAndPerfCups > 7)
+            ))(
+              views.html.user.bits.perfTrophies(u, info.ranks),
+              otherTrophies(u, info),
+              u.plan.active option
+                a(href := routes.Plan.index, cls := "trophy award patron icon3d", ariaTitle(s"Patron since ${showDate(u.plan.sinceDate)}"))(patronIconChar)
+            )
+          )
         )
-      ),
-      div(cls := List(
-        "trophies" -> true,
-        "packed" -> (info.countTrophiesAndPerfCups > 7)
-      ))(
-        views.html.user.bits.perfTrophies(u, info.ranks),
-        otherTrophies(u, info),
-        u.plan.active option
-          a(href := routes.Plan.index, cls := "trophy award patron icon3d", ariaTitle(s"Patron since ${showDate(u.plan.sinceDate)}"))(patronIconChar)
       ),
       u.disabled option span(cls := "closed")("CLOSED")
     ),

--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -25,10 +25,17 @@ object header {
     div(cls := "box__top user-show__header")(
       h1(cls := s"user-link ${if (isOnline(u.id)) "online" else "offline"}")(
         if (u.isPatron) frag(
-          a(href := routes.Plan.index)(patronIcon),
-          userSpan(u, withPowerTip = false, withOnline = false)
+          table(
+            td(a(href := routes.Plan.index)(patronIcon)),
+            td(u.username)
+          )
         )
-        else userSpan(u, withPowerTip = false)
+        else frag(
+          table(
+            td(i(cls := "line")),
+            td(u.username)
+          )
+        )
       ),
       div(cls := List(
         "trophies" -> true,

--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -24,17 +24,9 @@ object header {
   )(implicit ctx: Context) = frag(
     div(cls := "box__top user-show__header")(
       h1(cls := s"user-link ${if (isOnline(u.id)) "online" else "offline"}")(
-        if (u.isPatron) frag(
-          table(
-            td(a(href := routes.Plan.index)(patronIcon)),
-            td(u.username)
-          )
-        )
-        else frag(
-          table(
-            td(i(cls := "line")),
-            td(u.username)
-          )
+        table(
+          td(if (u.isPatron) a(href := routes.Plan.index)(patronIcon) else i(cls := "line")),
+          td(u.username)
         )
       ),
       div(cls := List(

--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -26,6 +26,7 @@ object header {
       h1(cls := s"user-link ${if (isOnline(u.id)) "online" else "offline"}")(
         table(
           td(if (u.isPatron) a(href := routes.Plan.index)(patronIcon) else i(cls := "line")),
+          td(titleTag(u.title)),
           td(u.username)
         )
       ),


### PR DESCRIPTION
This pull request aligns the username to the icon (circle or patron wing) on the user page. It uses tables to do so.