### PR TITLE
Add study title

### DIFF
--- a/app/views/study/bits.scala
+++ b/app/views/study/bits.scala
@@ -48,7 +48,7 @@ object bits {
   }
 
   def widget(s: lila.study.Study.WithChaptersAndLiked, tag: Tag = h2)(implicit ctx: Context) = frag(
-    a(cls := "overlay", href := routes.Study.show(s.study.id.value)),
+    a(cls := "overlay", href := routes.Study.show(s.study.id.value), title := s.study.name.value),
     div(cls := "top", dataIcon := "4")(
       div(
         tag(cls := "study-name")(s.study.name.value),

--- a/ui/analyse/src/study/studyView.ts
+++ b/ui/analyse/src/study/studyView.ts
@@ -122,12 +122,12 @@ function buttons(root: AnalyseCtrl): VNode {
 
 function metadata(ctrl: StudyCtrl): VNode {
   const d = ctrl.data,
-    credit = ctrl.relay && ctrl.relay.data.credit;
+    credit = ctrl.relay && ctrl.relay.data.credit,
+    title = `${d.name}: ${ctrl.currentChapter().name}`;
   return h('div.study__metadata', [
     h('h2', [
-      h('span.name', [
-        d.name,
-        ': ' + ctrl.currentChapter().name,
+      h('span.name', {attrs: {title: title}},[
+        title,
         credit ?  h('span.credit', { hook: richHTML(credit, false) }) : undefined
       ]),
       h('span.liking.text', {


### PR DESCRIPTION
Fix #6057

- Title in study list will be shown when hovering on overlay
- Title in study view will include chapter name.

![Screenshot from 2020-03-20 08-49-43](https://user-images.githubusercontent.com/11418231/77129825-f9112100-6a87-11ea-8c5b-327f8646b33c.png)

![Screenshot from 2020-03-20 08-49-30](https://user-images.githubusercontent.com/11418231/77129805-e991d800-6a87-11ea-8ebe-82769a1c22ef.png)
