### PR TITLE
Force write class student initial ratings to db, closes #6100

### DIFF
--- a/modules/clas/src/main/ClasApi.scala
+++ b/modules/clas/src/main/ClasApi.scala
@@ -185,6 +185,7 @@ final class ClasApi(
         .orFail(s"No user could be created for ${data.username}")
         .flatMap { user =>
           userRepo.setKid(user, true) >>
+          userRepo.setManagedUserInitialPerfs(user.id) >>
             coll.insert.one(Student.make(user, clas, teacher.teacher.id, data.realName, managed = true)) >>
             sendWelcomeMessage(teacher, user, clas) inject
             (user -> password)

--- a/modules/rating/src/main/Glicko.scala
+++ b/modules/rating/src/main/Glicko.scala
@@ -61,6 +61,10 @@ case object Glicko {
 
   val default = Glicko(1500d, 350d, 0.06d)
 
+  val defaultManaged = Glicko(1000d, 350d, 0.06d)
+
+  val defaultManagedPuzzle = Glicko(800d, 350d, 0.06d)
+
   val defaultIntRating = default.rating.toInt
 
   val minDeviation              = 45

--- a/modules/rating/src/main/Perf.scala
+++ b/modules/rating/src/main/Perf.scala
@@ -63,7 +63,7 @@ case class Perf(
     latest.orNull
   )
 
-  def isEmpty  = nb == 0
+  def isEmpty  = latest.isEmpty
   def nonEmpty = !isEmpty
 
   def rankable(variant: chess.variant.Variant) = glicko.rankable(variant)
@@ -81,6 +81,10 @@ case object Perf {
   case class Typed(perf: Perf, perfType: PerfType)
 
   val default = Perf(Glicko.default, 0, Nil, None)
+
+  /* Set a latest date as a hack so that these are written to the db even though there are no games */
+  val defaultManaged = Perf(Glicko.defaultManaged, 0, Nil, DateTime.now.some)
+  val defaultManagedPuzzle = Perf(Glicko.defaultManagedPuzzle, 0, Nil, DateTime.now.some)
 
   val recentMaxSize = 12
 

--- a/modules/user/src/main/Perfs.scala
+++ b/modules/user/src/main/Perfs.scala
@@ -186,19 +186,9 @@ case object Perfs {
   }
 
   val defaultManaged = {
-    val p = Perf.default
     val managed = Perf.defaultManaged
     val managedPuzzle = Perf.defaultManagedPuzzle
-    Perfs(standard = managed,
-      chess960 = p,
-      kingOfTheHill = p,
-      threeCheck = p,
-      antichess = p,
-      atomic = p,
-      horde = p,
-      racingKings = p,
-      crazyhouse = p,
-      ultraBullet = p,
+    default.copy(standard = managed,
       bullet = managed,
       blitz = managed,
       rapid = managed,

--- a/modules/user/src/main/Perfs.scala
+++ b/modules/user/src/main/Perfs.scala
@@ -255,7 +255,7 @@ case object Perfs {
       )
     }
 
-    private def notNew(p: Perf): Option[Perf] = p.latest.isDefined option p
+    private def notNew(p: Perf): Option[Perf] = p.nonEmpty option p
 
     def writes(w: BSON.Writer, o: Perfs) = reactivemongo.api.bson.BSONDocument(
       "standard"       -> notNew(o.standard),

--- a/modules/user/src/main/Perfs.scala
+++ b/modules/user/src/main/Perfs.scala
@@ -185,6 +185,28 @@ case object Perfs {
     Perfs(p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p)
   }
 
+  val defaultManaged = {
+    val p = Perf.default
+    val managed = Perf.defaultManaged
+    val managedPuzzle = Perf.defaultManagedPuzzle
+    Perfs(standard = managed,
+      chess960 = p,
+      kingOfTheHill = p,
+      threeCheck = p,
+      antichess = p,
+      atomic = p,
+      horde = p,
+      racingKings = p,
+      crazyhouse = p,
+      ultraBullet = p,
+      bullet = managed,
+      blitz = managed,
+      rapid = managed,
+      classical = managed,
+      correspondence = managed,
+      puzzle = managedPuzzle)
+  }
+
   def variantLens(variant: chess.variant.Variant): Option[Perfs => Perf] = variant match {
     case chess.variant.Standard      => Some(_.standard)
     case chess.variant.Chess960      => Some(_.chess960)
@@ -233,7 +255,7 @@ case object Perfs {
       )
     }
 
-    private def notNew(p: Perf): Option[Perf] = p.nb > 0 option p
+    private def notNew(p: Perf): Option[Perf] = p.latest.isDefined option p
 
     def writes(w: BSON.Writer, o: Perfs) = reactivemongo.api.bson.BSONDocument(
       "standard"       -> notNew(o.standard),

--- a/modules/user/src/main/UserRepo.scala
+++ b/modules/user/src/main/UserRepo.scala
@@ -182,12 +182,7 @@ final class UserRepo(val coll: Coll)(implicit ec: scala.concurrent.ExecutionCont
   }
 
   def setManagedUserInitialPerfs(id: User.ID) = {
-    coll.update
-      .one(
-        $id(id),
-        $set(s"${F.perfs}" -> Perfs.perfsBSONHandler.write(Perfs.defaultManaged))
-      )
-      .void
+    coll.updateField($id(id), F.perfs, Perfs.perfsBSONHandler.write(Perfs.defaultManaged)).void
   }
 
   def setPerf(userId: String, pt: PerfType, perf: Perf) =

--- a/modules/user/src/main/UserRepo.scala
+++ b/modules/user/src/main/UserRepo.scala
@@ -181,6 +181,15 @@ final class UserRepo(val coll: Coll)(implicit ec: scala.concurrent.ExecutionCont
       .void
   }
 
+  def setManagedUserInitialPerfs(id: User.ID) = {
+    coll.update
+      .one(
+        $id(id),
+        $set(s"${F.perfs}" -> Perfs.perfsBSONHandler.write(Perfs.defaultManaged))
+      )
+      .void
+  }
+
   def setPerf(userId: String, pt: PerfType, perf: Perf) =
     coll.update
       .one(


### PR DESCRIPTION
In many places in the existing code, there are ways to default the rating if it doesn't exist in the database. Many of them are inherently unaware of user attributes ([example](https://github.com/ornicar/lila/blob/master/modules/user/src/main/Perfs.scala#L215)) and thus we don't know whether to show standard defaults or student defaults. So I believe the best path forward is to write the default student ratings to the db when a student account is created.

I am only doing this for non-variants and for puzzle (the ratings that show up on the profile page).

Previously the code assumed rating was empty if `nb == 0` but I changed to `latest.isEmpty` and wrote a timestamp for the ratings I wanted to save to the db.

Things look ok in profile page, in game seeks, in a game, and rating update after a game is over.

![image](https://user-images.githubusercontent.com/28961086/75647679-9522d780-5c02-11ea-89b1-2ac6185f861c.png)
