### PR TITLE
Tell an IP-banned user why they cannot login/signup

### DIFF
--- a/app/controllers/Auth.scala
+++ b/app/controllers/Auth.scala
@@ -140,7 +140,7 @@ final class Auth(
             }
         )
       },
-      redirectTo("/").fuccess
+      Unauthorized("Sorry, your IP has been used to violate the ToS, and is now blacklisted.").fuccess
     )
   }
 
@@ -177,7 +177,7 @@ final class Auth(
   def signupPost = OpenBody { implicit ctx =>
     implicit val req = ctx.body
     NoTor {
-      Firewall {
+      Firewall({
         forms.preloadEmailDns >> negotiate(
           html = env.security.signup
             .website(ctx.blind)
@@ -203,7 +203,8 @@ final class Auth(
                 case Signup.AllSet(user, email) => welcome(user, email) >> authenticateUser(user)
               }
         )
-      }
+      },
+      Unauthorized("Sorry, your IP has been used to violate the ToS, and is now blacklisted.").fuccess)
     }
   }
 


### PR DESCRIPTION
Resolves #5754.

The display of the error message isn't anything fancy (alert box for the
login page, redirect to a page of text for the signup page), but this is
the simplest way to do this (not having to deal with the Play forms) and
it should still suffice to get the message across.