### PR TITLE
Add coordinates to the scan command

### DIFF
--- a/ui/analyse/src/plugins/nvui.ts
+++ b/ui/analyse/src/plugins/nvui.ts
@@ -137,7 +137,7 @@ function onCommand(ctrl: AnalyseController, notify: (txt: string) => void, c: st
   const pieces = ctrl.chessground.state.pieces;
   notify(
     commands.piece.apply(c, pieces, style) ||
-    commands.scan.apply(c, pieces) ||
+    commands.scan.apply(c, pieces, style) ||
     `Invalid command: ${c}`
   );
 }

--- a/ui/nvui/src/chess.ts
+++ b/ui/nvui/src/chess.ts
@@ -85,12 +85,12 @@ export function renderPieceKeys(pieces: Pieces, p: string, style: Style): string
   return `${name}: ${res.length ? res.map(k => renderKey(k, style)).join(', ') : 'none'}`;
 }
 
-export function renderPiecesOn(pieces: Pieces, rankOrFile: string): string {
+export function renderPiecesOn(pieces: Pieces, rankOrFile: string, style: Style): string {
   let res: string[] = [], piece: Piece | undefined;
   for (let k of allKeys) {
     if (k.includes(rankOrFile)) {
       piece = pieces[k];
-      if (piece) res.push(`${piece.color} ${piece.role}`);
+      if (piece) res.push(`${renderKey(k, style)} ${piece.color} ${piece.role}`);
     }
   }
   return res.join(', ');

--- a/ui/nvui/src/command.ts
+++ b/ui/nvui/src/command.ts
@@ -10,8 +10,8 @@ export const commands = {
   },
   scan: {
     help: 'scan: Read pieces on a rank or file. Example: scan a, scan 1.',
-    apply(c: string, pieces: Pieces): string | undefined {
-      return tryC(c, /^scan ([a-h1-8])$/i, p => renderPiecesOn(pieces, p));
+    apply(c: string, pieces: Pieces, style: Style): string | undefined {
+      return tryC(c, /^scan ([a-h1-8])$/i, p => renderPiecesOn(pieces, p, style));
     }
   }
 };

--- a/ui/round/src/plugins/nvui.ts
+++ b/ui/round/src/plugins/nvui.ts
@@ -190,7 +190,7 @@ function onCommand(ctrl: RoundController, notify: (txt: string) => void, c: stri
     const pieces = ctrl.chessground.state.pieces;
     notify(
       commands.piece.apply(c, pieces, style) ||
-      commands.scan.apply(c, pieces) ||
+      commands.scan.apply(c, pieces, style) ||
       `Invalid command: ${c}`
     );
   }


### PR DESCRIPTION
https://lichess.org/forum/lichess-feedback/suggestions-concerning-accessibility#3
> The output of the Scan command has already changed: blank squares on a file or rank are ignored, but screenreader doesn't read the squares on which certain pieces and pawns are  standing.
Actual result: Scan 1 = 'white rook white queen white rook white king' 
Expected result: Scan 1 = 'a1 white rook d1 white queen e1 white rook g1 white king'

Included in #6401 

It compiled but I couldn't test to check.