### PR TITLE
Exclude inactive players from variant leaderboards

### DIFF
--- a/modules/rating/src/main/Glicko.scala
+++ b/modules/rating/src/main/Glicko.scala
@@ -20,7 +20,10 @@ case class Glicko(
   def intervalMax = (rating + deviation * 2).toInt
   def interval = intervalMin -> intervalMax
 
-  def rankable = deviation <= Glicko.rankableDeviation
+  def rankable(variant: chess.variant.Variant) = deviation <= (variant match {
+    case chess.variant.Standard => Glicko.standardRankableDeviation
+    case _ => Glicko.variantRankableDeviation
+  })
   def provisional = deviation >= Glicko.provisionalDeviation
   def established = !provisional
   def establishedIntRating = established option intRating
@@ -61,7 +64,8 @@ case object Glicko {
   val defaultIntRating = default.rating.toInt
 
   val minDeviation = 50
-  val rankableDeviation = 80
+  val variantRankableDeviation = 60
+  val standardRankableDeviation = 80
   val provisionalDeviation = 110
   val maxDeviation = 350
 

--- a/modules/rating/src/main/Perf.scala
+++ b/modules/rating/src/main/Perf.scala
@@ -65,7 +65,7 @@ case class Perf(
   def isEmpty = nb == 0
   def nonEmpty = !isEmpty
 
-  def rankable = glicko.rankable
+  def rankable(variant: chess.variant.Variant) = glicko.rankable(variant)
   def provisional = glicko.provisional
   def established = glicko.established
 }

--- a/modules/user/src/main/RankingApi.scala
+++ b/modules/user/src/main/RankingApi.scala
@@ -30,7 +30,7 @@ final class RankingApi(
       "perf" -> perfType.id,
       "rating" -> perf.intRating,
       "prog" -> perf.progress,
-      "stable" -> perf.rankable,
+      "stable" -> perf.rankable(PerfType variantOf perfType),
       "expiresAt" -> DateTime.now.plusDays(7)
     ),
       upsert = true).void


### PR DESCRIPTION
Variant players in the feedback forum are getting unruly again... and while in my opinion having rating leaderboards is strange, also strange is featuring players who infrequently play (RD > 60 except for Rapid/Classical; perhaps also RD thresholds for Bullet and Blitz should be reduced?):
https://lichess.org/forum/lichess-feedback/unfair-behavior