### PR TITLE
Reduce Glicko.Result precision to 7 significant digits

### DIFF
--- a/modules/rating/src/main/Glicko.scala
+++ b/modules/rating/src/main/Glicko.scala
@@ -98,12 +98,12 @@ case object Glicko {
     )
   }
 
-  sealed abstract class Result(val v: Double) {
+  sealed abstract class Result(val v: Float) {
     def negate: Result
   }
   object Result {
     case object Win extends Result(1) { def negate = Loss }
     case object Loss extends Result(0) { def negate = Win }
-    case object Draw extends Result(0.5) { def negate = Draw }
+    case object Draw extends Result(0.5f) { def negate = Draw }
   }
 }


### PR DESCRIPTION
Since a game has only 3 possible results (win, loss, draw), perhaps 15 significant digits are unnecessary.