### PR TITLE
Re-order UI control panel in games to avoid abuse + tweaks

### DIFF
--- a/ui/round/css/_app-layout.scss
+++ b/ui/round/css/_app-layout.scss
@@ -107,7 +107,7 @@ $controls-height: auto;
     }
     .expiration-top { display: flex; }
     .rmoves {
-      margin-bottom: 0;
+      margin-bottom: 1px;
       .moves {
         display: none;
         background: none;

--- a/ui/round/css/_control.scss
+++ b/ui/round/css/_control.scss
@@ -43,23 +43,21 @@
     @extend %flex-center-nowrap;
     background: $c-accent;
     color: #fff;
-    margin-bottom: 1px;
+    padding: 1px;
     p {
       flex: 1 1 auto;
     }
     a {
       flex: 0 0 3rem;
       font-size: 1.5em;
-      line-height: 1.7em;
+      line-height: 3em;
       background: $c-bg-box;
     }
     .accept {
-      @extend %box-radius-left;
       color: $c-good;
       margin-right: 1px;
     }
     .decline {
-      @extend %box-radius-right;
       color: $c-bad;
     }
     a:hover {

--- a/ui/round/css/_icon.scss
+++ b/ui/round/css/_icon.scss
@@ -1,6 +1,7 @@
 .ricons {
   display: flex;
   justify-content: center;
+  margin-top: 10px;
   .fbt {
     font-size: 1.4em;
     padding: .1em 1em;

--- a/ui/round/src/view/table.ts
+++ b/ui/round/src/view/table.ts
@@ -68,10 +68,10 @@ export function renderTablePlay(ctrl: RoundController) {
   return [
     replay.render(ctrl),
     h('div.rcontrols', [
+      ...buttons,
       h('div.ricons', {
         class: { 'confirm': !!(ctrl.drawConfirm || ctrl.resignConfirm) }
-      }, icons),
-      ...buttons
+      }, icons)
     ])
   ];
 }


### PR DESCRIPTION
Solves https://github.com/ornicar/lila/issues/5896

Changes the old order of: 

1. move list controls
2. [move list]
3. resign/draw/takeback buttons
4. **offers**

To:

1. move list controls
2. [move list]
3. **offers**
4. resign/draw/takeback buttons

Which stops the problem of accidentally clicking on resign when navigating the game without move list:
![left](https://user-images.githubusercontent.com/35957528/77180943-f5eb5480-6aca-11ea-86c7-954f826f5e4a.PNG)

Also change the buttons size to make them full height. What's your opinion?
![normal](https://user-images.githubusercontent.com/35957528/77181052-11565f80-6acb-11ea-8c42-c9d83a7bb3fc.PNG)
![nomovelist](https://user-images.githubusercontent.com/35957528/77181060-14e9e680-6acb-11ea-87d3-2b5185a1615b.PNG)

On mobile:
![mobile](https://user-images.githubusercontent.com/35957528/77181071-19160400-6acb-11ea-81f7-37d8cbfa14f4.PNG)
