### PR TITLE
Silently allow missing app.version

### DIFF
--- a/app/Env.scala
+++ b/app/Env.scala
@@ -85,7 +85,7 @@ final class Env(
   val isStage           = config.get[Boolean]("app.stage")
   val explorerEndpoint  = config.get[String]("explorer.endpoint")
   val tablebaseEndpoint = config.get[String]("explorer.tablebase.endpoint")
-  val appVersion        = config.get[String]("app.version")
+  val appVersion        = config.getOptional[String]("app.version") // if desired, generate conf/version.conf properly with command in .github/workflows/server.yml
 
   def net = common.netConfig
 


### PR DESCRIPTION
New developers would hit something like `Missing: base.conf @ file:/Users/gfinley/fun-repos/lila/target/scala-2.13/classes/base.conf: 69: No configuration setting found for key 'app.version'`.

I knew how to resolve because I saw your commit making this thing, but we should just let it be blank if this file doesn't exist. Adding a step to dev onboarding or some hack to add a dummy file that is later gitignored seems worse.