### PR TITLE
Fix minor typo

### DIFF
--- a/app/views/account/close.scala
+++ b/app/views/account/close.scala
@@ -19,7 +19,7 @@ object close {
         postForm(cls := "form3", action := routes.Account.closeConfirm)(
           div(cls := "form-group")(trans.closeAccountExplanation()),
           div(cls := "form-group")(
-            "You will not be allowed to open a new account with the same name, even if the case if different."
+            "You will not be allowed to open a new account with the same name, even if the case is different."
           ),
           form3.passwordModified(form("passwd"), trans.password())(autocomplete := "off"),
           form3.actions(


### PR DESCRIPTION
I don't think that part is localized (yet?).

Seems to match the typo here:

![image](https://user-images.githubusercontent.com/14911070/71611431-a2154300-2b4d-11ea-9ada-b0fb688c40f9.png)
