### PR TITLE
Whitelist yahoo.ca, for #5989

### DIFF
--- a/modules/security/src/main/DisposableEmailDomain.scala
+++ b/modules/security/src/main/DisposableEmailDomain.scala
@@ -103,6 +103,8 @@ private object DisposableEmailDomain {
     "cox.net",
     "earthlink.net",
     "juno.com",
+    /* Canadian ISP domains */
+    "yahoo.ca",
     /* British ISP domains */
     "btinternet.com",
     "virginmedia.com",


### PR DESCRIPTION
Seems a legit domain per a [Yahoo help article](https://safety.yahoo.com/CA/SafetyGuides/Mail/index.htm): `Yahoo email address: Your Yahoo email address is your Yahoo ID followed by "@yahoo.ca."`

It could resolve the linked issue.