### PR TITLE
Cleaner recent mod log

### DIFF
--- a/modules/mod/src/main/ModlogApi.scala
+++ b/modules/mod/src/main/ModlogApi.scala
@@ -185,7 +185,12 @@ final class ModlogApi(repo: ModlogRepo, userRepo: UserRepo, slackApi: lila.slack
     Modlog(mod, user.some, Modlog.teamMadeOwner, details = Some(teamName take 140))
   }
 
-  def recent = coll.ext.find($empty).sort($sort naturalDesc).cursor[Modlog]().gather[List](100)
+  def recent = coll.ext.find(
+    $or(
+      $doc("mod" -> $ne("lichess")),
+      $doc("action" -> $nin("selfCloseAccount", "modMessage"))
+    )
+  ).sort($sort naturalDesc).cursor[Modlog]().gather[List](100)
 
   def wasUnengined(sus: Suspect) =
     coll.exists(


### PR DESCRIPTION
It's pretty unusable right now. This hides selfCloseAccount and
modMessage by lichess.