### PR TITLE
adds !important to highlight a premoved square on low contrast boards

### DIFF
--- a/ui/common/css/vendor/chessground/_chessground.scss
+++ b/ui/common/css/vendor/chessground/_chessground.scss
@@ -40,8 +40,9 @@ square {
   &.selected {
     background-color: rgba(20, 85, 30, 0.5);
   }
-  &.current-premove {
-    background-color: rgba(20, 30, 85, 0.5);
+  &.current-premove
+  &.current-premove.last-move {
+    background-color: rgba(20, 30, 85, 0.5) !important;
   }
   &.move-dest:hover {
     background: rgba(20, 85, 30, 0.3);


### PR DESCRIPTION
fixes an issue with pr #6085 for issue #5776 