### PR TITLE
Create XML file with latest git hash, for #6292

### DIFF
--- a/bin/prod/deploy
+++ b/bin/prod/deploy
@@ -3,6 +3,16 @@
 
 mode=$1
 
+# Write latest commit information to an XML file
+echo "<?xml version=\"1.0\" encoding=\"utf-8\"?>" > some-file.xml
+echo "<resources>" >> some-file.xml
+GITLOG=$(git log -1)
+echo "  <string name=\"commit\">$(echo $GITLOG | sed -n '1 p' | sed -e s/^'commit '//)</string>" >> some-file.xml
+echo "  <string name=\"author\">$(echo $GITLOG | sed -n '2 p' | sed -e s/^'Author: '// | tr -d '<>')</string>" >> some-file.xml
+echo "  <string name=\"date\">$(echo $GITLOG | sed -n '3 p' | sed -e s/^'Date:   '//)</string>" >> some-file.xml
+echo "  <string name=\"message\">$(echo $GITLOG | sed -n '5 p' | sed -e s/^'    '//)</string>" >> some-file.xml
+echo "</resources>" >> some-file.xml
+
 if [ -z $mode ]; then
   echo "Empty deploy target"
   exit 1


### PR DESCRIPTION
I'm thinking a file should be generated right before deploy (could also be a git post-commit hook, but that seems more annoying). This file could be `.gitignored`.

```
<?xml version="1.0" encoding="utf-8"?>
<resources>
  <string name="commit">480c9ce06d389a6ce1530daaa64cefe6606e14af</string>
  <string name="author">Thibault Duplessis thibault.duplessis@gmail.com</string>
  <string name="date">Sat Apr 4 21:03:14 2020 -0600</string>
  <string name="message">format</string>
</resources>
```

The site translations are already loaded via XML files, so I'm sure a similar pattern could be done here. I'm lacking the knowledge of the needed front-end changes to use this file, but maybe this is a start? Feel free to run with it from here if you like this idea.