### PR TITLE
Add coloured inline coords to all boards using ts

### DIFF
--- a/ui/analyse/src/ground.ts
+++ b/ui/analyse/src/ground.ts
@@ -5,7 +5,7 @@ import { Api as CgApi } from 'chessground/api';
 import { Config as CgConfig } from 'chessground/config';
 import * as cg from 'chessground/types';
 import { DrawShape } from 'chessground/draw';
-import changeColourHandle from 'common/coordsColour';
+import changeColorHandle from 'common/coordsColor';
 import resizeHandle from 'common/resize';
 import AnalyseCtrl from './ctrl';
 
@@ -59,7 +59,7 @@ export function makeConfig(ctrl: AnalyseCtrl): CgConfig {
       dropNewPiece: ctrl.userNewPiece,
       insert(elements) {
         if (!ctrl.embed) resizeHandle(elements, ctrl.data.pref.resizeHandle, ctrl.node.ply);
-        if (!ctrl.embed && ctrl.data.pref.coords == 1) changeColourHandle();
+        if (!ctrl.embed && ctrl.data.pref.coords == 1) changeColorHandle();
       }
     },
     premovable: {

--- a/ui/analyse/src/ground.ts
+++ b/ui/analyse/src/ground.ts
@@ -59,7 +59,7 @@ export function makeConfig(ctrl: AnalyseCtrl): CgConfig {
       dropNewPiece: ctrl.userNewPiece,
       insert(elements) {
         if (!ctrl.embed) resizeHandle(elements, ctrl.data.pref.resizeHandle, ctrl.node.ply);
-        if (!ctrl.embed && ctrl.data.pref.coords == 1)changeColourHandle();
+        if (!ctrl.embed && ctrl.data.pref.coords == 1) changeColourHandle();
       }
     },
     premovable: {

--- a/ui/analyse/src/ground.ts
+++ b/ui/analyse/src/ground.ts
@@ -5,6 +5,7 @@ import { Api as CgApi } from 'chessground/api';
 import { Config as CgConfig } from 'chessground/config';
 import * as cg from 'chessground/types';
 import { DrawShape } from 'chessground/draw';
+import changeColourHandle from 'common/coordsColour';
 import resizeHandle from 'common/resize';
 import AnalyseCtrl from './ctrl';
 
@@ -58,6 +59,7 @@ export function makeConfig(ctrl: AnalyseCtrl): CgConfig {
       dropNewPiece: ctrl.userNewPiece,
       insert(elements) {
         if (!ctrl.embed) resizeHandle(elements, ctrl.data.pref.resizeHandle, ctrl.node.ply);
+        if (!ctrl.embed && ctrl.data.pref.coords == 1)changeColourHandle();
       }
     },
     premovable: {

--- a/ui/analyse/src/view.ts
+++ b/ui/analyse/src/view.ts
@@ -2,6 +2,7 @@ import { h } from 'snabbdom'
 import { VNode } from 'snabbdom/vnode'
 import * as chessground from './ground';
 import { bind, onInsert, dataIcon, spinner, bindMobileMousedown } from './util';
+import changeColourHandle from 'common/coordsColour';
 import { getPlayer, playable } from 'game';
 import * as router from 'game/router';
 import statusView from 'game/view/status';
@@ -228,8 +229,10 @@ function controls(ctrl: AnalyseCtrl) {
 }
 
 function forceInnerCoords(ctrl: AnalyseCtrl, v: boolean) {
-  if (ctrl.data.pref.coords == 2)
+  if (ctrl.data.pref.coords == 2){
     $('body').toggleClass('coords-in', v).toggleClass('coords-out', !v);
+    changeColourHandle();
+  }
 }
 
 function addChapterId(study: StudyCtrl | undefined, cssClass: string) {

--- a/ui/analyse/src/view.ts
+++ b/ui/analyse/src/view.ts
@@ -2,7 +2,7 @@ import { h } from 'snabbdom'
 import { VNode } from 'snabbdom/vnode'
 import * as chessground from './ground';
 import { bind, onInsert, dataIcon, spinner, bindMobileMousedown } from './util';
-import changeColourHandle from 'common/coordsColour';
+import changeColorHandle from 'common/coordsColor';
 import { getPlayer, playable } from 'game';
 import * as router from 'game/router';
 import statusView from 'game/view/status';
@@ -231,7 +231,7 @@ function controls(ctrl: AnalyseCtrl) {
 function forceInnerCoords(ctrl: AnalyseCtrl, v: boolean) {
   if (ctrl.data.pref.coords == 2){
     $('body').toggleClass('coords-in', v).toggleClass('coords-out', !v);
-    changeColourHandle();
+    changeColorHandle();
   }
 }
 

--- a/ui/common/css/vendor/chessground/_coords-colors.scss
+++ b/ui/common/css/vendor/chessground/_coords-colors.scss
@@ -1,47 +1,21 @@
 @mixin coords-colors {
-  .blue {
-    coord { text-shadow: none; }
+    :root {
+    --color-white: #fff;
+    --color-black: #fff;
+    --shadow: 0 1px 2px #000;
+  }
+
+    coord { text-shadow: var(--shadow); }
     .orientation-white .files coords:nth-child(2n+1),
     .orientation-white .ranks coords:nth-child(2n),
     .orientation-black .files coords:nth-child(2n),
     .orientation-black .ranks coords:nth-child(2n+1) {
-      color: #DEE3E6;
+      color: var(--color-white);
     }
     .orientation-white .files coord:nth-child(2n),
     .orientation-white .ranks coord:nth-child(2n+1),
     .orientation-black .files coord:nth-child(2n+1),
     .orientation-black .ranks coord:nth-child(2n) {
-      color: #788a94;
+      color: var(--color-black);
     }
-  }
-  .brown {
-    coord { text-shadow: none; }
-    .orientation-white .files coord:nth-child(2n+1),
-    .orientation-white .ranks coord:nth-child(2n),
-    .orientation-black .files coord:nth-child(2n),
-    .orientation-black .ranks coord:nth-child(2n+1) {
-      color: #F0D9B5;
-    }
-    .orientation-white .files coord:nth-child(2n),
-    .orientation-white .ranks coord:nth-child(2n+1),
-    .orientation-black .files coord:nth-child(2n+1),
-    .orientation-black .ranks coord:nth-child(2n) {
-      color: #946f51;
-    }
-  }
-  .green {
-    coord { text-shadow: none; }
-    .orientation-white .files coords:nth-child(2n+1),
-    .orientation-white .ranks coords:nth-child(2n),
-    .orientation-black .files coords:nth-child(2n),
-    .orientation-black .ranks coords:nth-child(2n+1) {
-      color: #FFFFDD;
-    }
-    .orientation-white .files coord:nth-child(2n),
-    .orientation-white .ranks coord:nth-child(2n+1),
-    .orientation-black .files coord:nth-child(2n+1),
-    .orientation-black .ranks coord:nth-child(2n) {
-      color: #6d8753;
-    }
-  }
 }

--- a/ui/common/css/vendor/chessground/_coords-colors.scss
+++ b/ui/common/css/vendor/chessground/_coords-colors.scss
@@ -5,11 +5,11 @@
     --shadow: 0 1px 2px #000;
   }
 
-    coord { text-shadow: var(--shadow); }
-    .orientation-white .files coords:nth-child(2n+1),
-    .orientation-white .ranks coords:nth-child(2n),
-    .orientation-black .files coords:nth-child(2n),
-    .orientation-black .ranks coords:nth-child(2n+1) {
+    coords { text-shadow: var(--shadow); }
+    .orientation-white .files coord:nth-child(2n+1),
+    .orientation-white .ranks coord:nth-child(2n),
+    .orientation-black .files coord:nth-child(2n),
+    .orientation-black .ranks coord:nth-child(2n+1) {
       color: var(--color-white);
     }
     .orientation-white .files coord:nth-child(2n),

--- a/ui/common/src/coordsColor.ts
+++ b/ui/common/src/coordsColor.ts
@@ -1,4 +1,4 @@
-export default function changeColourHandle(){
+export default function changeColorHandle(){
 
 	const listClass: string[] = $('body').attr('class').split(' ')
 

--- a/ui/common/src/coordsColour.ts
+++ b/ui/common/src/coordsColour.ts
@@ -8,8 +8,25 @@ export default function changeColourHandle(){
 		"blue3": ["#d9e0e6", "#315991"],
 		"canvas": ["#d7daeb", "#547388"],
 		"wood": ["#d8a45b", "#9b4d0f"],
+		"wood2": ["#a38b5d", "#6c5017"],
+		"wood3": ["#d0ceca", "#755839"],
+		"maple": ["#e8ceab", "#bc7944"],
+		"maple2": ["#E2C89F", "#996633"],
+		"leather": ["#d1d1c9", "#c28e16"],
+		"green": ["#FFFFDD", "#6d8753"],
 		"brown": ["#F0D9B5", "#946f51"],
-		"pink": ["#f1f1c9", "#f07272"]
+		"pink": ["#E8E9B7", "#ED7272"],
+		"marble": ["#93ab91", "#4f644e"],
+		"blue-marble": ["#EAE6DD", "#7C7F87"],
+		"green-plastic": ["#f2f9bb", "#59935d"],
+		"green-glass": ["#fafa97", "#e4a836"],
+		"grey": ["#b8b8b8", "#7d7d7d"],
+		"metal": ["#c9c9c9", "#727272"],
+		"olive": ["#b8b19f", "#6d6655"],
+		"newspaper": ["#fff", "#8d8d8d"],
+		"purple": ["#9f90b0", "#7d4a8d"],
+		"purple-diag": ["#E5DAF0", "#957AB0"],
+		"ic": ["#ececec", "#c1c18e"]
 	}
 	let color: string
 	for (color of list_class){

--- a/ui/common/src/coordsColour.ts
+++ b/ui/common/src/coordsColour.ts
@@ -1,0 +1,22 @@
+export default function changeColourHandle(){
+
+	const list_class: string[] = $('body').attr('class').split(' ')
+
+	const dict: {[color: string]: [string, string]} = {
+		"blue": ["#DEE3E6", "#788a94"],
+		"blue2": ["#97b2c7", "#546f82"],
+		"blue3": ["#d9e0e6", "#315991"],
+		"canvas": ["#d7daeb", "#547388"],
+		"wood": ["#d8a45b", "#9b4d0f"],
+		"brown": ["#F0D9B5", "#946f51"],
+		"pink": ["#f1f1c9", "#f07272"]
+	}
+	let color: string
+	for (color of list_class){
+		if (color in dict){
+			document.documentElement.style.setProperty('--color-white', dict[color][0]);
+			document.documentElement.style.setProperty('--color-black', dict[color][1]);
+			document.documentElement.style.setProperty('--shadow', "none");
+		}
+	}
+}

--- a/ui/common/src/coordsColour.ts
+++ b/ui/common/src/coordsColour.ts
@@ -1,6 +1,6 @@
 export default function changeColourHandle(){
 
-	const list_class: string[] = $('body').attr('class').split(' ')
+	const listClass: string[] = $('body').attr('class').split(' ')
 
 	const dict: {[color: string]: [string, string]} = {
 		"blue": ["#DEE3E6", "#788a94"],
@@ -29,7 +29,7 @@ export default function changeColourHandle(){
 		"ic": ["#ececec", "#c1c18e"]
 	}
 	let color: string
-	for (color of list_class){
+	for (color of listClass){
 		if (color in dict){
 			document.documentElement.style.setProperty('--color-white', dict[color][0]);
 			document.documentElement.style.setProperty('--color-black', dict[color][1]);

--- a/ui/dasher/src/theme.ts
+++ b/ui/dasher/src/theme.ts
@@ -1,6 +1,6 @@
 import { h } from 'snabbdom'
 import { VNode } from 'snabbdom/vnode'
-import changeColourHandle from 'common/coordsColour';
+import changeColorHandle from 'common/coordsColor';
 
 import { Redraw, Open, bind, header } from './util'
 
@@ -69,5 +69,5 @@ function themeView(current: Theme, set: (t: Theme) => void) {
 
 function applyTheme(t: Theme, list: Theme[]) {
   $('body').removeClass(list.join(' ')).addClass(t);
-  changeColourHandle()
+  changeColorHandle()
 }

--- a/ui/dasher/src/theme.ts
+++ b/ui/dasher/src/theme.ts
@@ -1,5 +1,6 @@
 import { h } from 'snabbdom'
 import { VNode } from 'snabbdom/vnode'
+import changeColourHandle from 'common/coordsColour';
 
 import { Redraw, Open, bind, header } from './util'
 
@@ -68,4 +69,5 @@ function themeView(current: Theme, set: (t: Theme) => void) {
 
 function applyTheme(t: Theme, list: Theme[]) {
   $('body').removeClass(list.join(' ')).addClass(t);
+  changeColourHandle()
 }

--- a/ui/editor/src/chessground.ts
+++ b/ui/editor/src/chessground.ts
@@ -4,6 +4,7 @@ import { Chessground } from 'chessground';
 import { Config as CgConfig } from 'chessground/config';
 import { MouchEvent } from 'chessground/types';
 import * as util from 'chessground/util';
+import changeColourHandle from 'common/coordsColour';
 import EditorCtrl from './ctrl';
 
 export default function(ctrl: EditorCtrl): VNode {
@@ -145,7 +146,10 @@ function makeConfig(ctrl: EditorCtrl): CgConfig {
       lastMove: false
     },
     events: {
-      change: ctrl.onChange.bind(ctrl)
+      change: ctrl.onChange.bind(ctrl),
+      insert(){
+        changeColourHandle()
+      }
     }
   };
 }

--- a/ui/editor/src/chessground.ts
+++ b/ui/editor/src/chessground.ts
@@ -4,7 +4,7 @@ import { Chessground } from 'chessground';
 import { Config as CgConfig } from 'chessground/config';
 import { MouchEvent } from 'chessground/types';
 import * as util from 'chessground/util';
-import changeColourHandle from 'common/coordsColour';
+import changeColorHandle from 'common/coordsColor';
 import EditorCtrl from './ctrl';
 
 export default function(ctrl: EditorCtrl): VNode {
@@ -147,7 +147,7 @@ function makeConfig(ctrl: EditorCtrl): CgConfig {
     },
     events: {
       change: ctrl.onChange.bind(ctrl),
-      insert: changeColourHandle
+      insert: changeColorHandle
     }
   };
 }

--- a/ui/editor/src/chessground.ts
+++ b/ui/editor/src/chessground.ts
@@ -147,9 +147,7 @@ function makeConfig(ctrl: EditorCtrl): CgConfig {
     },
     events: {
       change: ctrl.onChange.bind(ctrl),
-      insert(){
-        changeColourHandle()
-      }
+      insert: changeColourHandle
     }
   };
 }

--- a/ui/puzzle/src/view/chessground.ts
+++ b/ui/puzzle/src/view/chessground.ts
@@ -2,6 +2,7 @@ import { h } from 'snabbdom'
 import { VNode } from 'snabbdom/vnode';
 import { Chessground } from 'chessground';
 import { Config as CgConfig } from 'chessground/config';
+import changeColourHandle from 'common/coordsColour';
 import resizeHandle from 'common/resize';
 import { Controller } from '../interfaces';
 
@@ -46,7 +47,8 @@ function makeConfig(ctrl: Controller): CgConfig {
           ctrl.pref.resizeHandle,
           ctrl.vm.node.ply,
           (_) => true
-        )
+        );
+        if (ctrl.pref.coords == 1) changeColourHandle();
       }
     },
     premovable: {

--- a/ui/puzzle/src/view/chessground.ts
+++ b/ui/puzzle/src/view/chessground.ts
@@ -2,7 +2,7 @@ import { h } from 'snabbdom'
 import { VNode } from 'snabbdom/vnode';
 import { Chessground } from 'chessground';
 import { Config as CgConfig } from 'chessground/config';
-import changeColourHandle from 'common/coordsColour';
+import changeColorHandle from 'common/coordsColor';
 import resizeHandle from 'common/resize';
 import { Controller } from '../interfaces';
 
@@ -48,7 +48,7 @@ function makeConfig(ctrl: Controller): CgConfig {
           ctrl.vm.node.ply,
           (_) => true
         );
-        if (ctrl.pref.coords == 1) changeColourHandle();
+        if (ctrl.pref.coords == 1) changeColorHandle();
       }
     },
     premovable: {

--- a/ui/puzzle/src/view/main.ts
+++ b/ui/puzzle/src/view/main.ts
@@ -1,5 +1,6 @@
 import { h } from 'snabbdom'
 import { VNode } from 'snabbdom/vnode'
+import changeColourHandle from 'common/coordsColour';
 import chessground from './chessground';
 import { render as treeView } from './tree';
 import { view as cevalView } from 'ceval';
@@ -76,8 +77,10 @@ export default function(ctrl: Controller): VNode {
       postpatch(old, vnode) {
         gridHacks.start(vnode.elm as HTMLElement)
         if (old.data!.gaugeOn !== gaugeOn) {
-          if (ctrl.pref.coords == 2)
+          if (ctrl.pref.coords == 2){
             $('body').toggleClass('coords-in', gaugeOn).toggleClass('coords-out', !gaugeOn);
+            changeColourHandle();
+          }
           window.lichess.dispatchEvent(document.body, 'chessground.resize');
         }
         vnode.data!.gaugeOn = gaugeOn;

--- a/ui/puzzle/src/view/main.ts
+++ b/ui/puzzle/src/view/main.ts
@@ -1,6 +1,6 @@
 import { h } from 'snabbdom'
 import { VNode } from 'snabbdom/vnode'
-import changeColourHandle from 'common/coordsColour';
+import changeColorHandle from 'common/coordsColor';
 import chessground from './chessground';
 import { render as treeView } from './tree';
 import { view as cevalView } from 'ceval';
@@ -79,7 +79,7 @@ export default function(ctrl: Controller): VNode {
         if (old.data!.gaugeOn !== gaugeOn) {
           if (ctrl.pref.coords == 2){
             $('body').toggleClass('coords-in', gaugeOn).toggleClass('coords-out', !gaugeOn);
-            changeColourHandle();
+            changeColorHandle();
           }
           window.lichess.dispatchEvent(document.body, 'chessground.resize');
         }

--- a/ui/round/src/ground.ts
+++ b/ui/round/src/ground.ts
@@ -2,7 +2,8 @@ import { h } from 'snabbdom'
 import { Chessground } from 'chessground';
 import * as cg from 'chessground/types';
 import { Api as CgApi } from 'chessground/api';
-import { Config } from 'chessground/config'
+import { Config } from 'chessground/config';
+import changeColourHandle from 'common/coordsColour';
 import resizeHandle from 'common/resize';
 import * as util from './util';
 import { plyStep } from './round';
@@ -31,6 +32,7 @@ export function makeConfig(ctrl: RoundController): Config {
       dropNewPiece: hooks.onNewPiece,
       insert(elements) {
         resizeHandle(elements, ctrl.data.pref.resizeHandle, ctrl.ply);
+        if (data.pref.coords == 1) changeColourHandle();
       }
     },
     movable: {

--- a/ui/round/src/ground.ts
+++ b/ui/round/src/ground.ts
@@ -3,7 +3,7 @@ import { Chessground } from 'chessground';
 import * as cg from 'chessground/types';
 import { Api as CgApi } from 'chessground/api';
 import { Config } from 'chessground/config';
-import changeColourHandle from 'common/coordsColour';
+import changeColorHandle from 'common/coordsColor';
 import resizeHandle from 'common/resize';
 import * as util from './util';
 import { plyStep } from './round';
@@ -32,7 +32,7 @@ export function makeConfig(ctrl: RoundController): Config {
       dropNewPiece: hooks.onNewPiece,
       insert(elements) {
         resizeHandle(elements, ctrl.data.pref.resizeHandle, ctrl.ply);
-        if (data.pref.coords == 1) changeColourHandle();
+        if (data.pref.coords == 1) changeColorHandle();
       }
     },
     movable: {


### PR DESCRIPTION
Close #5809 and close #5820 

This PR adds alternate colours for all inline boards, using ts. I've mainly kept the colours proposed by JimiRecard.

A few examples:

Old
![Screen Shot 2020-04-26 at 14 09 31](https://user-images.githubusercontent.com/56031107/80308572-aaae1b00-87c7-11ea-9419-cd45d629e146.png)
New
![Screen Shot 2020-04-26 at 13 55 52](https://user-images.githubusercontent.com/56031107/80308251-c2849f80-87c5-11ea-8cd0-3ca6366f0b80.png)
Old
![Screen Shot 2020-04-26 at 14 09 42](https://user-images.githubusercontent.com/56031107/80308575-ae41a200-87c7-11ea-8391-6dba35c0043d.png)
New
![Screen Shot 2020-04-26 at 13 56 02](https://user-images.githubusercontent.com/56031107/80308254-c57f9000-87c5-11ea-8085-c37c52c0e52d.png)
Old
![Screen Shot 2020-04-26 at 14 09 51](https://user-images.githubusercontent.com/56031107/80308576-af72cf00-87c7-11ea-803c-f9a22a88b922.png)
New
![Screen Shot 2020-04-26 at 13 56 12](https://user-images.githubusercontent.com/56031107/80308255-c6182680-87c5-11ea-89a0-b3fb30369cb0.png)
