### PR TITLE
Remove finished tournaments from the duelstore explicitly

### DIFF
--- a/modules/tournament/src/main/Duel.scala
+++ b/modules/tournament/src/main/Duel.scala
@@ -67,4 +67,6 @@ final private class DuelStore {
       if (tb.size <= 1) byTourId.remove(tourId)
       else byTourId.put(tourId, tb.filter(_.gameId != game.id))
     }
+  
+  def remove(tour: Tournament): Unit = byTourId.remove(tour.id)
 }

--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -204,6 +204,7 @@ final class TournamentApi(
             callbacks.indexLeaderboard(tour).logFailure(logger, _ => s"${tour.id} indexLeaderboard")
             callbacks.clearWinnersCache(tour)
             callbacks.clearTrophyCache(tour)
+            duelStore.remove(tour)
           }
       }
     }


### PR DESCRIPTION
When the tournament ends with ongoing games they are never cleared from the DuelStore, effectively createing a memory leak: TournamentApi.finishGame does not select finished tournaments, and thus never calls duelStore.remove for those games.