### PR TITLE
Removing bottom border on friends box

### DIFF
--- a/ui/common/css/component/_friend-box.scss
+++ b/ui/common/css/component/_friend-box.scss
@@ -10,6 +10,7 @@
   background: $c-bg-popup;
   border: $border;
   border-right: 0;
+  border-bottom: 0;
   border-top-left-radius: $box-radius-size;
   font-size: .9rem;
   min-width: 150px;


### PR DESCRIPTION
Removing bottom border so that user can drop mouse to the edge of monitor and still click friends box. As of right now last 1px of border avoids click to toggle friends list.

Container bottom border still remains visible after change.

![image](https://user-images.githubusercontent.com/1594975/78739341-e7919b00-7908-11ea-8fc3-afb8b8f4207a.png)
