### PR TITLE
Sanitize more than 2 consecutive line breaks

### DIFF
--- a/modules/common/src/main/base/RawHtml.scala
+++ b/modules/common/src/main/base/RawHtml.scala
@@ -9,26 +9,9 @@ import lila.common.base.StringUtils.escapeHtmlRaw
 final object RawHtml {
   @inline implicit def toPimpedChars(i: Iterable[CharSequence]) = new PimpedChars(i)
 
-  def nl2br(s: String): String = {
-    var i = s.indexOf('\n')
-    if (i < 0) s
-    else {
-      val sb      = new jStringBuilder(s.length + 30)
-      var copyIdx = 0
-      do {
-        if (i > copyIdx) {
-          // copyIdx >= 0, so i - 1 >= 0
-          sb.append(s, copyIdx, if (s.charAt(i - 1) == '\r') i - 1 else i)
-        }
-        sb.append("<br />")
-        copyIdx = i + 1
-        i = s.indexOf('\n', copyIdx)
-      } while (i >= 0)
-
-      sb.append(s, copyIdx, s.length)
-      sb.toString
-    }
-  }
+  def nl2br(s: String): String =
+    s.replaceAll("[\r\n]{3,}", "\n\n") // collapse more than two consecutive nl chars
+      .replaceAll("\r\n|\n", "<br />")  // replace newlines with breaks
 
   private[this] val urlPattern = (
     """(?i)\b[a-z](?>""" +                                     // pull out first char for perf.

--- a/modules/common/src/main/base/RawHtml.scala
+++ b/modules/common/src/main/base/RawHtml.scala
@@ -9,9 +9,22 @@ import lila.common.base.StringUtils.escapeHtmlRaw
 final object RawHtml {
   @inline implicit def toPimpedChars(i: Iterable[CharSequence]) = new PimpedChars(i)
 
-  def nl2br(s: String): String =
-    s.replaceAll("[\r\n]{3,}", "\n\n") // collapse more than two consecutive nl chars
-      .replaceAll("\r\n|\n", "<br />")  // replace newlines with breaks
+  def nl2br(s: String): String = {
+    val sb = new jStringBuilder(s.length)
+    var counter = 0
+    for (char <- s) {
+      if (char == '\n') {
+        counter += 1
+        if (counter < 3) {
+          sb.append("<br />")
+        }
+      } else if (char != '\r') {
+        counter = 0
+        sb.append(char)
+        }
+    }
+    sb.toString
+  }
 
   private[this] val urlPattern = (
     """(?i)\b[a-z](?>""" +                                     // pull out first char for perf.

--- a/modules/common/src/test/RawHtmlTest.scala
+++ b/modules/common/src/test/RawHtmlTest.scala
@@ -170,4 +170,32 @@ class RawHtmlTest extends Specification {
       copyLinkConsistency("@foo")
     }
   }
+
+  "nl2br" should {
+    "convert windows style newlines into <br />" in {
+      nl2br("hello\r\nworld") must_== "hello<br />world"
+      nl2br("\r\nworld") must_== "<br />world"
+      nl2br("hello\r\n") must_== "hello<br />"
+      nl2br("hello\r\nworld\r\nagain") must_== "hello<br />world<br />again"
+    }
+
+    "convert posix style newlines into <br />" in {
+      nl2br("hello\nworld") must_== "hello<br />world"
+      nl2br("\nworld") must_== "<br />world"
+      nl2br("hello\n") must_== "hello<br />"
+      nl2br("hello\nworld\nagain") must_== "hello<br />world<br />again"
+    }
+
+    "not output more than two consecutive <br /> chars" in {
+      nl2br("\n\n\n\ndef") must_== "<br /><br />def"
+      nl2br("abc\n\n\n\n") must_== "abc<br /><br />"
+      nl2br("abc\n\n\n\ndef") must_== "abc<br /><br />def"
+      nl2br("abc\n\n\n\ndef\n\n\n\nabc\n\n\n\ndef") must_== "abc<br /><br />def<br /><br />abc<br /><br />def"
+
+      nl2br("\r\n\r\n\r\n\ndef") must_== "<br /><br />def"
+      nl2br("abc\r\n\r\n\r\n\r\n") must_== "abc<br /><br />"
+      nl2br("abc\r\n\r\n\r\n\r\ndef") must_== "abc<br /><br />def"
+      nl2br("abc\r\n\r\n\r\n\r\ndef\r\n\r\n\r\n\r\nabc\r\n\r\n\r\n\r\ndef") must_== "abc<br /><br />def<br /><br />abc<br /><br />def"
+    }
+  }
 }


### PR DESCRIPTION
This fixes #6382.

I have lila set up locally but there seem to be no default topics I can comment on in the forum, so I've only verified that this works via unit tests.

Also, I'm not sure how to test whether the micro-optimization in `nl2br` is actually needed, any suggestion there?

---

Side note, I didn't find any guideline on contributing PRs, let me know if there's something I haven't done right.