### PR TITLE
Show +0 rating change in puzzles

### DIFF
--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -53,7 +53,7 @@ export function userBox(ctrl: Controller): MaybeVNode {
   return h('div.puzzle__side__user', [
     h('h2', ctrl.trans.vdom('yourPuzzleRatingX', h('strong', [
       data.user.rating,
-      ...(diff > 0 ? [' ', h('good.rp', '+' + diff)] : []),
+      ...(diff >= 0 ? [' ', h('good.rp', '+' + diff)] : []),
       ...(diff < 0 ? [' ', h('bad.rp', '−' + (-diff))] : [])
     ]))),
     h('div', thunk('div.rating_chart.' + hash, ratingChart, [ctrl, hash]))


### PR DESCRIPTION
Probably a rare case, but with puzzle rating >2700 it starts being not unusual to solve a puzzle and gain 0 rating points. When that happens, there's no user feedback about the fact that the server updated your rating, unlike the normal case where you see the +5 or -25 show up next to your puzzle rating.

First contribution and I didn't see contribution guidelines on the README or the Wiki, so please let me know if there is anything I should do for testing etc. Thanks maintainers for the great project.

Edit: Ok found the contribution guidelines but I still didn't see much with regards to PRs haha