### PR TITLE
do not skip signup form validation (fixes #6106)

### DIFF
--- a/public/javascripts/signup.js
+++ b/public/javascripts/signup.js
@@ -30,5 +30,6 @@ $(function() {
     });
 });
 window.signupSubmit = function(token) {
-  document.getElementById("signup_form").submit();
+  const form = document.getElementById('signup_form');
+  if (form.reportValidity()) form.submit();
 }


### PR DESCRIPTION
Calling `.submit()` directly skips validation (e.g. required fields).

PR, because I do not fully understand how reCAPTCHA works here.