### PR TITLE
Update ModPreset to add stalling warning

### DIFF
--- a/modules/message/src/main/ModPreset.scala
+++ b/modules/message/src/main/ModPreset.scala
@@ -78,6 +78,13 @@ Account marked for computer assistance
 
 Our cheating detection algorithms have marked your account for using computer assistance. If you want to contest the mark, please send an email to Lichess Contact contact@lichess.org. If you are a titled player, we will need a proof of your identity. It can be a picture of a document, like an ID card or a driving license.
 
+""", /* ---------------------------------------------------------------*/ """
+
+Warning: leaving games / stalling on time
+
+In your game history, you have several games where you have left the game or just let the time run out instead of playing or resigning.
+This can be very annoying for your opponents. If this behavior continues to happen, we may be forced to terminate your account.
+
 """) flatMap toPreset
 
   private def toPreset(txt: String) =


### PR DESCRIPTION
By popular moderator demand. Purpose: for manual warnings when the counter was already under -10 before automatic warnings were added, and for variant players where the counter is disabled.