### PR TITLE
Copy URL button for each tournament in pm all

### DIFF
--- a/app/views/team/admin.scala
+++ b/app/views/team/admin.scala
@@ -68,7 +68,12 @@ object admin {
 
     views.html.base.layout(
       title = title,
-      moreCss = cssTag("team")
+      moreCss = cssTag("team"),
+      moreJs = embedJsUnsafe(s"""
+           |$$('.copy-url-button').on('click', function(e) {
+           |$$('#form3-message').val(function(i, x) {return x + $$(e.target).data('copyurl') + '\\n'})
+           |})
+           |""".stripMargin),
     ) {
       main(cls := "page-menu page-small")(
         bits.menu(none),
@@ -91,8 +96,11 @@ object admin {
                     " ",
                     momentFromNow(t.startsAt),
                     " - ",
-                    netDomain,
-                    routes.Tournament.show(t.id).url
+                    a(
+                      dataIcon := "u",
+                      cls := "text copy-url-button",
+                      data.copyurl := s"${netDomain}${routes.Tournament.show(t.id).url}",
+                    )("Copy URL")
                   )
                 }
               )

--- a/app/views/team/admin.scala
+++ b/app/views/team/admin.scala
@@ -97,10 +97,10 @@ object admin {
                     momentFromNow(t.startsAt),
                     " ",
                     a(
-                      dataIcon := "u",
+                      dataIcon := "z",
                       cls := "text copy-url-button",
                       data.copyurl := s"${netDomain}${routes.Tournament.show(t.id).url}",
-                    )("Copy URL")
+                    )()
                   )
                 }
               )

--- a/app/views/team/admin.scala
+++ b/app/views/team/admin.scala
@@ -69,11 +69,12 @@ object admin {
     views.html.base.layout(
       title = title,
       moreCss = cssTag("team"),
-      moreJs = embedJsUnsafe("""
+      moreJs =
+        embedJsUnsafe("""
            |$('.copy-url-button').on('click', function(e) {
            |$('#form3-message').val(function(i, x) {return x + $(e.target).data('copyurl') + '\n'})
            |})
-           |""".stripMargin),
+           |""".stripMargin)
     ) {
       main(cls := "page-menu page-small")(
         bits.menu(none),
@@ -99,7 +100,7 @@ object admin {
                     a(
                       dataIcon := "z",
                       cls := "text copy-url-button",
-                      data.copyurl := s"${netDomain}${routes.Tournament.show(t.id).url}",
+                      data.copyurl := s"${netDomain}${routes.Tournament.show(t.id).url}"
                     )()
                   )
                 }

--- a/app/views/team/admin.scala
+++ b/app/views/team/admin.scala
@@ -69,9 +69,9 @@ object admin {
     views.html.base.layout(
       title = title,
       moreCss = cssTag("team"),
-      moreJs = embedJsUnsafe(s"""
-           |$$('.copy-url-button').on('click', function(e) {
-           |$$('#form3-message').val(function(i, x) {return x + $$(e.target).data('copyurl') + '\\n'})
+      moreJs = embedJsUnsafe("""
+           |$('.copy-url-button').on('click', function(e) {
+           |$('#form3-message').val(function(i, x) {return x + $(e.target).data('copyurl') + '\n'})
            |})
            |""".stripMargin),
     ) {

--- a/app/views/team/admin.scala
+++ b/app/views/team/admin.scala
@@ -101,7 +101,7 @@ object admin {
                       dataIcon := "z",
                       cls := "text copy-url-button",
                       data.copyurl := s"${netDomain}${routes.Tournament.show(t.id).url}"
-                    )()
+                    )
                   )
                 }
               )

--- a/app/views/team/admin.scala
+++ b/app/views/team/admin.scala
@@ -95,7 +95,7 @@ object admin {
                     tournamentLink(t),
                     " ",
                     momentFromNow(t.startsAt),
-                    " - ",
+                    " ",
                     a(
                       dataIcon := "u",
                       cls := "text copy-url-button",


### PR DESCRIPTION
At the current stage of lichess you have to copy the arena urls manually, when sending the All-PM. I think it is an improvement to have a button, that copies the url.