### PR TITLE
remove cpl cap in insights (fixes #5617)

### DIFF
--- a/modules/insight/src/main/PovToEntry.scala
+++ b/modules/insight/src/main/PovToEntry.scala
@@ -109,7 +109,7 @@ object PovToEntry {
           role = role,
           eval = prevInfo.flatMap(_.cp).map(_.ceiled.centipawns),
           mate = prevInfo.flatMap(_.mate).map(_.moves),
-          cpl = cpDiffs lift i map (_ min 1000),
+          cpl = cpDiffs lift i,
           material = board.materialImbalance * from.pov.color.fold(1, -1),
           opportunism = opportunism,
           luck = luck


### PR DESCRIPTION
There's already a cap because evaluations are clamped between -10 and +10. Clamping at 1000 makes ACPL in insights inconsistent with ACPL reported elsewhere on the site (#5617).

Not pushing directly, in case there was a deeper reason for https://github.com/ornicar/lila/commit/67fb0820e65542921c5661fbb3abd44295833cb4 (`insights: cap eval diff to 10 (so going from +10 to -5 is still 10)`).