### PR TITLE
Added percentage sign for players percentile [Issue #6072]

### DIFF
--- a/app/views/stat/ratingDistribution.scala
+++ b/app/views/stat/ratingDistribution.scala
@@ -58,7 +58,7 @@ object ratingDistribution {
                     trans.yourPerfTypeRatingIsRating(perfType.trans, strong(rating)),
                     br,
                     trans.youAreBetterThanPercentOfPerfTypePlayers(
-                      strong((under * 100.0 / sum).round),
+                      strong((under * 100.0 / sum).round, "%"),
                       perfType.trans
                     )
                   )


### PR DESCRIPTION
This change adds the percentage sign in the rating distribution view, as mentioned in Issue #6072.
This way it matches the way the users percentile is shown in the users /perf/blitz view.