### PR TITLE
Generate leaderboard deviation answer

### DIFF
--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -290,7 +290,7 @@ object faq {
           ol(
             li("have played at least 30 rated games in a given rating,"),
             li("have played a rated game within the last week for this rating,"),
-            li("have a rating deviation lower than 80,"),
+            li("have a rating deviation lower than " + lila.rating.Glicko.standardRankableDeviation + ","),
             li("be in the top 10 in this rating.")
           ),
           p(


### PR DESCRIPTION
This change keeps the FAQ in sync with constant **Glicko.rankableDeviation**.