### PR TITLE
Replace custom option with 10+5 quick pairing at lobby

### DIFF
--- a/modules/pool/src/main/PoolList.scala
+++ b/modules/pool/src/main/PoolList.scala
@@ -14,6 +14,7 @@ object PoolList {
     PoolConfig(5 ++ 0, Wave(14 seconds, 40 players)),
     PoolConfig(5 ++ 3, Wave(25 seconds, 26 players)),
     PoolConfig(10 ++ 0, Wave(13 seconds, 30 players)),
+    PoolConfig(10 ++ 5, Wave(13 seconds, 20 players)),
     PoolConfig(15 ++ 15, Wave(60 seconds, 20 players))
   )
 

--- a/ui/lobby/src/boot.js
+++ b/ui/lobby/src/boot.js
@@ -1,5 +1,5 @@
 module.exports = function(cfg, element) {
-  var pools = [{id:"1+0",lim:1,inc:0,perf:"Bullet"},{id:"2+1",lim:2,inc:1,perf:"Bullet"},{id:"3+0",lim:3,inc:0,perf:"Blitz"},{"id":"3+2","lim":3,"inc":2,"perf":"Blitz"},{id:"5+0",lim:5,inc:0,perf:"Blitz"},{"id":"5+3","lim":5,"inc":3,"perf":"Blitz"},{id:"10+0",lim:10,inc:0,perf:"Rapid"},{id:"15+15",lim:15,inc:15,perf:"Classical"}];
+  var pools = [{id:"1+0",lim:1,inc:0,perf:"Bullet"},{id:"2+1",lim:2,inc:1,perf:"Bullet"},{id:"3+0",lim:3,inc:0,perf:"Blitz"},{"id":"3+2","lim":3,"inc":2,"perf":"Blitz"},{id:"5+0",lim:5,inc:0,perf:"Blitz"},{"id":"5+3","lim":5,"inc":3,"perf":"Blitz"},{id:"10+0",lim:10,inc:0,perf:"Rapid"},{id:"10+5",lim:10,inc:5,perf:"Rapid"},{id:"15+15",lim:15,inc:15,perf:"Classical"}];
   var lobby;
   var nbRoundSpread = spreadNumber(
     document.querySelector('#nb_games_in_play > strong'),

--- a/ui/lobby/src/view/pools.ts
+++ b/ui/lobby/src/view/pools.ts
@@ -32,10 +32,5 @@ export function render(ctrl: LobbyController) {
       (active && member!.range) ? renderRange(member!.range!) : h('div.perf', pool.perf),
       active ? spinner() : null
     ]);
-  }).concat(
-    h('div.custom', {
-      class: { transp: !!member },
-      attrs: { 'data-id': 'custom' }
-    }, ctrl.trans.noarg('custom'))
-  );
+  });
 }


### PR DESCRIPTION
Hello,

after no merge of pull request https://github.com/ornicar/lila/pull/5746 for a total of three month I took over the initiative and completed the issue mentioned from @ornicar and reduces the size of the changes.

The majority at the pull request agreeded on adding 10+5 beeing a good idea. As suggested in https://github.com/ornicar/lila/pull/5746#issuecomment-586567155 I would like to split the PR into two parts. This one will be part one, where there is the change from Custom to 10+5. Then the already open PR can be finished when there is a final answer on how solve the problem of adding chess variants to a quick pairing page.

**TL;DR:** Corona forces us to play more chess and 10+5 as new quick paring option would make a lot of people happy