### PR TITLE
Normalize ProtonMail addresses

### DIFF
--- a/modules/common/src/main/model.scala
+++ b/modules/common/src/main/model.scala
@@ -45,7 +45,8 @@ case class EmailAddress(value: String) extends AnyVal with StringValue {
   def normalize = NormalizedEmailAddress {
     val lower = value.toLowerCase
     lower.split('@') match {
-      case Array(name, domain) if domain == "gmail.com" || domain == "googlemail.com" => {
+      case Array(name, domain)
+          if domain == "gmail.com" || domain == "googlemail.com" || domain == "protonmail.com" || domain == "pm.me" => {
         val normalizedName = name
           .replace(".", "")  // remove all dots
           .takeWhile('+' !=) // skip everything after the first '+'


### PR DESCRIPTION
ProtonMail addresses are handled exactly like Gmail's (dots don't
matter, has support for the `+something`) so they can be
normalized in the same way.