### PR TITLE
Source translation Fix

### DIFF
--- a/translation/source/patron.xml
+++ b/translation/source/patron.xml
@@ -73,5 +73,5 @@ However, Patrons get bragging rights with a cool new profile icon.</string>
   <string name="checkOutProfile">Check out your profile page!</string>
   <string name="nowLifetime">You are now a lifetime Lichess Patron!</string>
   <string name="nowOneMonth">You are now a Lichess Patron for one month!</string>
-  <string name="downgradeNextMonth">In one month, you will NOT be charged again, and your Lichess account will be downgraded to free.</string>
+  <string name="downgradeNextMonth">In one month, you will NOT be charged again, and your Lichess account will revert to a regular account.</string>
 </resources>


### PR DESCRIPTION
From crowding
> Not keen on the wording 'downgraded to free', I feel it misrepresents the nature of patronage. What about 'will revert to a regular account'? Please consider revising the wording.