### PR TITLE
Report commit age against current time, closes #6336

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: olafurpg/setup-scala@49fc8c734ef6916b4e1da8ba8d81bb26a2b46a06 # v7
       with:
         java-version: openjdk@1.13.0-2
-    - run: echo "app.version = \"\"\"$(git log -1 --pretty='format:%h / %ar / %s')\"\"\"" > conf/version.conf
+    - run: echo "app.version = \"\"\"$(git log -1 --pretty='format:%h / %at / %s')\"\"\"" > conf/version.conf
     - run: ./lila -Depoll=true "test;dist"
     - run: unzip target/universal/lila-3.0.zip
     - run: cp LICENSE COPYING.md README.md lila-3.0 && git log -n 1 --pretty=oneline > lila-3.0/commit.txt

--- a/app/views/site/help.scala
+++ b/app/views/site/help.scala
@@ -41,12 +41,10 @@ object help {
         br,
         env.appVersion map { appVersion => {
           val parts = appVersion.split(" / ")
-          val relativeTime =  (((System.currentTimeMillis / 1000) - (parts(1)).toInt)/60).toString + " minutes ago"
-          parts(1) = relativeTime
-          val result = parts.mkString(" / ")
+          parts(1) = secondsToXAgo(((System.currentTimeMillis / 1000) - (parts(1)).toLong))
           st.section(cls := "box box-pad")(
             h1("lila version"),
-            pre(result)
+            pre(parts.mkString(" / "))
           )
         }
         },
@@ -54,6 +52,12 @@ object help {
         st.section(cls := "box")(freeJs())
       )
     )
+  }
+
+  def secondsToXAgo(x: Long) = {
+    if (x >= 86400) (x/86400).toString + " days ago"
+    else if (x >= 3600) (x/3600).toString + " hours ago"
+    else (x/60).toString + " minutes ago"
   }
 
   def webmasters()(implicit ctx: Context) = {

--- a/app/views/site/help.scala
+++ b/app/views/site/help.scala
@@ -39,11 +39,16 @@ object help {
           raw(~doc.getHtml("doc.content", resolver))
         ),
         br,
-        env.appVersion map { appVersion =>
+        env.appVersion map { appVersion => {
+          val parts = appVersion.split(" / ")
+          val relativeTime =  (((System.currentTimeMillis / 1000) - (parts(1)).toInt)/60).toString + " minutes ago"
+          parts(1) = relativeTime
+          val result = parts.mkString(" / ")
           st.section(cls := "box box-pad")(
             h1("lila version"),
-            pre(appVersion)
+            pre(result)
           )
+        }
         },
         br,
         st.section(cls := "box")(freeJs())


### PR DESCRIPTION
Recalculates every time you refresh the page.

![Screen Shot 2020-04-07 at 1 45 29 PM](https://user-images.githubusercontent.com/28961086/78717854-1b070200-78d6-11ea-9c40-fd95ef7e2b25.png)
