### PR TITLE
absolute (instead of protocol relative) asset urls

### DIFF
--- a/app/templating/AssetHelper.scala
+++ b/app/templating/AssetHelper.scala
@@ -20,7 +20,7 @@ trait AssetHelper { self: I18nHelper with SecurityHelper =>
 
   lazy val sameAssetDomain = netDomain.value == assetDomain.value
 
-  lazy val assetBaseUrl = s"//$assetDomain"
+  lazy val assetBaseUrl = env.net.assetBaseUrl
 
   def assetVersion = AssetVersion.current
 

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -6,6 +6,7 @@ net {
   domain = "localhost:9663"
   socket.domains = [ "localhost:9664" ]
   asset.domain = ${net.domain}
+  asset.base_url = "http://"${net.asset.domain}
   base_url = "http://"${net.domain}
   ip = "127.0.0.1"
   email = ""

--- a/modules/common/src/main/config.scala
+++ b/modules/common/src/main/config.scala
@@ -35,6 +35,7 @@ object config {
       domain: NetDomain,
       @ConfigName("base_url") baseUrl: BaseUrl,
       @ConfigName("asset.domain") assetDomain: AssetDomain,
+      @ConfigName("asset.base_url") assetBaseUrl: String,
       @ConfigName("socket.domains") socketDomains: List[String],
       crawlable: Boolean,
       @ConfigName("ratelimit") rateLimit: RateLimit,


### PR DESCRIPTION
Mostly for `og:image` / `og:twitter`, because some clients (including Twitter itself) seem to have issues with protocol relative URLs.

:warning: New configuration variable `net.asset.base_url`, that needs to be set before deploy.