### PR TITLE
Losing or drawing early reduces completion rate

### DIFF
--- a/modules/playban/src/main/model.scala
+++ b/modules/playban/src/main/model.scala
@@ -109,9 +109,9 @@ object Outcome {
   case object RageQuit extends Outcome(3, "Quits without resigning")
   case object Sitting extends Outcome(4, "Lets time run out")
   case object SitMoving extends Outcome(5, "Waits then moves at last moment")
-  case object Sandbag extends Outcome(6, "Deliberately lost the game")
+  case object Opening extends Outcome(6, "Draws or loses in the opening")
 
-  val all = List(Good, Abort, NoPlay, RageQuit, Sitting, SitMoving, Sandbag)
+  val all = List(Good, Abort, NoPlay, RageQuit, Sitting, SitMoving, Opening)
 
   val byId = all map { v => (v.id, v) } toMap
 


### PR DESCRIPTION
Historically, "sandbagging" refers to two different ideas:
a) Losing or drawing in the opening (sometimes called "boosting")
b) Reducing rating as a result of quickly losing games (regardless of move count)

https://lichess.org/forum/lichess-feedback/sandbagging-warning-received raises an interesting point that a player with RD 50 who at a classical TC plays horribly and resigns in a lost position isn't doing b).  This patch doesn't attempt to change the "sandbag" warning (or reduce game completion rate for games drawn or lost in the opening), but simply renames outcome "Sandbag" to "Opening" and counts it against the player's game completion rate.