### PR TITLE
Do not word-break view count

### DIFF
--- a/ui/site/css/forum/_table.scss
+++ b/ui/site/css/forum/_table.scss
@@ -4,9 +4,6 @@
     padding-top: 1.5rem;
     padding-bottom: 1.5rem;
   }
-  &.topics td {
-    @extend %break-word;
-  }
 
   td.right, & th.right {
     display: none;


### PR DESCRIPTION
If the browser zoom is over 100% (or using userstyles which affect font width), a 5-digit view count wraps the 5th digit to a successive line.

Looking at the commit history, I don't see why this `word-break` is useful.  I wonder if in some browser long subjects failed to word wrap?