### PR TITLE
Fix increment mapping

### DIFF
--- a/modules/lobby/src/main/Hook.scala
+++ b/modules/lobby/src/main/Hook.scala
@@ -34,7 +34,7 @@ case class Hook(
 
   val isAuth = user.nonEmpty
 
-  val hasIncrement = if (clock.incrementSeconds > 0) 0 else 1
+  val hasIncrement = if (clock.incrementSeconds > 0) 1 else 0
 
   def compatibleWith(h: Hook) =
     isAuth == h.isAuth &&


### PR DESCRIPTION
I had made Yes=0 and No=1 in my original PR but the refactoring away from Scalachess `Increment` flipped it. I suppose 1 is a more sane value for Yes anyways, so just flip the definition.