### PR TITLE
Rename Active players to Games played

### DIFF
--- a/app/views/user/list.scala
+++ b/app/views/user/list.scala
@@ -102,7 +102,7 @@ object list {
       ol(users map { u =>
         li(
           lightUserLink(u.user),
-          span(title := trans.gamesPlayed.txt())(s"#${u.count.localize}")
+          span(title := trans.gamesPlayed.txt())(s"${u.count.localize}")
         )
       })
     )

--- a/translation/dest/site/en-US.xml
+++ b/translation/dest/site/en-US.xml
@@ -457,7 +457,7 @@ computer analysis, game chat and shareable URL.</string>
   <string name="previouslyOnLichessTV">Previously on Lichess TV</string>
   <string name="onlinePlayers">Online players</string>
   <string name="activeToday">Active today</string>
-  <string name="activePlayers">Active players</string>
+  <string name="activePlayers">Games played</string>
   <string name="bewareTheGameIsRatedButHasNoClock">Beware, the game is rated but has no clock!</string>
   <string name="training">Puzzles</string>
   <string name="yourPuzzleRatingX">Your puzzle rating: %s</string>


### PR DESCRIPTION
- Removed the # before the number of games played in the "Active players" list on https://lichess.org/player

- Renamed "Active players" to "Games played" to accurately represent what the leaderboard is showing. It isn't showing how active the players are, it's showing how many games they've played. Only changed for English.