### PR TITLE
translate /inbox UI, closes #5986

### DIFF
--- a/app/views/msg.scala
+++ b/app/views/msg.scala
@@ -37,6 +37,7 @@ object msg {
     trans.unblock,
     trans.blocked,
     trans.delete,
-    trans.reportXToModerators
+    trans.reportXToModerators,
+    trans.searchOrStartNewDiscussion
   )
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -786,6 +786,7 @@ val `availableInNbLanguages` = new Translated("availableInNbLanguages", Site)
 val `nbSecondsToPlayTheFirstMove` = new Translated("nbSecondsToPlayTheFirstMove", Site)
 val `nbSeconds` = new Translated("nbSeconds", Site)
 val `andSaveNbPremoveLines` = new Translated("andSaveNbPremoveLines", Site)
+val `searchOrStartNewDiscussion` = new Translated("searchOrStartNewDiscussion", Site)
 
 object arena {
 val `isItRated` = new Translated("isItRated", Arena)

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -893,4 +893,5 @@ computer analysis, game chat and shareable URL.</string>
   <string name="agreementNice">I agree that I will always be respectful to other players.</string>
   <string name="agreementAccount">I agree that I will not create multiple accounts.</string>
   <string name="agreementPolicy">I agree that I will follow all Lichess policies.</string>
+  <string name="searchOrStartNewDiscussion">Search or start new discussion</string>
 </resources>

--- a/ui/msg/src/view/search.ts
+++ b/ui/msg/src/view/search.ts
@@ -11,7 +11,7 @@ export function renderInput(ctrl: MsgCtrl): VNode {
     ctrl.data.me.kid ? null : h('input', {
       attrs: {
         value: '',
-        placeholder: 'Search or start new discussion'
+        placeholder: ctrl.trans.noarg('searchOrStartNewDiscussion')
       },
       hook: {
         insert(vnode) {


### PR DESCRIPTION
Works in dev. I believe this is the only untranslated text in `/inbox`