### PR TITLE
Apply 2D style to miniboard

### DIFF
--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -144,7 +144,7 @@ function uciToLastMove(lm?: string): Key[] | undefined {
 }
 
 function makeCg(preview: ChapterPreview): VNode {
-  return h('div.mini-board.cg-wrap', {
+  return h('div.mini-board.cg-wrap.is2d', {
     hook: {
       insert(vnode) {
         const cg = Chessground(vnode.elm as HTMLElement, {


### PR DESCRIPTION
3D miniboard piece offset looks wrong, for example https://lichess.org/broadcast/2019-fide-world-cup-round-2-tiebreaks-game-1/rJsuL3We
![image](https://user-images.githubusercontent.com/1834123/64919734-074a5180-d774-11e9-816e-63bf4c59b6ba.png)
