### PR TITLE
Prevent play timer ticking in lobby, when player has not moved

### DIFF
--- a/modules/api/src/main/LobbyApi.scala
+++ b/modules/api/src/main/LobbyApi.scala
@@ -53,6 +53,7 @@ final class LobbyApi(
         "speed" -> pov.game.speed.key,
         "perf"  -> lila.game.PerfPicker.key(pov.game),
         "rated" -> pov.game.rated,
+        "hasMoved" -> pov.hasMoved,
         "opponent" -> Json
           .obj(
             "id" -> pov.opponent.userId,

--- a/ui/lobby/src/view/playing.ts
+++ b/ui/lobby/src/view/playing.ts
@@ -40,7 +40,7 @@ export default function(ctrl: LobbyController) {
           pov.opponent.ai ? ctrl.trans('aiNameLevelAiLevel', 'Stockfish', pov.opponent.ai) : pov.opponent.username,
           h('span.indicator',
             pov.isMyTurn ?
-            (pov.secondsLeft ? timer(pov) : [ctrl.trans.noarg('yourTurn')]) :
+            ((pov.secondsLeft && pov.hasMoved) ? timer(pov) : [ctrl.trans.noarg('yourTurn')]) :
             h('span', '\xa0')) // &nbsp;
         ])
       ]);


### PR DESCRIPTION
Instead of letting the time tick, check if the player has moved. Now it shows 'Your turn'.
Link to issue: https://github.com/ornicar/lila/issues/6260.