### PR TITLE
Various translation improvements for teams

### DIFF
--- a/app/views/team/bits.scala
+++ b/app/views/team/bits.scala
@@ -14,7 +14,7 @@ object bits {
     st.nav(cls := "page-menu__menu subnav")(
       (ctx.teamNbRequests > 0) option
         a(cls := tab.active("requests"), href := routes.Team.requests())(
-          xJoinRequests(ctx.teamNbRequests)
+          xJoinRequests.pluralSame(ctx.teamNbRequests)
         ),
       ctx.isAuth option
         a(cls := tab.active("mine"), href := routes.Team.mine())(

--- a/app/views/team/request.scala
+++ b/app/views/team/request.scala
@@ -42,7 +42,7 @@ object request {
   }
 
   def all(requests: List[lila.team.RequestWithUser])(implicit ctx: Context) = {
-    val title = s"${requests.size} join requests"
+    val title = xJoinRequests.pluralSameTxt(requests.size)
     bits.layout(title = title) {
       main(cls := "page-menu")(
         bits.menu("requests".some),

--- a/app/views/team/show.scala
+++ b/app/views/team/show.scala
@@ -102,7 +102,7 @@ object show {
                   dataIcon := "e"
                 )(
                   span(
-                    strong("Message all members"),
+                    strong(messageAllMembers()),
                     em("Send a private message to every member of the team")
                   )
                 )

--- a/app/views/team/show.scala
+++ b/app/views/team/show.scala
@@ -103,7 +103,7 @@ object show {
                 )(
                   span(
                     strong(messageAllMembers()),
-                    em("Send a private message to every member of the team")
+                    em(messageAllMembersOverview())
                   )
                 )
               )

--- a/app/views/team/show.scala
+++ b/app/views/team/show.scala
@@ -93,7 +93,7 @@ object show {
                 )(
                   span(
                     strong(teamTournament()),
-                    em("An Arena tournament that only members of your team can join")
+                    em(teamTournamentOverview())
                   )
                 ),
                 a(

--- a/app/views/team/show.scala
+++ b/app/views/team/show.scala
@@ -83,7 +83,7 @@ object show {
                 )(
                   span(
                     strong(teamBattle()),
-                    em("A battle of multiple teams, each players scores points for their team")
+                    em(teamBattleOverview())
                   )
                 ),
                 a(

--- a/app/views/team/show.scala
+++ b/app/views/team/show.scala
@@ -58,7 +58,7 @@ object show {
                 frag(br, trans.location(), ": ", richText(loc))
               },
               info.hasRequests option div(cls := "requests")(
-                h2(xJoinRequests(info.requests.size)),
+                h2(xJoinRequests.pluralSame(info.requests.size)),
                 views.html.team.request.list(info.requests, t.some)
               )
             ),

--- a/app/views/team/show.scala
+++ b/app/views/team/show.scala
@@ -92,7 +92,7 @@ object show {
                   dataIcon := "g"
                 )(
                   span(
-                    strong("Team tournament"),
+                    strong(teamTournament()),
                     em("An Arena tournament that only members of your team can join")
                   )
                 ),

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1531,6 +1531,7 @@ val `beingReviewed` = new I18nKey("team:beingReviewed")
 val `teamBattle` = new I18nKey("team:teamBattle")
 val `teamBattleOverview` = new I18nKey("team:teamBattleOverview")
 val `teamTournament` = new I18nKey("team:teamTournament")
+val `teamTournamentOverview` = new I18nKey("team:teamTournamentOverview")
 val `nbMembers` = new I18nKey("team:nbMembers")
 val `xJoinRequests` = new I18nKey("team:xJoinRequests")
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1533,6 +1533,7 @@ val `teamBattleOverview` = new I18nKey("team:teamBattleOverview")
 val `teamTournament` = new I18nKey("team:teamTournament")
 val `teamTournamentOverview` = new I18nKey("team:teamTournamentOverview")
 val `messageAllMembers` = new I18nKey("team:messageAllMembers")
+val `messageAllMembersOverview` = new I18nKey("team:messageAllMembersOverview")
 val `nbMembers` = new I18nKey("team:nbMembers")
 val `xJoinRequests` = new I18nKey("team:xJoinRequests")
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1532,6 +1532,7 @@ val `teamBattle` = new I18nKey("team:teamBattle")
 val `teamBattleOverview` = new I18nKey("team:teamBattleOverview")
 val `teamTournament` = new I18nKey("team:teamTournament")
 val `teamTournamentOverview` = new I18nKey("team:teamTournamentOverview")
+val `messageAllMembers` = new I18nKey("team:messageAllMembers")
 val `nbMembers` = new I18nKey("team:nbMembers")
 val `xJoinRequests` = new I18nKey("team:xJoinRequests")
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1530,6 +1530,7 @@ val `willBeReviewed` = new I18nKey("team:willBeReviewed")
 val `beingReviewed` = new I18nKey("team:beingReviewed")
 val `teamBattle` = new I18nKey("team:teamBattle")
 val `teamBattleOverview` = new I18nKey("team:teamBattleOverview")
+val `teamTournament` = new I18nKey("team:teamTournament")
 val `nbMembers` = new I18nKey("team:nbMembers")
 val `xJoinRequests` = new I18nKey("team:xJoinRequests")
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1529,6 +1529,7 @@ val `changeOwner` = new I18nKey("team:changeOwner")
 val `willBeReviewed` = new I18nKey("team:willBeReviewed")
 val `beingReviewed` = new I18nKey("team:beingReviewed")
 val `teamBattle` = new I18nKey("team:teamBattle")
+val `teamBattleOverview` = new I18nKey("team:teamBattleOverview")
 val `nbMembers` = new I18nKey("team:nbMembers")
 val `xJoinRequests` = new I18nKey("team:xJoinRequests")
 }

--- a/translation/source/team.xml
+++ b/translation/source/team.xml
@@ -31,5 +31,5 @@
   <string name="teamBattle">Team Battle</string>
   <string name="teamBattleOverview">A battle of multiple teams, each players scores points for their team</string>
   <string name="teamTournament">Team tournament</string>
-  
+  <string name="teamTournamentOverview">An Arena tournament that only members of your team can join</string>
 </resources>

--- a/translation/source/team.xml
+++ b/translation/source/team.xml
@@ -30,4 +30,6 @@
   <string name="beingReviewed">Your join request is being reviewed by the team leader.</string>
   <string name="teamBattle">Team Battle</string>
   <string name="teamBattleOverview">A battle of multiple teams, each players scores points for their team</string>
+  <string name="teamTournament">Team tournament</string>
+  
 </resources>

--- a/translation/source/team.xml
+++ b/translation/source/team.xml
@@ -29,4 +29,5 @@
   <string name="willBeReviewed">Your join request will be reviewed by the team leader.</string>
   <string name="beingReviewed">Your join request is being reviewed by the team leader.</string>
   <string name="teamBattle">Team Battle</string>
+  <string name="teamBattleOverview">A battle of multiple teams, each players scores points for their team</string>
 </resources>

--- a/translation/source/team.xml
+++ b/translation/source/team.xml
@@ -33,4 +33,5 @@
   <string name="teamTournament">Team tournament</string>
   <string name="teamTournamentOverview">An Arena tournament that only members of your team can join</string>
   <string name="messageAllMembers">Message all members</string>
+  <string name="messageAllMembersOverview">Send a private message to every member of the team</string>
 </resources>

--- a/translation/source/team.xml
+++ b/translation/source/team.xml
@@ -32,4 +32,5 @@
   <string name="teamBattleOverview">A battle of multiple teams, each players scores points for their team</string>
   <string name="teamTournament">Team tournament</string>
   <string name="teamTournamentOverview">An Arena tournament that only members of your team can join</string>
+  <string name="messageAllMembers">Message all members</string>
 </resources>


### PR DESCRIPTION
Add translations to `/team/<name-of-the-team>` from the leader point-of-vue and fix the title of `/team/requests`.