### PR TITLE
Add Tournament url to Marathon Trophies

### DIFF
--- a/app/views/user/show/otherTrophies.scala
+++ b/app/views/user/show/otherTrophies.scala
@@ -17,7 +17,7 @@ object otherTrophies {
           trophy.kind.icon.map { iconChar =>
             a(
               awardCls(trophy),
-              href := trophy.kind.url,
+              href := trophy.kind.url.orElse(trophy.url),
               ariaTitle(s"${trophy.kind.name}")
             )(raw(iconChar))
           }

--- a/modules/tournament/src/main/Tournament.scala
+++ b/modules/tournament/src/main/Tournament.scala
@@ -192,6 +192,8 @@ object Tournament {
     startsAt = sched.at
   )
 
+  def tournamentUrl(tourId: String): String = s"https://lichess.org/tournament/$tourId"
+
   def makeId = Random nextString 8
 
   case class TournamentTable(tours: List[Tournament])

--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -203,13 +203,14 @@ final class TournamentApi(
 
   private def awardTrophies(tour: Tournament): Funit = {
     import lila.user.TrophyKind._
+    import lila.tournament.Tournament.tournamentUrl
     tour.schedule.??(_.freq == Schedule.Freq.Marathon) ?? {
       playerRepo.bestByTourWithRank(tour.id, 100).flatMap {
         _.map {
-          case rp if rp.rank == 1  => trophyApi.award(rp.player.userId, marathonWinner)
-          case rp if rp.rank <= 10 => trophyApi.award(rp.player.userId, marathonTopTen)
-          case rp if rp.rank <= 50 => trophyApi.award(rp.player.userId, marathonTopFifty)
-          case rp                  => trophyApi.award(rp.player.userId, marathonTopHundred)
+          case rp if rp.rank == 1  => trophyApi.award(tournamentUrl(tour.id), rp.player.userId, marathonWinner)
+          case rp if rp.rank <= 10 => trophyApi.award(tournamentUrl(tour.id), rp.player.userId, marathonTopTen)
+          case rp if rp.rank <= 50 => trophyApi.award(tournamentUrl(tour.id), rp.player.userId, marathonTopFifty)
+          case rp                  => trophyApi.award(tournamentUrl(tour.id), rp.player.userId, marathonTopHundred)
         }.sequenceFu.void
       }
     }

--- a/modules/tournament/src/main/arena/OrnicarPairing.scala
+++ b/modules/tournament/src/main/arena/OrnicarPairing.scala
@@ -1,7 +1,8 @@
 package lila.tournament
 package arena
 
-import PairingSystem.{ url, Data }
+import PairingSystem.Data
+import lila.tournament.Tournament.tournamentUrl;
 
 private object OrnicarPairing {
 
@@ -101,7 +102,7 @@ private object OrnicarPairing {
     }
     if (!continue)
       pairingLogger.warn(
-        s"smartPairings cutoff! [${nowMillis - startAt}ms] ${url(data.tour.id)} ${players.size} players, ${preps.size} preps"
+        s"smartPairings cutoff! [${nowMillis - startAt}ms] ${tournamentUrl(data.tour.id)} ${players.size} players, ${preps.size} preps"
       )
     preps
   }

--- a/modules/tournament/src/main/arena/PairingSystem.scala
+++ b/modules/tournament/src/main/arena/PairingSystem.scala
@@ -12,6 +12,7 @@ final private[tournament] class PairingSystem(
 )(implicit ec: scala.concurrent.ExecutionContext, idGenerator: lila.game.IdGenerator) {
 
   import PairingSystem._
+  import lila.tournament.Tournament.tournamentUrl;
 
   // if waiting users can make pairings
   // then pair all users
@@ -34,7 +35,7 @@ final private[tournament] class PairingSystem(
     } yield pairings
   }.chronometer
     .logIfSlow(500, pairingLogger) { pairings =>
-      s"createPairings ${url(tour.id)} ${pairings.size} pairings"
+      s"createPairings ${tournamentUrl(tour.id)} ${pairings.size} pairings"
     }
     .result
 
@@ -64,7 +65,7 @@ final private[tournament] class PairingSystem(
   }.monSuccess(_.tournament.pairing.prep)
     .chronometer
     .logIfSlow(200, pairingLogger) { preps =>
-      s"makePreps ${url(data.tour.id)} ${users.size} users, ${preps.size} preps"
+      s"makePreps ${tournamentUrl(data.tour.id)} ${users.size} users, ${preps.size} preps"
     }
     .result
 
@@ -98,8 +99,6 @@ private object PairingSystem {
   ) {
     val isFirstRound = lastOpponents.hash.isEmpty && tour.isRecentlyStarted
   }
-
-  def url(tourId: String) = s"https://lichess.org/tournament/$tourId"
 
   /* Was previously static 1000.
    * By increasing the factor for high ranked players,

--- a/modules/user/src/main/Trophy.scala
+++ b/modules/user/src/main/Trophy.scala
@@ -6,7 +6,8 @@ case class Trophy(
     _id: String, // random
     user: String,
     kind: TrophyKind,
-    date: DateTime
+    date: DateTime,
+    url: Option[String]
 ) extends Ordered[Trophy] {
 
   def timestamp = date.getMillis

--- a/modules/user/src/main/TrophyApi.scala
+++ b/modules/user/src/main/TrophyApi.scala
@@ -41,29 +41,33 @@ final class TrophyApi(
         _id = "",
         user = user.id,
         kind = kindCache sync TrophyKind.moderator,
-        date = org.joda.time.DateTime.now
+        date = org.joda.time.DateTime.now,
+        url = none,
       ),
       isDev option Trophy(
         _id = "",
         user = user.id,
         kind = kindCache sync TrophyKind.developer,
-        date = org.joda.time.DateTime.now
+        date = org.joda.time.DateTime.now,
+        url = none,
       ),
       isVerified option Trophy(
         _id = "",
         user = user.id,
         kind = kindCache sync TrophyKind.verified,
-        date = org.joda.time.DateTime.now
+        date = org.joda.time.DateTime.now,
+        url = none,
       )
     ).flatten
 
-  def award(userId: String, kindKey: String): Funit =
+  def award(trophyUrl: String, userId: String, kindKey: String): Funit =
     coll.insert
       .one(
         $doc(
           "_id"  -> ornicar.scalalib.Random.nextString(8),
           "user" -> userId,
           "kind" -> kindKey,
+          "url" -> trophyUrl,
           "date" -> DateTime.now
       )
     ) void


### PR DESCRIPTION
Fixes #4179

I spun up a local instance and tested that back filling the url for summer15 (via `marathon-trophies.js`) worked.

I did not try to create and run a new marathon tournament to verify the code in `modules/tournament/src/main/TournamentApi.scala`