### PR TITLE
Make default ratings for managed accounts as part of User, for #6100

### DIFF
--- a/modules/rating/src/main/Glicko.scala
+++ b/modules/rating/src/main/Glicko.scala
@@ -61,6 +61,10 @@ case object Glicko {
 
   val default = Glicko(1500d, 350d, 0.06d)
 
+  val defaultManaged = Glicko(1000d, 350d, 0.06d)
+
+  val defaultManagedPuzzle = Glicko(800d, 350d, 0.06d)
+
   val defaultIntRating = default.rating.toInt
 
   val minDeviation              = 45

--- a/modules/rating/src/main/Perf.scala
+++ b/modules/rating/src/main/Perf.scala
@@ -82,6 +82,10 @@ case object Perf {
 
   val default = Perf(Glicko.default, 0, Nil, None)
 
+  val defaultManaged = Perf(Glicko.defaultManaged, 0, Nil, None)
+
+  val defaultManagedPuzzle = Perf(Glicko.defaultManagedPuzzle, 0, Nil, None)
+
   val recentMaxSize = 12
 
   implicit val perfBSONHandler = new BSON[Perf] {

--- a/modules/user/src/main/Perfs.scala
+++ b/modules/user/src/main/Perfs.scala
@@ -185,6 +185,12 @@ case object Perfs {
     Perfs(p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p)
   }
 
+  val defaultManaged = {
+    val p = Perf.defaultManaged
+    val puzzle = Perf.defaultManagedPuzzle
+    Perfs(p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, puzzle)
+  }
+
   def variantLens(variant: chess.variant.Variant): Option[Perfs => Perf] = variant match {
     case chess.variant.Standard      => Some(_.standard)
     case chess.variant.Chess960      => Some(_.chess960)

--- a/modules/user/src/main/User.scala
+++ b/modules/user/src/main/User.scala
@@ -253,7 +253,7 @@ object User {
     def reads(r: BSON.Reader): User = User(
       id = r str id,
       username = r str username,
-      perfs = r.getO[Perfs](perfs) | Perfs.default,
+      perfs = r.getO[Perfs](perfs) | perfsFromEmail(r.str(email)),
       count = r.get[Count](count),
       enabled = r bool enabled,
       roles = ~r.getO[List[String]](roles),
@@ -307,4 +307,8 @@ object User {
     PerfType.Horde,
     PerfType.RacingKings
   )
+
+  private def perfsFromEmail(str: String): Perfs = {
+    EmailAddress.from(str).fold(Perfs.default)(email => if (email.isNoReply) Perfs.defaultManaged else Perfs.default)
+  }
 }


### PR DESCRIPTION
So far I have the new defaults and I have `User.perfs` do the right thing now based off whether the email address is managed or not.

However, some more surgery remains. Default ratings is now a `User` thing and can no longer live in vacuum. I'm thinking move all the defaults from `Glicko`, `Perfs`, and `Perf` to `User` as private `vals` and refactor the things calling them to call into `User.perfs` instead.

@ornicar wanted to check in that this plan makes sense? If so, I can address in the next few days.