### PR TITLE
Add RD requirements for variant leaderboards in FAQ

### DIFF
--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -315,7 +315,7 @@ object faq {
           ol(
             li("have played at least 30 rated games in a given rating,"),
             li("have played a rated game within the last week for this rating,"),
-            li("have a rating deviation lower than " + lila.rating.Glicko.standardRankableDeviation + ","),
+            li("have a rating deviation lower than " + lila.rating.Glicko.standardRankableDeviation + " in standard chess, and lower than " + lila.rating.Glicko.variantRankableDeviation + " in variants,"),
             li("be in the top 10 in this rating.")
           ),
           p(


### PR DESCRIPTION
Currently the FAQ does not mention that the RD is different to apply for variants leaderboards, and variant players are misled and think there is a bug or that the FAQ is outdated:
https://lichess.org/forum/lichess-feedback/no-rank-in-chess960
https://lichess.org/forum/general-chess-discussion/why-do-i-not-have-an-rk-rank?page=1

This PR adds the missing information