### PR TITLE
slightly randomize tournament start times

### DIFF
--- a/modules/tournament/src/main/Tournament.scala
+++ b/modules/tournament/src/main/Tournament.scala
@@ -170,8 +170,9 @@ object Tournament {
     teamBattle = teamBattle,
     noBerserk = !berserkable,
     schedule = None,
-    startsAt = startDate | {
-      DateTime.now plusMinutes waitMinutes
+    startsAt = startDate match {
+      case Some(startDate) => startDate plusSeconds scala.util.Random.nextInt(60)
+      case None =>            DateTime.now plusMinutes waitMinutes
     }
   )
 
@@ -189,7 +190,7 @@ object Tournament {
     mode = Mode.Rated,
     conditions = sched.conditions,
     schedule = Some(sched),
-    startsAt = sched.at
+    startsAt = sched.at plusSeconds scala.util.Random.nextInt(60)
   )
 
   def makeId = Random nextString 8


### PR DESCRIPTION
This (or something like it) should help a lot to alleviate the spike of pairings and game page loads at exactly every full hour.

Edit: Checked that doing this for official scheduled tournaments does not lead to duplicates, because the scheduler checks for overlaps, not precise start time.