### PR TITLE
Translate FAQ page

### DIFF
--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -278,22 +278,24 @@ object faq {
         ),
         question(
           "leaderboards",
-          "How do ranks and leaderboards work?",
-          p("In order to get on the ", a(href := routes.User.list())("rating leaderboards"), ", you must:"),
+          howDoLeaderoardsWork.txt(),
+          p(inOrderToAppearsYouMust(
+            a(href := routes.User.list())(ratingLeaderboards())
+            )
+        ),
           ol(
-            li("have played at least 30 rated games in a given rating,"),
-            li("have played a rated game within the last week for this rating,"),
+            li(havePlayedMoreThanThirtyGamesInThatRating()),
+            li(havePlayedARatedGameAtLeastOneWeekAgo()),
             li(
-              "have a rating deviation lower than ",
-              lila.rating.Glicko.standardRankableDeviation,
-              " in standard chess, and lower than ",
-              lila.rating.Glicko.variantRankableDeviation,
-              " in variants,"
+              ratingDeviationLowerThanXinChessYinVariants(
+                lila.rating.Glicko.standardRankableDeviation,
+                lila.rating.Glicko.variantRankableDeviation
+              )
             ),
-            li("be in the top 10 in this rating.")
+            li(beInTopTen())
           ),
           p(
-            "The 2nd requirement is so that players who no longer use their accounts stop populating leaderboards."
+            secondRequirementToStopOldPlayersTrustingLeaderboards()
           )
         ),
         question(

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -49,8 +49,8 @@ object faq {
         ),
         question(
           "contributing",
-          "How can I contribute to Lichess?",
-          p("Lichess is powered by donations from patrons and the efforts of a team of volunteers."),
+          howCanIContributeToLichess.txt(),
+          p(lichessPoweredByDonationsAndVolunteers()),
           p(
             "You can find out more about ",
             a(href := routes.Plan.index())("being a patron"),

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -8,6 +8,8 @@ import lila.app.ui.ScalatagsTemplate._
 
 object faq {
 
+  import trans.faq._
+
   private val fideHandbook = "https://www.fide.com/FIDE/handbook/LawsOfChess.pdf"
 
   private def question(id: String, title: String, answer: Frag*) =
@@ -26,7 +28,7 @@ object faq {
       moreCss = cssTag("faq")
     ) {
       main(cls := "faq small-page box box-pad")(
-        h1(cls := "lichess_title")("Frequently Asked Questions"),
+        h1(cls := "lichess_title")(frequentlyAskedQuestions()),
         h2("Lichess"),
         question(
           "name",

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -237,6 +237,7 @@ object faq {
           ),
           p(
             wayOfBerserkExplanation(
+              "%",
               a(href := "https://lichess.org/tournament/cDyjj1nL")(aHourlyBulletTournament())
             )
           ),

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -32,7 +32,7 @@ object faq {
         h2("Lichess"),
         question(
           "name",
-          "Why is Lichess called Lichess?",
+          whyIsLichessCalledLichess.txt(),
           p(
             "Lichess is a combination of live/light/libre and chess. It is pronounced ",
             em("lee-chess"),

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -75,12 +75,12 @@ object faq {
             li(a(href := "https://lidraughts.org")("lidraughts.org"))
           )
         ),
-        h2("Fair Play"),
+        h2(fairPlay()),
         question(
           "marks",
-          "Why am I flagged for artificial rating manipulation (sandbagging and boosting) or computer assistance?",
+          whyFlaggedRatingManipulationOrCheater.txt(),
           p(
-            s"Lichess has strong detection methods and a very thorough process for reviewing all the evidence and making a decision. The process often involves many moderators and can take a long time. Other than the mark itself, we will not go into details about evidence or the decision making process for individual cases. Doing so would make it easier to avoid detection in the future, and be an invitation to unproductive debates. That time and effort is better spent on other important cases. Users can appeal by emailing $contactEmail, but decisions are rarely overturned."
+            cheatDetectionMethods(contactEmail)
           )
         ),
         question(

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -185,14 +185,13 @@ object faq {
         h2(accounts()),
         question(
           "titles",
-          "What titles are there on Lichess?",
+          titlesAvailableOnLichess.txt(),
           p(
-            "Lichess recognises all FIDE titles gained from OTB (over the board) play, as well as ",
+            lichessRecognizeAllOTBtitles(
             a(href := "https://github.com/ornicar/lila/wiki/Handling-title-verification-requests")(
-              "many national master titles"
-            ),
-            ". ",
-            "Here is a list of FIDE titles:"
+              asWellAsManyNMtitles()
+            )
+          )
           ),
           ul(
             li("Grandmaster (GM)"),

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -52,13 +52,11 @@ object faq {
           howCanIContributeToLichess.txt(),
           p(lichessPoweredByDonationsAndVolunteers()),
           p(
-            "You can find out more about ",
-            a(href := routes.Plan.index())("being a patron"),
-            " (including a ",
-            a(href := routes.Main.costs())("breakdown of our costs"),
-            "). If you want to help Lichess by volunteering your time and skills, there are many ",
-            a(href := routes.Page.help())("other ways to help"),
-            "."
+            findMoreAndSeeHowHelp(
+            a(href := routes.Plan.index())(beingAPatron()),
+            a(href := routes.Main.costs())(breakdownOfOurCosts()),
+            a(href := routes.Page.help())(otherWaysToHelp())
+            )
           )
         ),
         question(

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -209,25 +209,20 @@ object faq {
             a(href := "#lm")(lichessMasterLM())
             )
           )
-        )
-          ,
+        ),
         question(
           "lm",
-          "Can I get the Lichess Master (LM) title?",
-          p(strong("No.")),
-          p("This honorific title is unofficial and only exists on Lichess."),
-          p(
-            "We rarely award it to highly notable players who are good citizens of Lichess, at our discretion. You don't get the LM title, the LM title gets to you. If you qualify, you will get a message from us regarding it and the choice to accept or decline."
-          ),
-          p("Do not request to get the LM title.")
+          canIbecomeLM.txt(),
+          p(strong(noUpperCaseDot())),
+          p(lMtitleComesToYouDoNotRequestIt())
         ),
         question(
           "usernames",
-          "What can my username be?",
+          whatUsernameCanIchoose.txt(),
           p(
-            "In general, usernames should not be: offensive, impersonating someone else, or advertising. You can read more about the ",
-            a(href := "https://github.com/ornicar/lila/wiki/Username-policy")("guidelines"),
-            "."
+            usernamesNotOffensive(
+            a(href := "https://github.com/ornicar/lila/wiki/Username-policy")(guidelines())
+            )
           )
         ),
         question(

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -34,9 +34,7 @@ object faq {
           "name",
           whyIsLichessCalledLichess.txt(),
           p(
-            "Lichess is a combination of live/light/libre and chess. It is pronounced ",
-            em("lee-chess"),
-            ".",
+            lichessCombinationLiveLightLibrePronounced(em(leechess())),
             a(href := "https://www.youtube.com/watch?v=KRpPqcrdE-o")("Hear it pronounced by a specialist.")
           ),
           p(

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -146,7 +146,8 @@ object faq {
           "timeout",
           insufficientMaterial.txt(),
           p(
-            lichessFollowFIDErules(linkToFIDErules())
+            lichessFollowFIDErules(
+              a(href := fideHandbook)(linkToFIDErules()))
           )
         ),
         question(
@@ -236,7 +237,7 @@ object faq {
           ),
           p(
             wayOfBerserkExplanation(
-              a(href := "https://lichess.org/tournament/cDyjj1nL")(trans.tourname.hourlyXArena("Bullet"))
+              a(href := "https://lichess.org/tournament/cDyjj1nL")(aHourlyBulletTournament())
             )
           ),
           h4("The Golden Zee"),

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -137,31 +137,16 @@ object faq {
         ),
         question(
           "acpl",
-          """What is "average centipawn loss"?""",
+          whatIsACPL.txt(),
           p(
-            "The centipawn is the unit of measure used in chess as representation of the advantage. A centipawn is equal to 1/100th of a pawn. Therefore 100 centipawns = 1 pawn. These values play no formal role in the game but are useful to players, and essential in computer chess, for evaluating positions."
-          ),
-          p(
-            "The top computer move will lose zero centipawns, but lesser moves will result in a deterioration of the position, measured in centipawns."
-          ),
-          p(
-            "This value can be used as an indicator of the quality of play. The fewer centipawns one loses per move, the stronger the play."
-          ),
-          p("The computer analysis on Lichess is powered by Stockfish.")
+            acplExplanation()
+           )
         ),
         question(
           "timeout",
-          "Losing on time, drawing and insufficient material",
+          insufficientMaterial.txt(),
           p(
-            "In the event of one player running out of time, that player will usually lose the game. However, the game is drawn if the position is such that the opponent cannot checkmate the player's king by any possible series of legal moves (",
-            a(href := fideHandbook)("FIDE handbook §6.9, pdf"),
-            ")."
-          ),
-          p(
-            "In rare cases this can be difficult to decide automatically (forced lines, fortresses). By default we always side with the player who did not run out of time."
-          ),
-          p(
-            "Note that it can be possible to mate with a single knight or bishop if the opponent has a piece that could block the king."
+            lichessFollowFIDErules(linkToFIDErules())
           )
         ),
         question(

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -204,13 +204,13 @@ object faq {
             li("Woman Candidate Master (WCM)")
           ),
           p(
-            "If you have an OTB title, you can apply to have this displayed on your account by completing the ",
-            a(href := routes.Main.verifyTitle())("verification form"),
-            ", including a clear image of an identifying document/card and a selfie of you holding the document/card."
-          ),
-          p("Verifying as a titled player on Lichess gives access to play in the Titled Arena events."),
-          p("Finally there is an honorary ", a(href := "#lm")("Lichess Master (LM)"), " title.")
-        ),
+            showYourTitle(
+            a(href := routes.Main.verifyTitle())(verificationForm()),
+            a(href := "#lm")(lichessMasterLM())
+            )
+          )
+        )
+          ,
         question(
           "lm",
           "Can I get the Lichess Master (LM) title?",

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -35,17 +35,16 @@ object faq {
           whyIsLichessCalledLichess.txt(),
           p(
             lichessCombinationLiveLightLibrePronounced(em(leechess())),
-            a(href := "https://www.youtube.com/watch?v=KRpPqcrdE-o")("Hear it pronounced by a specialist.")
+            a(href := "https://www.youtube.com/watch?v=KRpPqcrdE-o")(hearItPronouncedBySpecialist())
           ),
           p(
-            "Live, because games are played and watched in real-time 24/7; light and libre for the fact that Lichess is open-source and unencumbered by proprietary junk that plagues other websites."
+            whyLiveLightLibre()
           ),
           p(
-            "Similarly, the source code for Lichess, ",
-            a(href := "https://github.com/ornicar/lila")("lila"),
-            ", stands for li[chess in sca]la, seeing as the bulk of Lichess is written in ",
-            a(href := "https://www.scala-lang.org/")("Scala"),
-            ", an intuitive programming language."
+            whyIsLilaCalledLila(
+              a(href := "https://github.com/ornicar/lila")("lila"),
+              a(href := "https://www.scala-lang.org/")("Scala")
+            )
           )
         ),
         question(

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -162,13 +162,12 @@ object faq {
         ),
         question(
           "threefold",
-          "Threefold repetition",
+          threefoldRepetition.txt(),
           p(
-            "If a position occurs three times, players can claim a draw by ",
-            a(href := "https://en.wikipedia.org/wiki/Threefold_repetition")("threefold repetition"),
-            ". Lichess implements the official FIDE rules, as described in Article 9.2 (d) of the ",
-            a(href := fideHandbook)("handbook (pdf)"),
-            "."
+            threefoldRepetitionExplanation(
+            a(href := "https://en.wikipedia.org/wiki/Threefold_repetition")(threefoldRepetitionLowerCase()),
+            a(href := fideHandbook)(handBookPDF())
+            )
           ),
           h4("We did not repeat moves. Why was the game still drawn by repetition?"),
           p(

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -182,7 +182,7 @@ object faq {
             )
           )
         ),
-        h2("Accounts"),
+        h2(accounts()),
         question(
           "titles",
           "What titles are there on Lichess?",

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -85,24 +85,23 @@ object faq {
         ),
         question(
           "rating-refund",
-          "When am I eligible for the automatic rating refund from cheaters?",
+          whenAmIEligibleRatinRefund.txt(),
           p(
-            "One minute after a player is marked, their 40 latest rated wins in the last 3 days are taken. If you are their opponent in those games and your rating was not provisional, you get a rating refund. The refund is capped based on your peak rating and your rating progress after the game. ",
-            "(For example, if your rating greatly increased after those games, you might get no refund or only a partial refund.) A refund will never exceed 150 points."
-          )
+            ratingRefundExplanation()
+            )
         ),
         question(
           "leaving",
-          "What is done about players leaving games without resigning?",
+          preventLeavingGameWithoutResigning.txt(),
           p(
-            """If your opponent frequently aborts/leaves games, they get "play banned", which means they're temporarily banned from playing games. This is not publically indicated on their profile. If this behaviour continues, the length of the playban increases - and prolonged behaviour of this nature may lead to account closure."""
+            leavingGameWithoutResigningExplanation()
           )
         ),
         question(
           "mod-application",
-          "How can I become a moderator?",
+          howCanIBecomeModerator.txt(),
           p(
-            "It’s not possible to apply to become a moderator. If we see someone who we think would be good as a moderator, we will contact them directly."
+            youCannotApply()
           )
         ),
         question(

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -227,26 +227,26 @@ object faq {
         ),
         question(
           "trophies",
-          "Unique trophies",
+          uniqueTrophies.txt(),
           h4("The way of Berserk"),
           p(
-            "That trophy is unique in the history of Lichess, nobody other than ",
-            a(href := "https://lichess.org/@/hiimgosu")("hiimgosu"),
-            " will ever have it."
+            ownerUniqueTrophies(
+              a(href := "https://lichess.org/@/hiimgosu")("hiimgosu")
+            )
           ),
           p(
-            "To get it, hiimgosu challenged himself to berserk and win 100% games of ",
-            a(href := "https://lichess.org/tournament/cDyjj1nL")("a hourly bullet tournament"),
-            "."
+            wayOfBerserkExplanation(
+              a(href := "https://lichess.org/tournament/cDyjj1nL")(trans.tourname.hourlyXArena("Bullet"))
+            )
           ),
           h4("The Golden Zee"),
           p(
-            "That trophy is unique in the history of Lichess, nobody other than ",
-            a(href := "https://lichess.org/@/ZugAddict")("ZugAddict"),
-            " will ever have it."
+            ownerUniqueTrophies(
+              a(href := "https://lichess.org/@/ZugAddict")("ZugAddict")
+            )
           ),
           p(
-            "ZugAddict was streaming and for the last 2 hours he had been trying to defeat A.I. level 8 in a 1+0 game, without success. Thibault told him that if he successfully did it on stream, he'd get a unique trophy. One hour later, he smashed Stockfish, and the promise was honoured."
+            goldenZeeExplanation()
           )
         ),
         h2("Lichess ratings"),

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -250,7 +250,7 @@ object faq {
             goldenZeeExplanation()
           )
         ),
-        h2("Lichess ratings"),
+        h2(lichessRatings()),
         question(
           "ratings",
           whichRatingSystemUsedByLichess.txt(),
@@ -310,28 +310,26 @@ object faq {
           howToHideRatingWhilePlaying.txt(),
           p(
             enableZenMode(
-              a(href := routes.Pref.form("game-display"))("display preferences"),
+              a(href := routes.Pref.form("game-display"))(displayPreferences()),
               em("z")
             )
           )
         ),
         question(
           "disconnection-loss",
-          "I lost a game due to lag/disconnection. Can I get my rating points back?",
+          connexionLostCanIGetMyRatingBack.txt(),
           p(
-            "Unfortunately, we cannot give back rating points for games lost due to lag or disconnection, regardless of whether the problem was at your end or our end. The latter is very rare though. Also note that when Lichess restarts and you lose on time because of that, we abort the game to prevent an unfair loss."
+            weCannotDoThatEvenIfItIsServerSideButThatsRare()
           )
         ),
-        h2("How to..."),
+        h2(howToThreeDots()),
         question(
           "browser-notifications",
-          "Enable or disable notification popups?",
-          p(img(src := assetUrl("images/connection-info.png"), alt := "View site information popup")),
+          enableDisableNotificationPopUps.txt(),
+          p(img(src := assetUrl("images/connection-info.png"), alt := viewSiteInformationPopUp.txt())),
           p(
-            "Lichess can optionally send popup notifications, for example when it is your turn or you received a private message."
-          ),
-          p("Click the lock icon next to the lichess.org address in the URL bar of your browser."),
-          p("Then select whether to allow or block notifications from Lichess.")
+            lichessCanOptionnalySendPopUps()
+          )
         )
       )
     }

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -61,15 +61,13 @@ object faq {
         ),
         question(
           "sites_based_on_Lichess",
-          "Are there websites based on Lichess?",
+          areThereWebsitesBasedOnLichess.txt(),
           p(
-            "Yes. Lichess has indeed inspired other open-source sites that use our ",
-            a(href := "/source")("source code"),
-            ", ",
+            yesLichessInspiredOtherOpenSourceWebsites(
+            a(href := "/source")(trans.sourceCode()),
             a(href := "/api")("API"),
-            ", or ",
-            a(href := "https://database.lichess.org")("database"),
-            "."
+            a(href := "https://database.lichess.org")(trans.database())
+            )
           ),
           ul(
             li(a(href := "https://blitztactics.com/about")("Blitz Tactics")),

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -106,20 +106,17 @@ object faq {
         ),
         question(
           "correspondence",
-          "Is correspondence different from normal chess?",
+          isCorrespondenceDifferent.txt(),
           p(
-            "On Lichess, the main difference in rules for correspondence chess is that an opening book is allowed. The use of engines is still prohibited and will result in being flagged for engine assistance. Although ICCF allows engine use in correspondence, Lichess does not."
+            youCanUseOpeningBookNoEngine()
           )
         ),
         h2("Gameplay"),
         question(
           "time-controls",
-          "How are Bullet, Blitz and other time controls decided?",
+          howBulletBlitzEtcDecided.txt(),
           p(
-            "Lichess time controls are based on estimated game duration = ",
-            strong("(clock initial time) + 40 * (clock increment)"),
-            br,
-            "For instance, the estimated duration of a 5+3 game is 5 * 60 + 40 * 3 = 420 seconds."
+            basedOnGameDuration(strong(durationFormula()))
           ),
           ul(
             li("< 30s = UltraBullet"),

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -151,23 +151,13 @@ object faq {
         ),
         question(
           "en-passant",
-          "Why can a pawn capture another pawn when it is already passed? (en passant)",
+          discoveringEnPassant.txt(),
           p(
-            """This is a legal move known as "en passant". The Wikipedia article gives a """,
-            a(href := "https://en.wikipedia.org/wiki/En_passant")("good introduction.")
-          ),
-          p(
-            "It is described in section 3.7 (d) of the ",
-            a(href := fideHandbook)("official rules (pdf)"),
-            ":"
-          ),
-          p(
-            """"A pawn occupying a square on the same rank as and on an adjacent file to an opponent’s pawn which has just advanced two squares in one move from its original square may capture this opponent’s pawn as though the latter had been moved only one square. This capture is only legal on the move following this advance and is called an ‘en passant’ capture.""""
-          ),
-          p(
-            "See the ",
-            a(href := s"${routes.Learn.index()}#/15")("Lichess training"),
-            " on this move for some practice with it."
+            explainingEnPassant(
+            a(href := "https://en.wikipedia.org/wiki/En_passant")(goodIntroduction()),
+            a(href := fideHandbook)(officialRulesPDF()),
+            a(href := s"${routes.Learn.index()}#/15")(lichessTraining())
+            )
           )
         ),
         question(

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -128,11 +128,11 @@ object faq {
         ),
         question(
           "variants",
-          "What variants can I play on Lichess?",
+          whatVariantsCanIplay.txt(),
           p(
-            "Lichess supports standard chess and ",
-            a(href := routes.Page.variantHome())("8 chess variants"),
-            "."
+            lichessSupportChessAnd(
+            a(href := routes.Page.variantHome())(eightVariants())
+            )
           )
         ),
         question(

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -53,9 +53,9 @@ object faq {
           p(lichessPoweredByDonationsAndVolunteers()),
           p(
             findMoreAndSeeHowHelp(
-            a(href := routes.Plan.index())(beingAPatron()),
-            a(href := routes.Main.costs())(breakdownOfOurCosts()),
-            a(href := routes.Page.help())(otherWaysToHelp())
+              a(href := routes.Plan.index())(beingAPatron()),
+              a(href := routes.Main.costs())(breakdownOfOurCosts()),
+              a(href := routes.Page.help())(otherWaysToHelp())
             )
           )
         ),
@@ -64,9 +64,9 @@ object faq {
           areThereWebsitesBasedOnLichess.txt(),
           p(
             yesLichessInspiredOtherOpenSourceWebsites(
-            a(href := "/source")(trans.sourceCode()),
-            a(href := "/api")("API"),
-            a(href := "https://database.lichess.org")(trans.database())
+              a(href := "/source")(trans.sourceCode()),
+              a(href := "/api")("API"),
+              a(href := "https://database.lichess.org")(trans.database())
             )
           ),
           ul(
@@ -88,7 +88,7 @@ object faq {
           whenAmIEligibleRatinRefund.txt(),
           p(
             ratingRefundExplanation()
-            )
+          )
         ),
         question(
           "leaving",
@@ -119,11 +119,11 @@ object faq {
             basedOnGameDuration(strong(durationFormula()))
           ),
           ul(
-            li(inferiorThanXsEqualYtimeControl(30,"UltraBullet")),
-            li(inferiorThanXsEqualYtimeControl(180,"Bullet")),
-            li(inferiorThanXsEqualYtimeControl(480,"Blitz")),
-            li(inferiorThanXsEqualYtimeControl(1500,trans.rapid())),
-            li(superiorThanXsEqualYtimeControl(1500,trans.classical()))
+            li(inferiorThanXsEqualYtimeControl(30, "UltraBullet")),
+            li(inferiorThanXsEqualYtimeControl(180, "Bullet")),
+            li(inferiorThanXsEqualYtimeControl(480, "Blitz")),
+            li(inferiorThanXsEqualYtimeControl(1500, trans.rapid())),
+            li(superiorThanXsEqualYtimeControl(1500, trans.classical()))
           )
         ),
         question(
@@ -131,7 +131,7 @@ object faq {
           whatVariantsCanIplay.txt(),
           p(
             lichessSupportChessAnd(
-            a(href := routes.Page.variantHome())(eightVariants())
+              a(href := routes.Page.variantHome())(eightVariants())
             )
           )
         ),
@@ -140,14 +140,13 @@ object faq {
           whatIsACPL.txt(),
           p(
             acplExplanation()
-           )
+          )
         ),
         question(
           "timeout",
           insufficientMaterial.txt(),
           p(
-            lichessFollowFIDErules(
-              a(href := fideHandbook)(linkToFIDErules()))
+            lichessFollowFIDErules(a(href := fideHandbook)(linkToFIDErules()))
           )
         ),
         question(
@@ -155,9 +154,9 @@ object faq {
           discoveringEnPassant.txt(),
           p(
             explainingEnPassant(
-            a(href := "https://en.wikipedia.org/wiki/En_passant")(goodIntroduction()),
-            a(href := fideHandbook)(officialRulesPDF()),
-            a(href := s"${routes.Learn.index()}#/15")(lichessTraining())
+              a(href := "https://en.wikipedia.org/wiki/En_passant")(goodIntroduction()),
+              a(href := fideHandbook)(officialRulesPDF()),
+              a(href := s"${routes.Learn.index()}#/15")(lichessTraining())
             )
           )
         ),
@@ -166,8 +165,8 @@ object faq {
           threefoldRepetition.txt(),
           p(
             threefoldRepetitionExplanation(
-            a(href := "https://en.wikipedia.org/wiki/Threefold_repetition")(threefoldRepetitionLowerCase()),
-            a(href := fideHandbook)(handBookPDF())
+              a(href := "https://en.wikipedia.org/wiki/Threefold_repetition")(threefoldRepetitionLowerCase()),
+              a(href := fideHandbook)(handBookPDF())
             )
           ),
           h4(notRepeatedMoves()),
@@ -179,7 +178,7 @@ object faq {
           h4(weRepeatedthreeTimesPosButNoDraw()),
           p(
             threeFoldHasToBeClaimed(
-              a(href := routes.Pref.form("game-behavior"))(configure()),
+              a(href := routes.Pref.form("game-behavior"))(configure())
             )
           )
         ),
@@ -189,10 +188,10 @@ object faq {
           titlesAvailableOnLichess.txt(),
           p(
             lichessRecognizeAllOTBtitles(
-            a(href := "https://github.com/ornicar/lila/wiki/Handling-title-verification-requests")(
-              asWellAsManyNMtitles()
+              a(href := "https://github.com/ornicar/lila/wiki/Handling-title-verification-requests")(
+                asWellAsManyNMtitles()
+              )
             )
-          )
           ),
           ul(
             li("Grandmaster (GM)"),
@@ -206,8 +205,8 @@ object faq {
           ),
           p(
             showYourTitle(
-            a(href := routes.Main.verifyTitle())(verificationForm()),
-            a(href := "#lm")(lichessMasterLM())
+              a(href := routes.Main.verifyTitle())(verificationForm()),
+              a(href := "#lm")(lichessMasterLM())
             )
           )
         ),
@@ -222,7 +221,7 @@ object faq {
           whatUsernameCanIchoose.txt(),
           p(
             usernamesNotOffensive(
-            a(href := "https://github.com/ornicar/lila/wiki/Username-policy")(guidelines())
+              a(href := "https://github.com/ornicar/lila/wiki/Username-policy")(guidelines())
             )
           )
         ),
@@ -267,7 +266,7 @@ object faq {
             li(
               notPlayedEnoughRatedGamesAgainstX(
                 em(similarOpponents())
-              ) 
+              )
             ),
             li(
               notPlayedRecently()
@@ -280,10 +279,11 @@ object faq {
         question(
           "leaderboards",
           howDoLeaderoardsWork.txt(),
-          p(inOrderToAppearsYouMust(
-            a(href := routes.User.list())(ratingLeaderboards())
+          p(
+            inOrderToAppearsYouMust(
+              a(href := routes.User.list())(ratingLeaderboards())
             )
-        ),
+          ),
           ol(
             li(havePlayedMoreThanThirtyGamesInThatRating()),
             li(havePlayedARatedGameAtLeastOneWeekAgo()),

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -300,23 +300,19 @@ object faq {
         ),
         question(
           "high-ratings",
-          "Why are ratings higher compared to other sites and organisations such as FIDE, USCF and the ICC?",
+          whyAreRatingHigher.txt(),
           p(
-            "It is best not to think of ratings as absolute numbers, or compare them against other organisations. Different organisations have different levels of players, different rating systems (Elo, Glicko, Glicko-2, or a modified version of the aforementioned). These factors can drastically affect the absolute numbers (ratings)."
-          ),
-          p(
-            """It's best to think of ratings as "relative" figures (as opposed to "absolute" figures): Within a pool of players, their relative differences in ratings will help you estimate who will win/draw/lose, and how often. Saying "I have X rating" means nothing unless there are other players to compare that rating to."""
+            whyAreRatingHigherExplanation()
           )
         ),
         question(
           "hide-ratings",
-          "How to hide ratings while playing?",
+          howToHideRatingWhilePlaying.txt(),
           p(
-            "Enable Zen-mode in the ",
-            a(href := routes.Pref.form("game-display"))("display preferences"),
-            " or by pressing ",
-            em("z"),
-            " during a game."
+            enableZenMode(
+              a(href := routes.Pref.form("game-display"))("display preferences"),
+              em("z")
+            )
           )
         ),
         question(

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -169,17 +169,17 @@ object faq {
             a(href := fideHandbook)(handBookPDF())
             )
           ),
-          h4("We did not repeat moves. Why was the game still drawn by repetition?"),
+          h4(notRepeatedMoves()),
           p(
-            "Threefold repetition is about repeated ",
-            em("positions"),
-            ", not moves. Repetition does not have to occur consecutively."
+            repeatedPositionsThatMatters(
+              em(positions())
+            )
           ),
-          h4("We repeated a position three times. Why was the game not drawn?"),
+          h4(weRepeatedthreeTimesPosButNoDraw()),
           p(
-            "Repetition needs to be claimed by one of the players. You can do so by pressing the button that is shown, or by offering a draw before your final repeating move. You can also ",
-            a(href := routes.Pref.form("game-behavior"))("configure"),
-            " Lichess to automatically claim repetitions for you. Additionally, fivefold repetition always immediately ends the game."
+            threeFoldHasToBeClaimed(
+              a(href := routes.Pref.form("game-behavior"))(configure()),
+            )
           )
         ),
         h2("Accounts"),

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -253,36 +253,27 @@ object faq {
         h2("Lichess ratings"),
         question(
           "ratings",
-          "What rating system does Lichess use?",
+          whichRatingSystemUsedByLichess.txt(),
           p(
-            "Ratings are calculated using the Glicko-2 rating method developed by Mark Glickman. This is a very popular rating method, and is used by a significant number of chess organisations (FIDE being a notable counter-example, as they still use the dated Elo rating system)."
-          ),
-          p(
-            """Fundamentally, Glicko ratings use "confidence intervals" when calculating and representing your rating. When you first start using the site, your rating starts at 1500 ± 700. The 1500 represents your rating, and the 700 represents the confidence interval."""
-          ),
-          p(
-            "Basically, the system is 90% sure that your rating is somewhere between 800 and 2200. It is incredibly uncertain. Because of this, when a player is just starting out, their rating will change very dramatically, potentially several hundred points at a time. But after some games against established players the confidence interval will narrow, and the amount of points gained/lost after each game will decrease."
-          ),
-          p(
-            "Another point to note is that, as time passes, the confidence interval will increase. This allows you to gain/lose points points more rapidly to match any changes in your skill level over that time."
+            ratingSystemUsedByLichess()
           )
         ),
         question(
           "provisional",
-          "Why is there a question mark (?) next to a rating?",
-          p("The question mark means the rating is provisional. Reasons include:"),
+          whatIsProvisionalRating.txt(),
+          p(provisionalRatingExplanation()),
           ul(
             li(
-              "The player has not yet finished enough rated games against ",
-              em("opponents of similar strength"),
-              " in the rating category."
+              notPlayedEnoughRatedGamesAgainstX(
+                em(similarOpponents())
+              ) 
             ),
             li(
-              "The player hasn't played enough recent games. Depending on the number of games you've played, it might take around a year of inactivity for your rating to become provisional again."
+              notPlayedRecently()
             )
           ),
           p(
-            "Concretely, it means that the Glicko-2 deviation is greater than 110. The deviation is the level of confidence the system has in the rating. The lower the deviation, the more stable is a rating."
+            ratingDeviationMorethanOneHundredTen()
           )
         ),
         question(

--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -119,11 +119,11 @@ object faq {
             basedOnGameDuration(strong(durationFormula()))
           ),
           ul(
-            li("< 30s = UltraBullet"),
-            li("< 180s = Bullet"),
-            li("< 480s = Blitz"),
-            li("< 1500s = Rapid"),
-            li(">= 1500s = Classical")
+            li(inferiorThanXsEqualYtimeControl(30,"UltraBullet")),
+            li(inferiorThanXsEqualYtimeControl(180,"Bullet")),
+            li(inferiorThanXsEqualYtimeControl(480,"Blitz")),
+            li(inferiorThanXsEqualYtimeControl(1500,trans.rapid())),
+            li(superiorThanXsEqualYtimeControl(1500,trans.classical()))
           )
         ),
         question(

--- a/bin/trans-dump.js
+++ b/bin/trans-dump.js
@@ -2,7 +2,7 @@ const fs = require('fs-extra');
 const parseString = require('xml2js').parseString;
 
 const baseDir = 'translation/source';
-const dbs = 'site arena emails learn activity coordinates study clas contact patron coach broadcast streamer tfa settings preferences team perfStat search tourname'.split(' ');
+const dbs = 'site arena emails learn activity coordinates study clas contact patron coach broadcast streamer tfa settings preferences team perfStat search tourname faq'.split(' ');
 
 function ucfirst(s) {
   return s.charAt(0).toUpperCase() + s.slice(1);

--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,7 @@ lazy val i18n = module("i18n",
     MessageCompiler(
       sourceDir = new File("translation/source"),
       destDir = new File("translation/dest"),
-      dbs = "site arena emails learn activity coordinates study class contact patron coach broadcast streamer tfa settings preferences team perfStat search tourname".split(' ').toList,
+      dbs = "site arena emails learn activity coordinates study class contact patron coach broadcast streamer tfa settings preferences team perfStat search tourname faq".split(' ').toList,
       compileTo = (sourceManaged in Compile).value
     )
   }.taskValue,

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1676,6 +1676,11 @@ val `superiorThanXsEqualYtimeControl` = new I18nKey("faq:superiorThanXsEqualYtim
 val `whatVariantsCanIplay` = new I18nKey("faq:whatVariantsCanIplay")
 val `lichessSupportChessAnd` = new I18nKey("faq:lichessSupportChessAnd")
 val `eightVariants` = new I18nKey("faq:eightVariants")
+val `whatIsACPL` = new I18nKey("faq:whatIsACPL")
+val `acplExplanation` = new I18nKey("faq:acplExplanation")
+val `insufficientMaterial` = new I18nKey("faq:insufficientMaterial")
+val `lichessFollowFIDErules` = new I18nKey("faq:lichessFollowFIDErules")
+val `linkToFIDErules` = new I18nKey("faq:linkToFIDErules")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1641,4 +1641,8 @@ val `eliteX` = new I18nKey("tourname:eliteX")
 val `xArena` = new I18nKey("tourname:xArena")
 }
 
+object faq {
+val `frequentlyAskedQuestions` = new I18nKey("faq:frequentlyAskedQuestions")
+}
+
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1657,6 +1657,9 @@ val `breakdownOfOurCosts` = new I18nKey("faq:breakdownOfOurCosts")
 val `otherWaysToHelp` = new I18nKey("faq:otherWaysToHelp")
 val `areThereWebsitesBasedOnLichess` = new I18nKey("faq:areThereWebsitesBasedOnLichess")
 val `yesLichessInspiredOtherOpenSourceWebsites` = new I18nKey("faq:yesLichessInspiredOtherOpenSourceWebsites")
+val `fairPlay` = new I18nKey("faq:fairPlay")
+val `whyFlaggedRatingManipulationOrCheater` = new I18nKey("faq:whyFlaggedRatingManipulationOrCheater")
+val `cheatDetectionMethods` = new I18nKey("faq:cheatDetectionMethods")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1666,6 +1666,11 @@ val `preventLeavingGameWithoutResigning` = new I18nKey("faq:preventLeavingGameWi
 val `leavingGameWithoutResigningExplanation` = new I18nKey("faq:leavingGameWithoutResigningExplanation")
 val `howCanIBecomeModerator` = new I18nKey("faq:howCanIBecomeModerator")
 val `youCannotApply` = new I18nKey("faq:youCannotApply")
+val `isCorrespondenceDifferent` = new I18nKey("faq:isCorrespondenceDifferent")
+val `youCanUseOpeningBookNoEngine` = new I18nKey("faq:youCanUseOpeningBookNoEngine")
+val `howBulletBlitzEtcDecided` = new I18nKey("faq:howBulletBlitzEtcDecided")
+val `basedOnGameDuration` = new I18nKey("faq:basedOnGameDuration")
+val `durationFormula` = new I18nKey("faq:durationFormula")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1690,6 +1690,12 @@ val `threefoldRepetition` = new I18nKey("faq:threefoldRepetition")
 val `threefoldRepetitionExplanation` = new I18nKey("faq:threefoldRepetitionExplanation")
 val `threefoldRepetitionLowerCase` = new I18nKey("faq:threefoldRepetitionLowerCase")
 val `handBookPDF` = new I18nKey("faq:handBookPDF")
+val `notRepeatedMoves` = new I18nKey("faq:notRepeatedMoves")
+val `repeatedPositionsThatMatters` = new I18nKey("faq:repeatedPositionsThatMatters")
+val `positions` = new I18nKey("faq:positions")
+val `weRepeatedthreeTimesPosButNoDraw` = new I18nKey("faq:weRepeatedthreeTimesPosButNoDraw")
+val `threeFoldHasToBeClaimed` = new I18nKey("faq:threeFoldHasToBeClaimed")
+val `configure` = new I18nKey("faq:configure")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1651,6 +1651,10 @@ val `whyLiveLightLibre` = new I18nKey("faq:whyLiveLightLibre")
 val `whyIsLilaCalledLila` = new I18nKey("faq:whyIsLilaCalledLila")
 val `howCanIContributeToLichess` = new I18nKey("faq:howCanIContributeToLichess")
 val `lichessPoweredByDonationsAndVolunteers` = new I18nKey("faq:lichessPoweredByDonationsAndVolunteers")
+val `findMoreAndSeeHowHelp` = new I18nKey("faq:findMoreAndSeeHowHelp")
+val `beingAPatron` = new I18nKey("faq:beingAPatron")
+val `breakdownOfOurCosts` = new I18nKey("faq:breakdownOfOurCosts")
+val `otherWaysToHelp` = new I18nKey("faq:otherWaysToHelp")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1709,6 +1709,10 @@ val `lMtitleComesToYouDoNotRequestIt` = new I18nKey("faq:lMtitleComesToYouDoNotR
 val `whatUsernameCanIchoose` = new I18nKey("faq:whatUsernameCanIchoose")
 val `usernamesNotOffensive` = new I18nKey("faq:usernamesNotOffensive")
 val `guidelines` = new I18nKey("faq:guidelines")
+val `uniqueTrophies` = new I18nKey("faq:uniqueTrophies")
+val `ownerUniqueTrophies` = new I18nKey("faq:ownerUniqueTrophies")
+val `wayOfBerserkExplanation` = new I18nKey("faq:wayOfBerserkExplanation")
+val `goldenZeeExplanation` = new I18nKey("faq:goldenZeeExplanation")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1696,6 +1696,7 @@ val `positions` = new I18nKey("faq:positions")
 val `weRepeatedthreeTimesPosButNoDraw` = new I18nKey("faq:weRepeatedthreeTimesPosButNoDraw")
 val `threeFoldHasToBeClaimed` = new I18nKey("faq:threeFoldHasToBeClaimed")
 val `configure` = new I18nKey("faq:configure")
+val `accounts` = new I18nKey("faq:accounts")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1646,6 +1646,9 @@ val `frequentlyAskedQuestions` = new I18nKey("faq:frequentlyAskedQuestions")
 val `whyIsLichessCalledLichess` = new I18nKey("faq:whyIsLichessCalledLichess")
 val `lichessCombinationLiveLightLibrePronounced` = new I18nKey("faq:lichessCombinationLiveLightLibrePronounced")
 val `leechess` = new I18nKey("faq:leechess")
+val `hearItPronouncedBySpecialist` = new I18nKey("faq:hearItPronouncedBySpecialist")
+val `whyLiveLightLibre` = new I18nKey("faq:whyLiveLightLibre")
+val `whyIsLilaCalledLila` = new I18nKey("faq:whyIsLilaCalledLila")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1699,7 +1699,10 @@ val `configure` = new I18nKey("faq:configure")
 val `accounts` = new I18nKey("faq:accounts")
 val `titlesAvailableOnLichess` = new I18nKey("faq:titlesAvailableOnLichess")
 val `lichessRecognizeAllOTBtitles` = new I18nKey("faq:lichessRecognizeAllOTBtitles")
+val `showYourTitle` = new I18nKey("faq:showYourTitle")
 val `asWellAsManyNMtitles` = new I18nKey("faq:asWellAsManyNMtitles")
+val `verificationForm` = new I18nKey("faq:verificationForm")
+val `lichessMasterLM` = new I18nKey("faq:lichessMasterLM")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1703,6 +1703,12 @@ val `showYourTitle` = new I18nKey("faq:showYourTitle")
 val `asWellAsManyNMtitles` = new I18nKey("faq:asWellAsManyNMtitles")
 val `verificationForm` = new I18nKey("faq:verificationForm")
 val `lichessMasterLM` = new I18nKey("faq:lichessMasterLM")
+val `canIbecomeLM` = new I18nKey("faq:canIbecomeLM")
+val `noUpperCaseDot` = new I18nKey("faq:noUpperCaseDot")
+val `lMtitleComesToYouDoNotRequestIt` = new I18nKey("faq:lMtitleComesToYouDoNotRequestIt")
+val `whatUsernameCanIchoose` = new I18nKey("faq:whatUsernameCanIchoose")
+val `usernamesNotOffensive` = new I18nKey("faq:usernamesNotOffensive")
+val `guidelines` = new I18nKey("faq:guidelines")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1643,6 +1643,7 @@ val `xArena` = new I18nKey("tourname:xArena")
 
 object faq {
 val `frequentlyAskedQuestions` = new I18nKey("faq:frequentlyAskedQuestions")
+val `whyIsLichessCalledLichess` = new I18nKey("faq:whyIsLichessCalledLichess")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1730,6 +1730,11 @@ val `havePlayedARatedGameAtLeastOneWeekAgo` = new I18nKey("faq:havePlayedARatedG
 val `ratingDeviationLowerThanXinChessYinVariants` = new I18nKey("faq:ratingDeviationLowerThanXinChessYinVariants")
 val `beInTopTen` = new I18nKey("faq:beInTopTen")
 val `secondRequirementToStopOldPlayersTrustingLeaderboards` = new I18nKey("faq:secondRequirementToStopOldPlayersTrustingLeaderboards")
+val `whyAreRatingHigher` = new I18nKey("faq:whyAreRatingHigher")
+val `whyAreRatingHigherExplanation` = new I18nKey("faq:whyAreRatingHigherExplanation")
+val `howToHideRatingWhilePlaying` = new I18nKey("faq:howToHideRatingWhilePlaying")
+val `enableZenMode` = new I18nKey("faq:enableZenMode")
+val `displayPreferences` = new I18nKey("faq:displayPreferences")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1681,6 +1681,11 @@ val `acplExplanation` = new I18nKey("faq:acplExplanation")
 val `insufficientMaterial` = new I18nKey("faq:insufficientMaterial")
 val `lichessFollowFIDErules` = new I18nKey("faq:lichessFollowFIDErules")
 val `linkToFIDErules` = new I18nKey("faq:linkToFIDErules")
+val `discoveringEnPassant` = new I18nKey("faq:discoveringEnPassant")
+val `explainingEnPassant` = new I18nKey("faq:explainingEnPassant")
+val `goodIntroduction` = new I18nKey("faq:goodIntroduction")
+val `officialRulesPDF` = new I18nKey("faq:officialRulesPDF")
+val `lichessTraining` = new I18nKey("faq:lichessTraining")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1644,6 +1644,8 @@ val `xArena` = new I18nKey("tourname:xArena")
 object faq {
 val `frequentlyAskedQuestions` = new I18nKey("faq:frequentlyAskedQuestions")
 val `whyIsLichessCalledLichess` = new I18nKey("faq:whyIsLichessCalledLichess")
+val `lichessCombinationLiveLightLibrePronounced` = new I18nKey("faq:lichessCombinationLiveLightLibrePronounced")
+val `leechess` = new I18nKey("faq:leechess")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1697,6 +1697,9 @@ val `weRepeatedthreeTimesPosButNoDraw` = new I18nKey("faq:weRepeatedthreeTimesPo
 val `threeFoldHasToBeClaimed` = new I18nKey("faq:threeFoldHasToBeClaimed")
 val `configure` = new I18nKey("faq:configure")
 val `accounts` = new I18nKey("faq:accounts")
+val `titlesAvailableOnLichess` = new I18nKey("faq:titlesAvailableOnLichess")
+val `lichessRecognizeAllOTBtitles` = new I18nKey("faq:lichessRecognizeAllOTBtitles")
+val `asWellAsManyNMtitles` = new I18nKey("faq:asWellAsManyNMtitles")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1671,6 +1671,8 @@ val `youCanUseOpeningBookNoEngine` = new I18nKey("faq:youCanUseOpeningBookNoEngi
 val `howBulletBlitzEtcDecided` = new I18nKey("faq:howBulletBlitzEtcDecided")
 val `basedOnGameDuration` = new I18nKey("faq:basedOnGameDuration")
 val `durationFormula` = new I18nKey("faq:durationFormula")
+val `inferiorThanXsEqualYtimeControl` = new I18nKey("faq:inferiorThanXsEqualYtimeControl")
+val `superiorThanXsEqualYtimeControl` = new I18nKey("faq:superiorThanXsEqualYtimeControl")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1714,6 +1714,14 @@ val `ownerUniqueTrophies` = new I18nKey("faq:ownerUniqueTrophies")
 val `wayOfBerserkExplanation` = new I18nKey("faq:wayOfBerserkExplanation")
 val `aHourlyBulletTournament` = new I18nKey("faq:aHourlyBulletTournament")
 val `goldenZeeExplanation` = new I18nKey("faq:goldenZeeExplanation")
+val `whichRatingSystemUsedByLichess` = new I18nKey("faq:whichRatingSystemUsedByLichess")
+val `ratingSystemUsedByLichess` = new I18nKey("faq:ratingSystemUsedByLichess")
+val `whatIsProvisionalRating` = new I18nKey("faq:whatIsProvisionalRating")
+val `provisionalRatingExplanation` = new I18nKey("faq:provisionalRatingExplanation")
+val `notPlayedEnoughRatedGamesAgainstX` = new I18nKey("faq:notPlayedEnoughRatedGamesAgainstX")
+val `similarOpponents` = new I18nKey("faq:similarOpponents")
+val `notPlayedRecently` = new I18nKey("faq:notPlayedRecently")
+val `ratingDeviationMorethanOneHundredTen` = new I18nKey("faq:ratingDeviationMorethanOneHundredTen")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1673,6 +1673,9 @@ val `basedOnGameDuration` = new I18nKey("faq:basedOnGameDuration")
 val `durationFormula` = new I18nKey("faq:durationFormula")
 val `inferiorThanXsEqualYtimeControl` = new I18nKey("faq:inferiorThanXsEqualYtimeControl")
 val `superiorThanXsEqualYtimeControl` = new I18nKey("faq:superiorThanXsEqualYtimeControl")
+val `whatVariantsCanIplay` = new I18nKey("faq:whatVariantsCanIplay")
+val `lichessSupportChessAnd` = new I18nKey("faq:lichessSupportChessAnd")
+val `eightVariants` = new I18nKey("faq:eightVariants")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1649,6 +1649,8 @@ val `leechess` = new I18nKey("faq:leechess")
 val `hearItPronouncedBySpecialist` = new I18nKey("faq:hearItPronouncedBySpecialist")
 val `whyLiveLightLibre` = new I18nKey("faq:whyLiveLightLibre")
 val `whyIsLilaCalledLila` = new I18nKey("faq:whyIsLilaCalledLila")
+val `howCanIContributeToLichess` = new I18nKey("faq:howCanIContributeToLichess")
+val `lichessPoweredByDonationsAndVolunteers` = new I18nKey("faq:lichessPoweredByDonationsAndVolunteers")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1686,6 +1686,10 @@ val `explainingEnPassant` = new I18nKey("faq:explainingEnPassant")
 val `goodIntroduction` = new I18nKey("faq:goodIntroduction")
 val `officialRulesPDF` = new I18nKey("faq:officialRulesPDF")
 val `lichessTraining` = new I18nKey("faq:lichessTraining")
+val `threefoldRepetition` = new I18nKey("faq:threefoldRepetition")
+val `threefoldRepetitionExplanation` = new I18nKey("faq:threefoldRepetitionExplanation")
+val `threefoldRepetitionLowerCase` = new I18nKey("faq:threefoldRepetitionLowerCase")
+val `handBookPDF` = new I18nKey("faq:handBookPDF")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1660,6 +1660,12 @@ val `yesLichessInspiredOtherOpenSourceWebsites` = new I18nKey("faq:yesLichessIns
 val `fairPlay` = new I18nKey("faq:fairPlay")
 val `whyFlaggedRatingManipulationOrCheater` = new I18nKey("faq:whyFlaggedRatingManipulationOrCheater")
 val `cheatDetectionMethods` = new I18nKey("faq:cheatDetectionMethods")
+val `whenAmIEligibleRatinRefund` = new I18nKey("faq:whenAmIEligibleRatinRefund")
+val `ratingRefundExplanation` = new I18nKey("faq:ratingRefundExplanation")
+val `preventLeavingGameWithoutResigning` = new I18nKey("faq:preventLeavingGameWithoutResigning")
+val `leavingGameWithoutResigningExplanation` = new I18nKey("faq:leavingGameWithoutResigningExplanation")
+val `howCanIBecomeModerator` = new I18nKey("faq:howCanIBecomeModerator")
+val `youCannotApply` = new I18nKey("faq:youCannotApply")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1655,6 +1655,8 @@ val `findMoreAndSeeHowHelp` = new I18nKey("faq:findMoreAndSeeHowHelp")
 val `beingAPatron` = new I18nKey("faq:beingAPatron")
 val `breakdownOfOurCosts` = new I18nKey("faq:breakdownOfOurCosts")
 val `otherWaysToHelp` = new I18nKey("faq:otherWaysToHelp")
+val `areThereWebsitesBasedOnLichess` = new I18nKey("faq:areThereWebsitesBasedOnLichess")
+val `yesLichessInspiredOtherOpenSourceWebsites` = new I18nKey("faq:yesLichessInspiredOtherOpenSourceWebsites")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1722,6 +1722,14 @@ val `notPlayedEnoughRatedGamesAgainstX` = new I18nKey("faq:notPlayedEnoughRatedG
 val `similarOpponents` = new I18nKey("faq:similarOpponents")
 val `notPlayedRecently` = new I18nKey("faq:notPlayedRecently")
 val `ratingDeviationMorethanOneHundredTen` = new I18nKey("faq:ratingDeviationMorethanOneHundredTen")
+val `howDoLeaderoardsWork` = new I18nKey("faq:howDoLeaderoardsWork")
+val `inOrderToAppearsYouMust` = new I18nKey("faq:inOrderToAppearsYouMust")
+val `ratingLeaderboards` = new I18nKey("faq:ratingLeaderboards")
+val `havePlayedMoreThanThirtyGamesInThatRating` = new I18nKey("faq:havePlayedMoreThanThirtyGamesInThatRating")
+val `havePlayedARatedGameAtLeastOneWeekAgo` = new I18nKey("faq:havePlayedARatedGameAtLeastOneWeekAgo")
+val `ratingDeviationLowerThanXinChessYinVariants` = new I18nKey("faq:ratingDeviationLowerThanXinChessYinVariants")
+val `beInTopTen` = new I18nKey("faq:beInTopTen")
+val `secondRequirementToStopOldPlayersTrustingLeaderboards` = new I18nKey("faq:secondRequirementToStopOldPlayersTrustingLeaderboards")
 }
 
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1712,6 +1712,7 @@ val `guidelines` = new I18nKey("faq:guidelines")
 val `uniqueTrophies` = new I18nKey("faq:uniqueTrophies")
 val `ownerUniqueTrophies` = new I18nKey("faq:ownerUniqueTrophies")
 val `wayOfBerserkExplanation` = new I18nKey("faq:wayOfBerserkExplanation")
+val `aHourlyBulletTournament` = new I18nKey("faq:aHourlyBulletTournament")
 val `goldenZeeExplanation` = new I18nKey("faq:goldenZeeExplanation")
 }
 

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1714,6 +1714,7 @@ val `ownerUniqueTrophies` = new I18nKey("faq:ownerUniqueTrophies")
 val `wayOfBerserkExplanation` = new I18nKey("faq:wayOfBerserkExplanation")
 val `aHourlyBulletTournament` = new I18nKey("faq:aHourlyBulletTournament")
 val `goldenZeeExplanation` = new I18nKey("faq:goldenZeeExplanation")
+val `lichessRatings` = new I18nKey("faq:lichessRatings")
 val `whichRatingSystemUsedByLichess` = new I18nKey("faq:whichRatingSystemUsedByLichess")
 val `ratingSystemUsedByLichess` = new I18nKey("faq:ratingSystemUsedByLichess")
 val `whatIsProvisionalRating` = new I18nKey("faq:whatIsProvisionalRating")
@@ -1735,6 +1736,12 @@ val `whyAreRatingHigherExplanation` = new I18nKey("faq:whyAreRatingHigherExplana
 val `howToHideRatingWhilePlaying` = new I18nKey("faq:howToHideRatingWhilePlaying")
 val `enableZenMode` = new I18nKey("faq:enableZenMode")
 val `displayPreferences` = new I18nKey("faq:displayPreferences")
+val `connexionLostCanIGetMyRatingBack` = new I18nKey("faq:connexionLostCanIGetMyRatingBack")
+val `weCannotDoThatEvenIfItIsServerSideButThatsRare` = new I18nKey("faq:weCannotDoThatEvenIfItIsServerSideButThatsRare")
+val `howToThreeDots` = new I18nKey("faq:howToThreeDots")
+val `enableDisableNotificationPopUps` = new I18nKey("faq:enableDisableNotificationPopUps")
+val `viewSiteInformationPopUp` = new I18nKey("faq:viewSiteInformationPopUp")
+val `lichessCanOptionnalySendPopUps` = new I18nKey("faq:lichessCanOptionnalySendPopUps")
 }
 
 }

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -4,4 +4,7 @@
   <string name="whyIsLichessCalledLichess">Why is Lichess called Lichess?</string>
   <string name="lichessCombinationLiveLightLibrePronounced">Lichess is a combination of live/light/libre and chess. It is pronounced %1$s.</string>
   <string name="leechess">lee-chess</string>
+  <string name="hearItPronouncedBySpecialist">Hear it pronounced by a specialist.</string>
+  <string name="whyLiveLightLibre">Live, because games are played and watched in real-time 24/7; light and libre for the fact that Lichess is open-source and unencumbered by proprietary junk that plagues other websites.</string>
+  <string name="whyIsLilaCalledLila">Similarly, the source code for Lichess, %1$s, stands for li[chess in sca]la, seeing as the bulk of Lichess is written in %2$s, an intuitive programming language.</string>
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -90,5 +90,11 @@
   <string name="whatUsernameCanIchoose">What can my username be?</string>
   <string name="usernamesNotOffensive">In general, usernames should not be: offensive, impersonating someone else, or advertising. You can read more about the %1$s.</string>
   <string name="guidelines">guidelines</string>
+  <string name="uniqueTrophies">Unique trophies.</string>
+  <string name="ownerUniqueTrophies">That trophy is unique in the history of Lichess, nobody other than %1$s will ever have it.</string>
+  <string name="wayOfBerserkExplanation">To get it, hiimgosu challenged himself to berserk and win 100% games of an %1$s.</string>
+  <string name="goldenZeeExplanation">ZugAddict was streaming and for the last 2 hours he had been trying to defeat A.I. level 8 in a 1+0 game, without success. Thibault told him that if he successfully did it on stream, he'd get a unique trophy. One hour later, he smashed Stockfish, and the promise was honoured."
+          )
+  </string>
 
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -38,12 +38,17 @@
   <string name="eightVariants">8 chess variants</string>
   <string name="whatIsACPL">What is 'average centipawn loss'/ACPL?</string>
   <string name="acplExplanation">The centipawn is the unit of measure used in chess as representation of the advantage. A centipawn is equal to 1/100th of a pawn. Therefore 100 centipawns = 1 pawn. These values play no formal role in the game but are useful to players, and essential in computer chess, for evaluating positions.
+
   The top computer move will lose zero centipawns, but lesser moves will result in a deterioration of the position, measured in centipawns.
+
   This value can be used as an indicator of the quality of play. The fewer centipawns one loses per move, the stronger the play.
+
   The computer analysis on Lichess is powered by Stockfish.</string>
   <string name="insufficientMaterial">Losing on time, drawing and insufficient material</string>
   <string name="lichessFollowFIDErules">In the event of one player running out of time, that player will usually lose the game. However, the game is drawn if the position is such that the opponent cannot checkmate the player's king by any possible series of legal moves (%1$s).
+
   In rare cases this can be difficult to decide automatically (forced lines, fortresses). By default we always side with the player who did not run out of time.
+
   Note that it can be possible to mate with a single knight or bishop if the opponent has a piece that could block the king.</string>
   <string name="linkToFIDErules">FIDE handbook §6.9, pdf</string>
   <string name="discoveringEnPassant">Why can a pawn capture another pawn when it is already passed? (en passant)</string>
@@ -70,7 +75,7 @@
   <string name="configure">configure</string>
   <string name="accounts">Accounts</string>
   <string name="titlesAvailableOnLichess">What titles are there on Lichess?</string>
-  <string name="lichessRecognizeAllOTBtitles">Lichess recognises all FIDE titles gained from OTB (over the board) play, as well as %1$s, Here is a list of FIDE titles:</string>
+  <string name="lichessRecognizeAllOTBtitles">Lichess recognises all FIDE titles gained from OTB (over the board) play, as well as %1$s. Here is a list of FIDE titles:</string>
   <string name="showYourTitle">If you have an OTB title, you can apply to have this displayed on your account by completing the %1$s, including a clear image of an identifying document/card and a selfie of you holding the document/card.
 
   Verifying as a titled player on Lichess gives access to play in the Titled Arena events.
@@ -114,7 +119,7 @@
   <string name="ratingLeaderboards">rating leaderboards:</string>
   <string name="havePlayedMoreThanThirtyGamesInThatRating">have played at least 30 rated games in a given rating,</string>
   <string name="havePlayedARatedGameAtLeastOneWeekAgo">have played a rated game within the last week for this rating,</string>
-  <string name="ratingDeviationLowerThanXinChessYinVariants">"have a rating deviation lower than %1$s, in standard chess, and lower than %2$s in variants,</string>
+  <string name="ratingDeviationLowerThanXinChessYinVariants">have a rating deviation lower than %1$s, in standard chess, and lower than %2$s in variants,</string>
   <string name="beInTopTen">be in the top 10 in this rating.</string>
   <string name="secondRequirementToStopOldPlayersTrustingLeaderboards">The 2nd requirement is so that players who no longer use their accounts stop populating leaderboards.</string>
   <string name="whyAreRatingHigher">Why are ratings higher compared to other sites and organisations such as FIDE, USCF and the ICC?</string>
@@ -132,5 +137,6 @@
   <string name="lichessCanOptionnalySendPopUps">Lichess can optionally send popup notifications, for example when it is your turn or you received a private message.
 
   Click the lock icon next to the lichess.org address in the URL bar of your browser.
+  
   Then select whether to allow or block notifications from Lichess.</string>
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -116,5 +116,12 @@
   <string name="ratingDeviationLowerThanXinChessYinVariants">"have a rating deviation lower than %1$s, in standard chess, and lower than %2$s in variants,</string>
   <string name="beInTopTen">be in the top 10 in this rating.</string>
   <string name="secondRequirementToStopOldPlayersTrustingLeaderboards">The 2nd requirement is so that players who no longer use their accounts stop populating leaderboards.</string>
+  <string name="whyAreRatingHigher">Why are ratings higher compared to other sites and organisations such as FIDE, USCF and the ICC?</string>
+  <string name="whyAreRatingHigherExplanation">It is best not to think of ratings as absolute numbers, or compare them against other organisations. Different organisations have different levels of players, different rating systems (Elo, Glicko, Glicko-2, or a modified version of the aforementioned). These factors can drastically affect the absolute numbers (ratings).
+ 
+  It's best to think of ratings as 'relative' figures (as opposed to 'absolute' figures): Within a pool of players, their relative differences in ratings will help you estimate who will win/draw/lose, and how often. Saying 'I have X rating' means nothing unless there are other players to compare that rating to.</string>
+  <string name="howToHideRatingWhilePlaying">How to hide ratings while playing?</string>
+  <string name="enableZenMode">Enable Zen-mode in the %1$s, or by pressins %2$s during a game.</string>
+  <string name="displayPreferences">display preferences.</string>
 
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -80,5 +80,15 @@
   <string name="asWellAsManyNMtitles">many national master titles</string>
   <string name="verificationForm">verification form</string>
   <string name="lichessMasterLM">Lichess Master (LM)</string>
+  <string name="canIbecomeLM">Can I get the Lichess Master (LM) title?</string>
+  <string name="noUpperCaseDot">No.</string>
+  <string name="lMtitleComesToYouDoNotRequestIt">This honorific title is unofficial and only exists on Lichess.
+
+  We rarely award it to highly notable players who are good citizens of Lichess, at our discretion. You don't get the LM title, the LM title gets to you. If you qualify, you will get a message from us regarding it and the choice to accept or decline.
+
+  Do not request to get the LM title.</string>
+  <string name="whatUsernameCanIchoose">What can my username be?</string>
+  <string name="usernamesNotOffensive">In general, usernames should not be: offensive, impersonating someone else, or advertising. You can read more about the %1$s.</string>
+  <string name="guidelines">guidelines</string>
 
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -58,5 +58,10 @@
    <string name="goodIntroduction">good introduction.</string>
    <string name="officialRulesPDF">official rules (pdf)</string>
    <string name="lichessTraining">Lichess training</string>
+   <string name="threefoldRepetition">Threefold repetition</string>
+   <string name="threefoldRepetitionExplanation">
+    If a position occurs three times, players can claim a draw by %1$s. Lichess implements the official FIDE rules, as described in Article 9.2 (d) of the %2$s.</string>
+   <string name="threefoldRepetitionLowerCase">threefold repetition</string>
+   <string name="handBookPDF">handbook (pdf)</string>
 
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -108,5 +108,13 @@
   <string name="similarOpponents">opponents of similar strength</string>
   <string name="notPlayedRecently">The player hasn't played enough recent games. Depending on the number of games you've played, it might take around a year of inactivity for your rating to become provisional again.</string>
   <string name="ratingDeviationMorethanOneHundredTen">Concretely, it means that the Glicko-2 deviation is greater than 110. The deviation is the level of confidence the system has in the rating. The lower the deviation, the more stable is a rating.</string>
+  <string name="howDoLeaderoardsWork">How do ranks and leaderboards work?</string>
+  <string name="inOrderToAppearsYouMust">In order to get on the %1$s you must:</string>
+  <string name="ratingLeaderboards">rating leaderboards:</string>
+  <string name="havePlayedMoreThanThirtyGamesInThatRating">have played at least 30 rated games in a given rating,</string>
+  <string name="havePlayedARatedGameAtLeastOneWeekAgo">have played a rated game within the last week for this rating,</string>
+  <string name="ratingDeviationLowerThanXinChessYinVariants">"have a rating deviation lower than %1$s, in standard chess, and lower than %2$s in variants,</string>
+  <string name="beInTopTen">be in the top 10 in this rating.</string>
+  <string name="secondRequirementToStopOldPlayersTrustingLeaderboards">The 2nd requirement is so that players who no longer use their accounts stop populating leaderboards.</string>
 
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+  <string name="frequentlyAskedQuestions">Frequently Asked Questions</string>
+</resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -25,6 +25,11 @@
   <string name="leavingGameWithoutResigningExplanation">If your opponent frequently aborts/leaves games, they get 'play banned', which means they're temporarily banned from playing games. This is not publically indicated on their profile. If this behaviour continues, the length of the playban increases - and prolonged behaviour of this nature may lead to account closure.</string>
   <string name="howCanIBecomeModerator">How can I become a moderator?</string>
   <string name="youCannotApply">It’s not possible to apply to become a moderator. If we see someone who we think would be good as a moderator, we will contact them directly.</string>
-  
+  <string name="isCorrespondenceDifferent">Is correspondence different from normal chess?</string>
+  <string name="youCanUseOpeningBookNoEngine">On Lichess, the main difference in rules for correspondence chess is that an opening book is allowed. The use of engines is still prohibited and will result in being flagged for engine assistance. Although ICCF allows engine use in correspondence, Lichess does not.</string>
+  <string name="howBulletBlitzEtcDecided">How are Bullet, Blitz and other time controls decided?</string>
+  <string name="basedOnGameDuration">"Lichess time controls are based on estimated game duration = %1$s
+  For instance, the estimated duration of a 5+3 game is 5 * 60 + 40 * 3 = 420 seconds.</string>
+  <string name="durationFormula">(clock initial time) + 40 * (clock increment)</string>
 
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -70,5 +70,8 @@
   <string name="threeFoldHasToBeClaimed">Repetition needs to be claimed by one of the players. You can do so by pressing the button that is shown, or by offering a draw before your final repeating move. You can also %1$s Lichess to automatically claim repetitions for you. Additionally, fivefold repetition always immediately ends the game.</string>
   <string name="configure">configure</string>
   <string name="accounts">Accounts</string>
+  <string name="titlesAvailableOnLichess">What titles are there on Lichess?</string>
+  <string name="lichessRecognizeAllOTBtitles">Lichess recognises all FIDE titles gained from OTB (over the board) play, as well as %1$s, Here is a list of FIDE titles:</string>
+  <string name="asWellAsManyNMtitles">many national master titles</string>
 
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="frequentlyAskedQuestions">Frequently Asked Questions</string>
+  <string name="whyIsLichessCalledLichess">Why is Lichess called Lichess?</string>  
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -94,6 +94,7 @@
   <string name="wayOfBerserkExplanation">To get it, hiimgosu challenged himself to berserk and win 100% games of %1$s.</string>
   <string name="aHourlyBulletTournament">a hourly Bullet tournament</string>
   <string name="goldenZeeExplanation">ZugAddict was streaming and for the last 2 hours he had been trying to defeat A.I. level 8 in a 1+0 game, without success. Thibault told him that if he successfully did it on stream, he'd get a unique trophy. One hour later, he smashed Stockfish, and the promise was honoured.</string>
+  <string name="lichessRatings">Lichess ratings</string>
   <string name="whichRatingSystemUsedByLichess">What rating system does Lichess use?</string>
   <string name="ratingSystemUsedByLichess">Ratings are calculated using the Glicko-2 rating method developed by Mark Glickman. This is a very popular rating method, and is used by a significant number of chess organisations (FIDE being a notable counter-example, as they still use the dated Elo rating system).
 
@@ -122,6 +123,14 @@
   It's best to think of ratings as 'relative' figures (as opposed to 'absolute' figures): Within a pool of players, their relative differences in ratings will help you estimate who will win/draw/lose, and how often. Saying 'I have X rating' means nothing unless there are other players to compare that rating to.</string>
   <string name="howToHideRatingWhilePlaying">How to hide ratings while playing?</string>
   <string name="enableZenMode">Enable Zen-mode in the %1$s, or by pressins %2$s during a game.</string>
-  <string name="displayPreferences">display preferences.</string>
+  <string name="displayPreferences">display preferences</string>
+  <string name="connexionLostCanIGetMyRatingBack">I lost a game due to lag/disconnection. Can I get my rating points back?</string>
+  <string name="weCannotDoThatEvenIfItIsServerSideButThatsRare">Unfortunately, we cannot give back rating points for games lost due to lag or disconnection, regardless of whether the problem was at your end or our end. The latter is very rare though. Also note that when Lichess restarts and you lose on time because of that, we abort the game to prevent an unfair loss.</string>
+  <string name="howToThreeDots">How to...</string>
+  <string name="enableDisableNotificationPopUps">Enable or disable notification popups?</string>
+  <string name="viewSiteInformationPopUp">View site information popup</string>
+  <string name="lichessCanOptionnalySendPopUps">Lichess can optionally send popup notifications, for example when it is your turn or you received a private message.
 
+  Click the lock icon next to the lichess.org address in the URL bar of your browser.
+  Then select whether to allow or block notifications from Lichess.</string>
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -31,5 +31,7 @@
   <string name="basedOnGameDuration">"Lichess time controls are based on estimated game duration = %1$s
   For instance, the estimated duration of a 5+3 game is 5 * 60 + 40 * 3 = 420 seconds.</string>
   <string name="durationFormula">(clock initial time) + 40 * (clock increment)</string>
+  <string name="inferiorThanXsEqualYtimeControl">≤ %1$ss = %2$s</string>
+  <string name="superiorThanXsEqualYtimeControl">≥ %1$ss = %2$s</string>
 
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -18,4 +18,13 @@
   <string name="fairPlay">Fair Play</string>
   <string name="whyFlaggedRatingManipulationOrCheater">Why am I flagged for artificial rating manipulation (sandbagging and boosting) or computer assistance?</string>
   <string name="cheatDetectionMethods">Lichess has strong detection methods and a very thorough process for reviewing all the evidence and making a decision. The process often involves many moderators and can take a long time. Other than the mark itself, we will not go into details about evidence or the decision making process for individual cases. Doing so would make it easier to avoid detection in the future, and be an invitation to unproductive debates. That time and effort is better spent on other important cases. Users can appeal by emailing %1$s, but decisions are rarely overturned.</string>
+  <string name="whenAmIEligibleRatinRefund">When am I eligible for the automatic rating refund from cheaters?</string>
+  <string name="ratingRefundExplanation">One minute after a player is marked, their 40 latest rated wins in the last 3 days are taken. If you are their opponent in those games and your rating was not provisional, you get a rating refund. The refund is capped based on your peak rating and your rating progress after the game.
+  (For example, if your rating greatly increased after those games, you might get no refund or only a partial refund.) A refund will never exceed 150 points.</string>
+  <string name="preventLeavingGameWithoutResigning">What is done about players leaving games without resigning?</string>
+  <string name="leavingGameWithoutResigningExplanation">If your opponent frequently aborts/leaves games, they get 'play banned', which means they're temporarily banned from playing games. This is not publically indicated on their profile. If this behaviour continues, the length of the playban increases - and prolonged behaviour of this nature may lead to account closure.</string>
+  <string name="howCanIBecomeModerator">How can I become a moderator?</string>
+  <string name="youCannotApply">It’s not possible to apply to become a moderator. If we see someone who we think would be good as a moderator, we will contact them directly.</string>
+  
+
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -72,6 +72,13 @@
   <string name="accounts">Accounts</string>
   <string name="titlesAvailableOnLichess">What titles are there on Lichess?</string>
   <string name="lichessRecognizeAllOTBtitles">Lichess recognises all FIDE titles gained from OTB (over the board) play, as well as %1$s, Here is a list of FIDE titles:</string>
+  <string name="showYourTitle">If you have an OTB title, you can apply to have this displayed on your account by completing the %1$s, including a clear image of an identifying document/card and a selfie of you holding the document/card.
+
+  Verifying as a titled player on Lichess gives access to play in the Titled Arena events.
+
+  Finally there is an honorary %2$s title.</string>
   <string name="asWellAsManyNMtitles">many national master titles</string>
+  <string name="verificationForm">verification form</string>
+  <string name="lichessMasterLM">Lichess Master (LM)</string>
 
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -96,7 +96,7 @@
   <string name="guidelines">guidelines</string>
   <string name="uniqueTrophies">Unique trophies</string>
   <string name="ownerUniqueTrophies">That trophy is unique in the history of Lichess, nobody other than %1$s will ever have it.</string>
-  <string name="wayOfBerserkExplanation">To get it, hiimgosu challenged himself to berserk and win 100% games of %1$s.</string>
+  <string name="wayOfBerserkExplanation">To get it, hiimgosu challenged himself to berserk and win 100%1$s games of %2$s.</string>
   <string name="aHourlyBulletTournament">a hourly Bullet tournament</string>
   <string name="goldenZeeExplanation">ZugAddict was streaming and for the last 2 hours he had been trying to defeat A.I. level 8 in a 1+0 game, without success. Thibault told him that if he successfully did it on stream, he'd get a unique trophy. One hour later, he smashed Stockfish, and the promise was honoured.</string>
   <string name="lichessRatings">Lichess ratings</string>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -28,7 +28,7 @@
   <string name="isCorrespondenceDifferent">Is correspondence different from normal chess?</string>
   <string name="youCanUseOpeningBookNoEngine">On Lichess, the main difference in rules for correspondence chess is that an opening book is allowed. The use of engines is still prohibited and will result in being flagged for engine assistance. Although ICCF allows engine use in correspondence, Lichess does not.</string>
   <string name="howBulletBlitzEtcDecided">How are Bullet, Blitz and other time controls decided?</string>
-  <string name="basedOnGameDuration">"Lichess time controls are based on estimated game duration = %1$s
+  <string name="basedOnGameDuration">Lichess time controls are based on estimated game duration = %1$s
   For instance, the estimated duration of a 5+3 game is 5 * 60 + 40 * 3 = 420 seconds.</string>
   <string name="durationFormula">(clock initial time) + 40 * (clock increment)</string>
   <string name="inferiorThanXsEqualYtimeControl">≤ %1$ss = %2$s</string>
@@ -51,20 +51,19 @@
 
   It is described in section 3.7 (d) of the %2$s:
 	
-  A pawn occupying a square on the same rank as and on an adjacent file to an opponent’s pawn which has just advanced two squares in one move from its original square may capture this opponent’s pawn as though the latter had been moved only one square. This capture is only legal on the move following this advance and is called an ‘en passant’ capture.'
+  A pawn occupying a square on the same rank as and on an adjacent file to an opponent’s pawn which has just advanced two squares in one move from its original square may capture this opponent’s pawn as though the latter had been moved only one square. This capture is only legal on the move following this advance and is called an ‘en passant’ capture.
     
   See the %3$s on this move for some practice with it.
   </string>
-  <string name="goodIntroduction">good introduction.</string>
+  <string name="goodIntroduction">good introduction</string>
   <string name="officialRulesPDF">official rules (pdf)</string>
   <string name="lichessTraining">Lichess training</string>
   <string name="threefoldRepetition">Threefold repetition</string>
-  <string name="threefoldRepetitionExplanation">
-  If a position occurs three times, players can claim a draw by %1$s. Lichess implements the official FIDE rules, as described in Article 9.2 (d) of the %2$s.</string>
+  <string name="threefoldRepetitionExplanation">If a position occurs three times, players can claim a draw by %1$s. Lichess implements the official FIDE rules, as described in Article 9.2 (d) of the %2$s.</string>
   <string name="threefoldRepetitionLowerCase">threefold repetition</string>
   <string name="handBookPDF">handbook (pdf)</string>
   <string name="notRepeatedMoves">We did not repeat moves. Why was the game still drawn by repetition?</string>
-  <string name="repeatedPositionsThatMatters">Threefold repetition is about repeated %1$s, not moves. Repetition does not have to occur consecutively."</string>
+  <string name="repeatedPositionsThatMatters">Threefold repetition is about repeated %1$s, not moves. Repetition does not have to occur consecutively.</string>
   <string name="positions">positions</string>
   <string name="weRepeatedthreeTimesPosButNoDraw">We repeated a position three times. Why was the game not drawn?</string>
   <string name="threeFoldHasToBeClaimed">Repetition needs to be claimed by one of the players. You can do so by pressing the button that is shown, or by offering a draw before your final repeating move. You can also %1$s Lichess to automatically claim repetitions for you. Additionally, fivefold repetition always immediately ends the game.</string>
@@ -90,9 +89,10 @@
   <string name="whatUsernameCanIchoose">What can my username be?</string>
   <string name="usernamesNotOffensive">In general, usernames should not be: offensive, impersonating someone else, or advertising. You can read more about the %1$s.</string>
   <string name="guidelines">guidelines</string>
-  <string name="uniqueTrophies">Unique trophies.</string>
+  <string name="uniqueTrophies">Unique trophies</string>
   <string name="ownerUniqueTrophies">That trophy is unique in the history of Lichess, nobody other than %1$s will ever have it.</string>
-  <string name="wayOfBerserkExplanation">To get it, hiimgosu challenged himself to berserk and win 100% games of an %1$s.</string>
+  <string name="wayOfBerserkExplanation">To get it, hiimgosu challenged himself to berserk and win 100% games of %1$s.</string>
+  <string name="aHourlyBulletTournament">a hourly Bullet tournament</string>
   <string name="goldenZeeExplanation">ZugAddict was streaming and for the last 2 hours he had been trying to defeat A.I. level 8 in a 1+0 game, without success. Thibault told him that if he successfully did it on stream, he'd get a unique trophy. One hour later, he smashed Stockfish, and the promise was honoured."
           )
   </string>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -22,7 +22,7 @@
   <string name="ratingRefundExplanation">One minute after a player is marked, their 40 latest rated wins in the last 3 days are taken. If you are their opponent in those games and your rating was not provisional, you get a rating refund. The refund is capped based on your peak rating and your rating progress after the game.
   (For example, if your rating greatly increased after those games, you might get no refund or only a partial refund.) A refund will never exceed 150 points.</string>
   <string name="preventLeavingGameWithoutResigning">What is done about players leaving games without resigning?</string>
-  <string name="leavingGameWithoutResigningExplanation">If your opponent frequently aborts/leaves games, they get 'play banned', which means they're temporarily banned from playing games. This is not publically indicated on their profile. If this behaviour continues, the length of the playban increases - and prolonged behaviour of this nature may lead to account closure.</string>
+  <string name="leavingGameWithoutResigningExplanation">If your opponent frequently aborts/leaves games, they get "play banned", which means they're temporarily banned from playing games. This is not publically indicated on their profile. If this behaviour continues, the length of the playban increases - and prolonged behaviour of this nature may lead to account closure.</string>
   <string name="howCanIBecomeModerator">How can I become a moderator?</string>
   <string name="youCannotApply">It’s not possible to apply to become a moderator. If we see someone who we think would be good as a moderator, we will contact them directly.</string>
   <string name="isCorrespondenceDifferent">Is correspondence different from normal chess?</string>
@@ -36,7 +36,7 @@
   <string name="whatVariantsCanIplay">What variants can I play on Lichess?</string>
   <string name="lichessSupportChessAnd">Lichess supports standard chess and %1$s.</string>
   <string name="eightVariants">8 chess variants</string>
-  <string name="whatIsACPL">What is 'average centipawn loss'/ACPL?</string>
+  <string name="whatIsACPL">What is "average centipawn loss"/ACPL?</string>
   <string name="acplExplanation">The centipawn is the unit of measure used in chess as representation of the advantage. A centipawn is equal to 1/100th of a pawn. Therefore 100 centipawns = 1 pawn. These values play no formal role in the game but are useful to players, and essential in computer chess, for evaluating positions.
 
   The top computer move will lose zero centipawns, but lesser moves will result in a deterioration of the position, measured in centipawns.
@@ -52,11 +52,11 @@
   Note that it can be possible to mate with a single knight or bishop if the opponent has a piece that could block the king.</string>
   <string name="linkToFIDErules">FIDE handbook §6.9, pdf</string>
   <string name="discoveringEnPassant">Why can a pawn capture another pawn when it is already passed? (en passant)</string>
-  <string name="explainingEnPassant">This is a legal move known as 'en passant'. The Wikipedia article gives a %1$s.
+  <string name="explainingEnPassant">This is a legal move known as "en passant". The Wikipedia article gives a %1$s.
 
   It is described in section 3.7 (d) of the %2$s:
 	
-  A pawn occupying a square on the same rank as and on an adjacent file to an opponent’s pawn which has just advanced two squares in one move from its original square may capture this opponent’s pawn as though the latter had been moved only one square. This capture is only legal on the move following this advance and is called an ‘en passant’ capture.
+  "A pawn occupying a square on the same rank as and on an adjacent file to an opponent’s pawn which has just advanced two squares in one move from its original square may capture this opponent’s pawn as though the latter had been moved only one square. This capture is only legal on the move following this advance and is called an ‘en passant’ capture."
     
   See the %3$s on this move for some practice with it.
   </string>
@@ -103,7 +103,7 @@
   <string name="whichRatingSystemUsedByLichess">What rating system does Lichess use?</string>
   <string name="ratingSystemUsedByLichess">Ratings are calculated using the Glicko-2 rating method developed by Mark Glickman. This is a very popular rating method, and is used by a significant number of chess organisations (FIDE being a notable counter-example, as they still use the dated Elo rating system).
 
-  Fundamentally, Glicko ratings use 'confidence intervals' when calculating and representing your rating. When you first start using the site, your rating starts at 1500 ± 700. The 1500 represents your rating, and the 700 represents the confidence interval.
+  Fundamentally, Glicko ratings use "confidence intervals" when calculating and representing your rating. When you first start using the site, your rating starts at 1500 ± 700. The 1500 represents your rating, and the 700 represents the confidence interval.
 
   Basically, the system is 90% sure that your rating is somewhere between 800 and 2200. It is incredibly uncertain. Because of this, when a player is just starting out, their rating will change very dramatically, potentially several hundred points at a time. But after some games against established players the confidence interval will narrow, and the amount of points gained/lost after each game will decrease.
 
@@ -125,7 +125,7 @@
   <string name="whyAreRatingHigher">Why are ratings higher compared to other sites and organisations such as FIDE, USCF and the ICC?</string>
   <string name="whyAreRatingHigherExplanation">It is best not to think of ratings as absolute numbers, or compare them against other organisations. Different organisations have different levels of players, different rating systems (Elo, Glicko, Glicko-2, or a modified version of the aforementioned). These factors can drastically affect the absolute numbers (ratings).
  
-  It's best to think of ratings as 'relative' figures (as opposed to 'absolute' figures): Within a pool of players, their relative differences in ratings will help you estimate who will win/draw/lose, and how often. Saying 'I have X rating' means nothing unless there are other players to compare that rating to.</string>
+  It's best to think of ratings as "relative" figures (as opposed to "absolute" figures): Within a pool of players, their relative differences in ratings will help you estimate who will win/draw/lose, and how often. Saying "I have X rating" means nothing unless there are other players to compare that rating to.</string>
   <string name="howToHideRatingWhilePlaying">How to hide ratings while playing?</string>
   <string name="enableZenMode">Enable Zen-mode in the %1$s, or by pressins %2$s during a game.</string>
   <string name="displayPreferences">display preferences</string>
@@ -137,6 +137,6 @@
   <string name="lichessCanOptionnalySendPopUps">Lichess can optionally send popup notifications, for example when it is your turn or you received a private message.
 
   Click the lock icon next to the lichess.org address in the URL bar of your browser.
-  
+
   Then select whether to allow or block notifications from Lichess.</string>
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -93,8 +93,20 @@
   <string name="ownerUniqueTrophies">That trophy is unique in the history of Lichess, nobody other than %1$s will ever have it.</string>
   <string name="wayOfBerserkExplanation">To get it, hiimgosu challenged himself to berserk and win 100% games of %1$s.</string>
   <string name="aHourlyBulletTournament">a hourly Bullet tournament</string>
-  <string name="goldenZeeExplanation">ZugAddict was streaming and for the last 2 hours he had been trying to defeat A.I. level 8 in a 1+0 game, without success. Thibault told him that if he successfully did it on stream, he'd get a unique trophy. One hour later, he smashed Stockfish, and the promise was honoured."
-          )
-  </string>
+  <string name="goldenZeeExplanation">ZugAddict was streaming and for the last 2 hours he had been trying to defeat A.I. level 8 in a 1+0 game, without success. Thibault told him that if he successfully did it on stream, he'd get a unique trophy. One hour later, he smashed Stockfish, and the promise was honoured.</string>
+  <string name="whichRatingSystemUsedByLichess">What rating system does Lichess use?</string>
+  <string name="ratingSystemUsedByLichess">Ratings are calculated using the Glicko-2 rating method developed by Mark Glickman. This is a very popular rating method, and is used by a significant number of chess organisations (FIDE being a notable counter-example, as they still use the dated Elo rating system).
+
+  Fundamentally, Glicko ratings use 'confidence intervals' when calculating and representing your rating. When you first start using the site, your rating starts at 1500 ± 700. The 1500 represents your rating, and the 700 represents the confidence interval.
+
+  Basically, the system is 90% sure that your rating is somewhere between 800 and 2200. It is incredibly uncertain. Because of this, when a player is just starting out, their rating will change very dramatically, potentially several hundred points at a time. But after some games against established players the confidence interval will narrow, and the amount of points gained/lost after each game will decrease.
+
+  Another point to note is that, as time passes, the confidence interval will increase. This allows you to gain/lose points points more rapidly to match any changes in your skill level over that time.</string>
+  <string name="whatIsProvisionalRating">Why is there a question mark (?) next to a rating?</string>
+  <string name="provisionalRatingExplanation">The question mark means the rating is provisional. Reasons include:</string>
+  <string name="notPlayedEnoughRatedGamesAgainstX">The player has not yet finished enough rated games against %1$s in the rating category.</string>
+  <string name="similarOpponents">opponents of similar strength</string>
+  <string name="notPlayedRecently">The player hasn't played enough recent games. Depending on the number of games you've played, it might take around a year of inactivity for your rating to become provisional again.</string>
+  <string name="ratingDeviationMorethanOneHundredTen">Concretely, it means that the Glicko-2 deviation is greater than 110. The deviation is the level of confidence the system has in the rating. The lower the deviation, the more stable is a rating.</string>
 
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -4,7 +4,7 @@
   <string name="whyIsLichessCalledLichess">Why is Lichess called Lichess?</string>
   <string name="lichessCombinationLiveLightLibrePronounced">Lichess is a combination of live/light/libre and chess. It is pronounced %1$s.</string>
   <string name="leechess">lee-chess</string>
-  <string name="hearItPronouncedBySpecialist">Hear it pronounced by a specialist.</string>
+  <string name="hearItPronouncedBySpecialist"> Hear it pronounced by a specialist.</string>
   <string name="whyLiveLightLibre">Live, because games are played and watched in real-time 24/7; light and libre for the fact that Lichess is open-source and unencumbered by proprietary junk that plagues other websites.</string>
   <string name="whyIsLilaCalledLila">Similarly, the source code for Lichess, %1$s, stands for li[chess in sca]la, seeing as the bulk of Lichess is written in %2$s, an intuitive programming language.</string>
   <string name="howCanIContributeToLichess">How can I contribute to Lichess?</string>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="frequentlyAskedQuestions">Frequently Asked Questions</string>
-  <string name="whyIsLichessCalledLichess">Why is Lichess called Lichess?</string>  
+  <string name="whyIsLichessCalledLichess">Why is Lichess called Lichess?</string>
+  <string name="lichessCombinationLiveLightLibrePronounced">Lichess is a combination of live/light/libre and chess. It is pronounced %1$s.</string>
+  <string name="leechess">lee-chess</string>
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -46,5 +46,17 @@
   In rare cases this can be difficult to decide automatically (forced lines, fortresses). By default we always side with the player who did not run out of time.
   Note that it can be possible to mate with a single knight or bishop if the opponent has a piece that could block the king.</string>
   <string name="linkToFIDErules">FIDE handbook §6.9, pdf</string>
+  <string name="discoveringEnPassant">Why can a pawn capture another pawn when it is already passed? (en passant)</string>
+  <string name="explainingEnPassant">This is a legal move known as 'en passant'. The Wikipedia article gives a %1$s.
+
+  	It is described in section 3.7 (d) of the %2$s:
+	
+	'A pawn occupying a square on the same rank as and on an adjacent file to an opponent’s pawn which has just advanced two squares in one move from its original square may capture this opponent’s pawn as though the latter had been moved only one square. This capture is only legal on the move following this advance and is called an ‘en passant’ capture.'
+    
+    See the %3$s on this move for some practice with it.
+   </string>
+   <string name="goodIntroduction">good introduction.</string>
+   <string name="officialRulesPDF">official rules (pdf)</string>
+   <string name="lichessTraining">Lichess training</string>
 
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -63,5 +63,12 @@
     If a position occurs three times, players can claim a draw by %1$s. Lichess implements the official FIDE rules, as described in Article 9.2 (d) of the %2$s.</string>
    <string name="threefoldRepetitionLowerCase">threefold repetition</string>
    <string name="handBookPDF">handbook (pdf)</string>
+   <string name="notRepeatedMoves">We did not repeat moves. Why was the game still drawn by repetition?</string>
+   <string name="repeatedPositionsThatMatters">Threefold repetition is about repeated %1$s, not moves. Repetition does not have to occur consecutively."</string>
+   <string name="positions">positions</string>
+   <string name="weRepeatedthreeTimesPosButNoDraw">We repeated a position three times. Why was the game not drawn?</string>
+   <string name="threeFoldHasToBeClaimed">Repetition needs to be claimed by one of the players. You can do so by pressing the button that is shown, or by offering a draw before your final repeating move. You can also %1$s Lichess to automatically claim repetitions for you. Additionally, fivefold repetition always immediately ends the game.</string>
+   <string name="configure">configure</string>
+
 
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -9,4 +9,8 @@
   <string name="whyIsLilaCalledLila">Similarly, the source code for Lichess, %1$s, stands for li[chess in sca]la, seeing as the bulk of Lichess is written in %2$s, an intuitive programming language.</string>
   <string name="howCanIContributeToLichess">How can I contribute to Lichess?</string>
   <string name="lichessPoweredByDonationsAndVolunteers">Lichess is powered by donations from patrons and the efforts of a team of volunteers.</string>
+  <string name="findMoreAndSeeHowHelp">You can find out more about %1$s (including a %2$s). If you want to help Lichess by volunteering your time and skills, there are many %3$s.</string>
+  <string name="beingAPatron">being a patron</string>
+  <string name="breakdownOfOurCosts">breakdown of our costs</string>
+  <string name="otherWaysToHelp">other ways to help</string>
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -36,4 +36,15 @@
   <string name="whatVariantsCanIplay">What variants can I play on Lichess?</string>
   <string name="lichessSupportChessAnd">Lichess supports standard chess and %1$s.</string>
   <string name="eightVariants">8 chess variants</string>
+  <string name="whatIsACPL">What is 'average centipawn loss'/ACPL?</string>
+  <string name="acplExplanation">The centipawn is the unit of measure used in chess as representation of the advantage. A centipawn is equal to 1/100th of a pawn. Therefore 100 centipawns = 1 pawn. These values play no formal role in the game but are useful to players, and essential in computer chess, for evaluating positions.
+  The top computer move will lose zero centipawns, but lesser moves will result in a deterioration of the position, measured in centipawns.
+  This value can be used as an indicator of the quality of play. The fewer centipawns one loses per move, the stronger the play.
+  The computer analysis on Lichess is powered by Stockfish.</string>
+  <string name="insufficientMaterial">Losing on time, drawing and insufficient material</string>
+  <string name="lichessFollowFIDErules">In the event of one player running out of time, that player will usually lose the game. However, the game is drawn if the position is such that the opponent cannot checkmate the player's king by any possible series of legal moves (%1$s).
+  In rare cases this can be difficult to decide automatically (forced lines, fortresses). By default we always side with the player who did not run out of time.
+  Note that it can be possible to mate with a single knight or bishop if the opponent has a piece that could block the king.</string>
+  <string name="linkToFIDErules">FIDE handbook §6.9, pdf</string>
+
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -13,4 +13,6 @@
   <string name="beingAPatron">being a patron</string>
   <string name="breakdownOfOurCosts">breakdown of our costs</string>
   <string name="otherWaysToHelp">other ways to help</string>
+  <string name="areThereWebsitesBasedOnLichess">Are there websites based on Lichess?</string>
+  <string name="yesLichessInspiredOtherOpenSourceWebsites">Yes. Lichess has indeed inspired other open-source sites that use our %1$s, %2$s, or %3s.</string>
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -15,4 +15,7 @@
   <string name="otherWaysToHelp">other ways to help</string>
   <string name="areThereWebsitesBasedOnLichess">Are there websites based on Lichess?</string>
   <string name="yesLichessInspiredOtherOpenSourceWebsites">Yes. Lichess has indeed inspired other open-source sites that use our %1$s, %2$s, or %3s.</string>
+  <string name="fairPlay">Fair Play</string>
+  <string name="whyFlaggedRatingManipulationOrCheater">Why am I flagged for artificial rating manipulation (sandbagging and boosting) or computer assistance?</string>
+  <string name="cheatDetectionMethods">Lichess has strong detection methods and a very thorough process for reviewing all the evidence and making a decision. The process often involves many moderators and can take a long time. Other than the mark itself, we will not go into details about evidence or the decision making process for individual cases. Doing so would make it easier to avoid detection in the future, and be an invitation to unproductive debates. That time and effort is better spent on other important cases. Users can appeal by emailing %1$s, but decisions are rarely overturned.</string>
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -7,4 +7,6 @@
   <string name="hearItPronouncedBySpecialist">Hear it pronounced by a specialist.</string>
   <string name="whyLiveLightLibre">Live, because games are played and watched in real-time 24/7; light and libre for the fact that Lichess is open-source and unencumbered by proprietary junk that plagues other websites.</string>
   <string name="whyIsLilaCalledLila">Similarly, the source code for Lichess, %1$s, stands for li[chess in sca]la, seeing as the bulk of Lichess is written in %2$s, an intuitive programming language.</string>
+  <string name="howCanIContributeToLichess">How can I contribute to Lichess?</string>
+  <string name="lichessPoweredByDonationsAndVolunteers">Lichess is powered by donations from patrons and the efforts of a team of volunteers.</string>
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -49,26 +49,26 @@
   <string name="discoveringEnPassant">Why can a pawn capture another pawn when it is already passed? (en passant)</string>
   <string name="explainingEnPassant">This is a legal move known as 'en passant'. The Wikipedia article gives a %1$s.
 
-  	It is described in section 3.7 (d) of the %2$s:
+  It is described in section 3.7 (d) of the %2$s:
 	
-	'A pawn occupying a square on the same rank as and on an adjacent file to an opponent’s pawn which has just advanced two squares in one move from its original square may capture this opponent’s pawn as though the latter had been moved only one square. This capture is only legal on the move following this advance and is called an ‘en passant’ capture.'
+  A pawn occupying a square on the same rank as and on an adjacent file to an opponent’s pawn which has just advanced two squares in one move from its original square may capture this opponent’s pawn as though the latter had been moved only one square. This capture is only legal on the move following this advance and is called an ‘en passant’ capture.'
     
-    See the %3$s on this move for some practice with it.
-   </string>
-   <string name="goodIntroduction">good introduction.</string>
-   <string name="officialRulesPDF">official rules (pdf)</string>
-   <string name="lichessTraining">Lichess training</string>
-   <string name="threefoldRepetition">Threefold repetition</string>
-   <string name="threefoldRepetitionExplanation">
-    If a position occurs three times, players can claim a draw by %1$s. Lichess implements the official FIDE rules, as described in Article 9.2 (d) of the %2$s.</string>
-   <string name="threefoldRepetitionLowerCase">threefold repetition</string>
-   <string name="handBookPDF">handbook (pdf)</string>
-   <string name="notRepeatedMoves">We did not repeat moves. Why was the game still drawn by repetition?</string>
-   <string name="repeatedPositionsThatMatters">Threefold repetition is about repeated %1$s, not moves. Repetition does not have to occur consecutively."</string>
-   <string name="positions">positions</string>
-   <string name="weRepeatedthreeTimesPosButNoDraw">We repeated a position three times. Why was the game not drawn?</string>
-   <string name="threeFoldHasToBeClaimed">Repetition needs to be claimed by one of the players. You can do so by pressing the button that is shown, or by offering a draw before your final repeating move. You can also %1$s Lichess to automatically claim repetitions for you. Additionally, fivefold repetition always immediately ends the game.</string>
-   <string name="configure">configure</string>
-
+  See the %3$s on this move for some practice with it.
+  </string>
+  <string name="goodIntroduction">good introduction.</string>
+  <string name="officialRulesPDF">official rules (pdf)</string>
+  <string name="lichessTraining">Lichess training</string>
+  <string name="threefoldRepetition">Threefold repetition</string>
+  <string name="threefoldRepetitionExplanation">
+  If a position occurs three times, players can claim a draw by %1$s. Lichess implements the official FIDE rules, as described in Article 9.2 (d) of the %2$s.</string>
+  <string name="threefoldRepetitionLowerCase">threefold repetition</string>
+  <string name="handBookPDF">handbook (pdf)</string>
+  <string name="notRepeatedMoves">We did not repeat moves. Why was the game still drawn by repetition?</string>
+  <string name="repeatedPositionsThatMatters">Threefold repetition is about repeated %1$s, not moves. Repetition does not have to occur consecutively."</string>
+  <string name="positions">positions</string>
+  <string name="weRepeatedthreeTimesPosButNoDraw">We repeated a position three times. Why was the game not drawn?</string>
+  <string name="threeFoldHasToBeClaimed">Repetition needs to be claimed by one of the players. You can do so by pressing the button that is shown, or by offering a draw before your final repeating move. You can also %1$s Lichess to automatically claim repetitions for you. Additionally, fivefold repetition always immediately ends the game.</string>
+  <string name="configure">configure</string>
+  <string name="accounts">Accounts</string>
 
 </resources>

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -33,5 +33,7 @@
   <string name="durationFormula">(clock initial time) + 40 * (clock increment)</string>
   <string name="inferiorThanXsEqualYtimeControl">≤ %1$ss = %2$s</string>
   <string name="superiorThanXsEqualYtimeControl">≥ %1$ss = %2$s</string>
-
+  <string name="whatVariantsCanIplay">What variants can I play on Lichess?</string>
+  <string name="lichessSupportChessAnd">Lichess supports standard chess and %1$s.</string>
+  <string name="eightVariants">8 chess variants</string>
 </resources>


### PR DESCRIPTION
Hello,

This PR translate the FAQ page, as listed in #3382 

Generally I've tried to keep the answers in one string because I think it will be easier to maintain (it can be split again if this is not wanted). As a result, some translation strings are quite long, and some answers are also *slightly* thicker (see before/after)
![Screen Shot 2020-04-21 at 07 33 12](https://user-images.githubusercontent.com/56031107/79836764-7e9a3080-83a8-11ea-8fe0-b1ccce3efe4a.png)

I don't have translated titles and trophy names.