### PR TITLE
client side puzzle socket

### DIFF
--- a/ui/chess/src/main.ts
+++ b/ui/chess/src/main.ts
@@ -1,4 +1,5 @@
 import { piotr } from './piotr';
+export { uciCharPair } from './ucicharpair';
 
 export const initialFen: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 

--- a/ui/chess/src/ucicharpair.ts
+++ b/ui/chess/src/ucicharpair.ts
@@ -1,0 +1,34 @@
+type Square = number;
+
+type Role = 'pawn' | 'knight' | 'bishop' | 'rook' | 'queen' | 'king';
+
+interface UciMove {
+  from: Square;
+  to: Square;
+  promotion?: Role;
+}
+
+interface UciDrop {
+  role: Role;
+  to: Square;
+}
+
+type Uci = UciMove | UciDrop;
+
+function square(sq: Square): number {
+  return 35 + sq;
+}
+
+function drop(role: Role): number {
+  return 35 + 64 + 8 * 5 + ['queen', 'rook', 'bishop', 'knight', 'pawn'].indexOf(role);
+}
+
+function promotion(file: number, role: Role): number {
+  return 35 + 64 + 8 * ['queen', 'rook', 'bishop', 'knight', 'king'].indexOf(role) + file;
+}
+
+export function uciCharPair(uci: Uci): string {
+  if ('role' in uci) return String.fromCharCode(square(uci.to), drop(uci.role));
+  else if (!uci.promotion) return String.fromCharCode(square(uci.to), square(uci.from));
+  else return String.fromCharCode(square(uci.from), promotion(uci.to & 7, uci.promotion));
+}

--- a/ui/puzzle/package.json
+++ b/ui/puzzle/package.json
@@ -21,6 +21,7 @@
     "ceval": "2.0.0",
     "chess": "2.0.0",
     "chessground": "^7.6",
+    "chessops": "^0.3.4",
     "common": "2.0.0",
     "snabbdom": "ornicar/snabbdom#0.7.1-lichess",
     "tree": "2.0.0"

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -400,7 +400,6 @@ export default function(opts: PuzzleOpts, redraw: Redraw): Controller {
   }
 
   const socket = socketBuild({
-    send: opts.socketSend,
     addNode: addNode,
     addDests: addDests,
     reset: function() {
@@ -482,7 +481,6 @@ export default function(opts: PuzzleOpts, redraw: Redraw): Controller {
     getCeval,
     pref: opts.pref,
     trans: window.lichess.trans(opts.i18n),
-    socketReceive: socket.receive,
     gameOver,
     toggleCeval,
     toggleThreatMode,

--- a/ui/puzzle/src/interfaces.ts
+++ b/ui/puzzle/src/interfaces.ts
@@ -45,7 +45,6 @@ export interface Controller extends KeyboardController {
   thanks(): boolean;
   vote(v: boolean): void;
   pref: PuzzlePrefs;
-  socketReceive: any;
   userMove(orig: Key, dest: Key): void;
   promotion: any;
 
@@ -79,7 +78,6 @@ export interface PuzzleOpts {
   pref: PuzzlePrefs;
   data: PuzzleData;
   i18n: { [key: string]: string | undefined };
-  socketSend: any;
 }
 
 export interface PuzzlePrefs {

--- a/ui/puzzle/src/main.ts
+++ b/ui/puzzle/src/main.ts
@@ -14,7 +14,7 @@ menuHover();
 
 const patch = init([klass, attributes]);
 
-export default function(opts) {
+export default function(opts): void {
 
   let vnode: VNode, ctrl: Controller;
 
@@ -27,10 +27,6 @@ export default function(opts) {
   const blueprint = view(ctrl);
   opts.element.innerHTML = '';
   vnode = patch(opts.element, blueprint);
-
-  return {
-    socketReceive: ctrl.socketReceive
-  };
 };
 
 // that's for the rest of lichess to access chessground

--- a/ui/site/src/main.js
+++ b/ui/site/src/main.js
@@ -955,15 +955,8 @@
   ////////////////
 
   function startPuzzle(cfg) {
-    var puzzle;
     cfg.element = document.querySelector('main.puzzle');
-    lichess.socket = lichess.StrongSocket('/socket/v4', false, {
-      receive: function(t, d) {
-        puzzle.socketReceive(t, d);
-      }
-    });
-    cfg.socketSend = lichess.socket.send;
-    puzzle = LichessPuzzle.default(cfg);
+    LichessPuzzle.default(cfg);
   }
 
   ////////////////////


### PR DESCRIPTION
Proof of concept: Handle puzzle socket on client side, to check if all required features are implemented in `chessops`.

Does not increase asset size, because chessops was already pulled in for ceval.

The current patch reimplements the socket communication exactly, including unnescessary serialization. Does not yet take advantage of the fact that dests are available synchronously.