### PR TITLE
Remove Berserk Rate percentage from tournaments that do not allow berserk

### DIFF
--- a/ui/tournament/src/view/finished.ts
+++ b/ui/tournament/src/view/finished.ts
@@ -19,18 +19,24 @@ function confetti(data: TournamentData): VNode | undefined {
     });
 }
 
-function stats(st, noarg): VNode {
+function stats(data: TournamentData, noarg: any): VNode {
+  const tableData = [
+    numberRow(noarg('averageElo'), data.stats.averageRating, 'raw'),
+    numberRow(noarg('gamesPlayed'), data.stats.games),
+    numberRow(noarg('movesPlayed'), data.stats.moves),
+    numberRow(noarg('whiteWins'), [data.stats.whiteWins, data.stats.games], 'percent'),
+    numberRow(noarg('blackWins'), [data.stats.blackWins, data.stats.games], 'percent'),
+    numberRow(noarg('draws'), [data.stats.draws, data.stats.games], 'percent'),
+  ];
+
+  if (data.berserkable) {
+    const berserkRate = [data.stats.berserks / 2, data.stats.games];
+    tableData.push(numberRow(noarg('berserkRate'), berserkRate, 'percent'))
+  }
+
   return h('div.tour__stats', [
     h('h2', noarg('tournamentComplete')),
-    h('table', [
-      numberRow(noarg('averageElo'), st.averageRating, 'raw'),
-      numberRow(noarg('gamesPlayed'), st.games),
-      numberRow(noarg('movesPlayed'), st.moves),
-      numberRow(noarg('whiteWins'), [st.whiteWins, st.games], 'percent'),
-      numberRow(noarg('blackWins'), [st.blackWins, st.games], 'percent'),
-      numberRow(noarg('draws'), [st.draws, st.games], 'percent'),
-      numberRow(noarg('berserkRate'), [st.berserks / 2, st.games], 'percent')
-    ])
+    h('table', tableData)
   ]);
 }
 
@@ -55,7 +61,7 @@ export function main(ctrl: TournamentController): MaybeVNodes {
 export function table(ctrl: TournamentController): VNode | undefined {
   return ctrl.playerInfo.id ? playerInfo(ctrl) : (
     ctrl.teamInfo.requested ? teamInfo(ctrl) : (
-      stats ? stats(ctrl.data.stats, ctrl.trans.noarg) : undefined
+      stats ? stats(ctrl.data, ctrl.trans.noarg) : undefined
     )
   );
 }


### PR DESCRIPTION
This fixes #5866.

![image](https://user-images.githubusercontent.com/12041666/74580206-71f3f900-4f6f-11ea-8323-73f10813d3f8.png)

This is my first PR for Lichess! :tada: Let me know if I need to sign a CLA or something.

I was surprised that no tests for the UI are present. Maybe I just couldn't find them? Are they in a different repo? If not, I will consider making another PR to set up test infrastructure for the UI. I tested this manually, which was very tedious.
