### PR TITLE
Use Pov in GIF export, for #6102

### DIFF
--- a/app/controllers/Export.scala
+++ b/app/controllers/Export.scala
@@ -33,14 +33,14 @@ final class Export(env: Env) extends LilaController(env) {
     }
   }
 
-  def gif(id: String) = Open { implicit ctx =>
+  def gif(id: String, color: String) = Open { implicit ctx =>
     OnlyHumansAndFacebookOrTwitter {
       ExportRateLimitGlobal("-", msg = HTTPRequest.lastRemoteAddress(ctx.req).value) {
-        OptionFuResult(env.game.gameRepo gameWithInitialFen id) {
-          case (game, initialFen) =>
-            env.game.gifExport.fromGame(game, initialFen) map
+        OptionFuResult(env.game.gameRepo povWithInitialFen(id, color)) {
+          case (pov, initialFen) =>
+            env.game.gifExport.fromPov(pov, initialFen) map
               stream("image/gif") map
-              gameImageCacheSeconds(game)
+              gameImageCacheSeconds(pov.game)
         }
       }
     }

--- a/app/views/analyse/replay.scala
+++ b/app/views/analyse/replay.scala
@@ -66,7 +66,7 @@ object replay {
           dataIcon := "$",
           cls := "text",
           target := "_blank",
-          href := cdnUrl(routes.Export.gif(pov.gameId).url)
+          href := cdnUrl(routes.Export.gif(pov.gameId, pov.color.name).url)
         )(
           "Share as a GIF"
         )

--- a/conf/routes
+++ b/conf/routes
@@ -284,10 +284,10 @@ GET   /team/:id/users                         controllers.Team.users(id: String)
 # Analyse
 POST  /$gameId<\w{8}>/request-analysis        controllers.Analyse.requestAnalysis(gameId: String)
 
-GET   /game/export/$gameId<\w{8}>             controllers.Game.exportOne(gameId: String)
-GET   /game/export/$gameId<\w{8}>.pgn         controllers.Game.exportOne(gameId: String)
-GET   /game/export/png/$gameId<\w{8}>.png     controllers.Export.png(gameId: String)
-GET   /game/export/gif/$gameId<\w{8}>.gif     controllers.Export.gif(gameId: String)
+GET   /game/export/$gameId<\w{8}>                   controllers.Game.exportOne(gameId: String)
+GET   /game/export/$gameId<\w{8}>.pgn               controllers.Game.exportOne(gameId: String)
+GET   /game/export/png/$gameId<\w{8}>.png           controllers.Export.png(gameId: String)
+GET   /game/export/gif/$gameId<\w{8}>/:color.gif    controllers.Export.gif(gameId: String, color: String)
 
 # Fishnet
 POST  /fishnet/acquire                        controllers.Fishnet.acquire

--- a/modules/game/src/main/GameRepo.scala
+++ b/modules/game/src/main/GameRepo.scala
@@ -3,6 +3,7 @@ package lila.game
 import scala.util.Random
 
 import chess.format.{ FEN, Forsyth }
+import chess.Color.White
 import chess.{ Color, Status }
 import org.joda.time.DateTime
 import reactivemongo.akkastream.{ cursorProducer, AkkaStreamCursor }
@@ -394,6 +395,14 @@ final class GameRepo(val coll: Coll)(implicit ec: scala.concurrent.ExecutionCont
     _ ?? { game =>
       initialFen(game) dmap { fen =>
         Option(game -> fen)
+      }
+    }
+  }
+
+  def povWithInitialFen(gameId: ID, color: String): Fu[Option[(Pov, Option[FEN])]] = game(gameId) flatMap {
+    _ ?? { game =>
+      initialFen(game) dmap { fen =>
+        Option(Pov(game, Color(color).getOrElse(White)) -> fen)
       }
     }
   }

--- a/modules/game/src/main/Pov.scala
+++ b/modules/game/src/main/Pov.scala
@@ -56,6 +56,8 @@ object Pov {
 
   def apply(game: Game, player: Player) = new Pov(game, player.color)
 
+  def apply(game: Game, color: Color) = new Pov(game, color)
+
   def apply(game: Game, playerId: Player.ID): Option[Pov] =
     game player playerId map { apply(game, _) }
 

--- a/modules/game/src/main/Pov.scala
+++ b/modules/game/src/main/Pov.scala
@@ -56,8 +56,6 @@ object Pov {
 
   def apply(game: Game, player: Player) = new Pov(game, player.color)
 
-  def apply(game: Game, color: Color) = new Pov(game, color)
-
   def apply(game: Game, playerId: Player.ID): Option[Pov] =
     game player playerId map { apply(game, _) }
 


### PR DESCRIPTION
I thought this was close, but hitting this:

![image](https://user-images.githubusercontent.com/28961086/75597116-69f48880-5a48-11ea-8e88-95de8794d584.png)

Basically we'd substitute `Pov` instead of `Game`. For simplicity we could always pass the color in the URL even if white (i.e. `http://localhost:9663/game/export/gif/7drGFmRk/white.gif`).

Feel free to push more commits if you'd like, or I can address feedback.