### PR TITLE
Fix monitoring rating percentile calculation

### DIFF
--- a/modules/user/src/main/RankingApi.scala
+++ b/modules/user/src/main/RankingApi.scala
@@ -228,7 +228,7 @@ final class RankingApi(
         case (prev, (rating, nbUsers)) =>
           val acc = prev + nbUsers
           PerfType(perfId) foreach { pt =>
-            lila.mon.rating.distribution(pt.key, rating).update(acc.toDouble / total)
+            lila.mon.rating.distribution(pt.key, rating).update(prev.toDouble / total)
           }
           acc
       }


### PR DESCRIPTION
For example, the 1500 percentile should include all players in previous buckets (up to 1500), but not the current one (1500-1525).