### PR TITLE
perf.progress over 12 games

### DIFF
--- a/modules/rating/src/main/Perf.scala
+++ b/modules/rating/src/main/Perf.scala
@@ -90,8 +90,8 @@ case object Perf {
       val p = Perf(
         glicko = r.getO[Glicko]("gl") | Glicko.default,
         nb = r intD "nb",
-        latest = r dateO "la",
-        recent = r intsD "re"
+        recent = r intsD "re",
+        latest = r dateO "la"
       )
       p.copy(glicko = p.glicko.copy(deviation = Glicko.liveDeviation(p, false)))
     }

--- a/modules/rating/src/main/Perf.scala
+++ b/modules/rating/src/main/Perf.scala
@@ -53,7 +53,7 @@ case class Perf(
 
   private def updateRecentWith(glicko: Glicko) =
     if (nb < 10) recent
-    else (glicko.intRating :: recent) take Perf.recentMaxSize
+    else (glicko.intRating :: recent) take (Perf.recentMaxSize + 1)
 
   def toRating = new Rating(
     math.max(Glicko.minRating, glicko.rating),


### PR DESCRIPTION
perf.progress currently takes 12 games, and subtracts the rating at the 12th game from the rating at the 1st game to get the "progress over 12 games". However, this actually means that currently the progress is only over 11 games. This PR fixes this and makes it so the progress is over 12 games. `recentMaxSize` is still set to 12 in Perf.scala so the variable is still literally making sense.

Fixes #5815 