### PR TITLE
generalize to list of socket domains

### DIFF
--- a/app/views/base/layout.scala
+++ b/app/views/base/layout.scala
@@ -124,13 +124,13 @@ object layout {
   private val spaceRegex              = """\s{2,}+""".r
   private def spaceless(html: String) = raw(spaceRegex.replaceAllIn(html.replace("\\n", ""), ""))
 
-  private val dataVapid        = attr("data-vapid")
-  private val dataUser         = attr("data-user")
-  private val dataSoundSet     = attr("data-sound-set")
-  private val dataSocketDomain = attr("data-socket-domain")
-  private val dataPreload      = attr("data-preload")
-  private val dataNonce        = attr("data-nonce")
-  private val dataAnnounce     = attr("data-announce")
+  private val dataVapid         = attr("data-vapid")
+  private val dataUser          = attr("data-user")
+  private val dataSoundSet      = attr("data-sound-set")
+  private val dataSocketDomains = attr("data-socket-domains")
+  private val dataPreload       = attr("data-preload")
+  private val dataNonce         = attr("data-nonce")
+  private val dataAnnounce      = attr("data-announce")
 
   def apply(
       title: String,
@@ -204,7 +204,7 @@ object layout {
         dataVapid := vapidPublicKey,
         dataUser := ctx.userId,
         dataSoundSet := ctx.currentSoundSet.toString,
-        dataSocketDomain := socketDomain,
+        dataSocketDomains := socketDomains.mkString(","),
         dataAssetUrl := assetBaseUrl,
         dataAssetVersion := assetVersion.value,
         dataNonce := ctx.nonce.ifTrue(sameAssetDomain).map(_.value),

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -4,7 +4,7 @@ mongodb {
 }
 net {
   domain = "localhost:9663"
-  socket.domain = "localhost:9664"
+  socket.domains = [ "localhost:9664" ]
   asset.domain = ${net.domain}
   protocol = "http://"
   base_url = ${net.protocol}${net.domain}

--- a/modules/common/src/main/config.scala
+++ b/modules/common/src/main/config.scala
@@ -35,7 +35,7 @@ object config {
       protocol: String,
       @ConfigName("base_url") baseUrl: BaseUrl,
       @ConfigName("asset.domain") assetDomain: AssetDomain,
-      @ConfigName("socket.domain") socketDomain: String,
+      @ConfigName("socket.domains") socketDomains: List[String],
       crawlable: Boolean,
       @ConfigName("ratelimit") rateLimit: Boolean,
       email: EmailAddress,

--- a/ui/site/src/socket.js
+++ b/ui/site/src/socket.js
@@ -233,9 +233,7 @@ lichess.StrongSocket = function(url, version, settings) {
     }
   };
 
-  const baseUrls = (
-    d => [d].concat((d.includes('lichess.org') ? [5, 6, 7, 8, 9] : []).map(port => d + ':' + (9020 + port)))
-  )(document.body.getAttribute('data-socket-domain'));
+  const baseUrls = document.body.getAttribute('data-socket-domains').split(',');
 
   const baseUrl = function() {
     let url = storage.get();


### PR DESCRIPTION
In order to use new failovers (https://github.com/lichess-org/sysadmin#websocket-failovers).

* [x] Added DNS records
* [x] Added failovers to syrup
* [x] Added IPv6 addresses to syrup
* [x] Expanded nginx config and certificates
* [ ] Reload nginx on syrup
* [ ] Prepared lila-ws (https://github.com/ornicar/lila-ws/pull/20)
* [ ] Deployed lila-ws, configured with `csrf.origins = [ "socket.lichess.org", "socket1.lichess.org", "socket2.lichess.org", "socket3.lichess.org", "socket4.lichess.org", "socket5.lichess.org" ]`
* [ ] :warning: Configuration change in production
  ```diff
  - socket.domain = "socket.lichess.org"
  + socket.domains = [ "socket.lichess.org", "socket1.lichess.org", "socket2.lichess.org", "socket3.lichess.org", "socket4.lichess.org", "socket5.lichess.org" ]
  ```

---

* [ ] Remove NAT on syrup
* [ ] Expand local port range on syrup (absolute maximum is `1024 65535`)