### PR TITLE
Add Weekly Three Check

### DIFF
--- a/modules/tournament/src/main/TournamentScheduler.scala
+++ b/modules/tournament/src/main/TournamentScheduler.scala
@@ -223,13 +223,14 @@ Thank you all, you rock!"""
           }
       },
       List( // weekly variant tournaments!
-        nextMonday    -> Chess960,
+        nextMonday    -> ThreeCheck,
         nextTuesday   -> Crazyhouse,
         nextWednesday -> KingOfTheHill,
         nextThursday  -> RacingKings,
         nextFriday    -> Antichess,
         nextSaturday  -> Atomic,
-        nextSunday    -> Horde
+        nextSunday    -> Horde,
+        nextSunday    -> Chess960
       ).flatMap {
         case (day, variant) =>
           at(day, 19) map { date =>


### PR DESCRIPTION
This moves the weekly Chess960 tournament to Sunday since there isn't a weekly standard chess tournament on Sunday, and adds a weekly Three Check tournament on Monday.