### PR TITLE
Analysis Board: Hide Inline Annotations when Computer Is Disabled

### DIFF
--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -96,7 +96,7 @@ function renderMoveOf(ctx: Ctx, node: Tree.Node, opts: Opts): VNode {
     opts.withIndex || node.ply & 1 ? moveView.renderIndex(node.ply, true) : null,
     fixCrazySan(node.san!)
   ];
-  if (node.glyphs) moveView.renderGlyphs(node.glyphs).forEach(g => content.push(g));
+  if (node.glyphs && ctx.showGlyphs) moveView.renderGlyphs(node.glyphs).forEach(g => content.push(g));
   return h('move', {
     attrs: { p: path },
     class: nodeClasses(ctx, path)


### PR DESCRIPTION
Close #6419. First time contributor here :wave:.

Hides annotation glyphs from the inline move tree when the computer is disabled. This updates the inline view to match the existing behaviour of the [column view](https://github.com/ornicar/lila/blob/39a7134149e0b0f2e0d3b5fee9980d5b7acb995e/ui/analyse/src/moveView.ts#L38).

This change is only intended to affect the post-game analysis board feature. Studies remain configured to always show glyphs (since they can mix computer-created and human-created glyphs).

Before: 
![before](https://user-images.githubusercontent.com/5103414/80330926-98a69980-8814-11ea-97d9-eaba129bcba7.png)

After:
![after](https://user-images.githubusercontent.com/5103414/80330933-9e03e400-8814-11ea-973b-fb49bb1af911.png)

