### PR TITLE
Show selected square in blindfold mode even when king is in check

### DIFF
--- a/ui/chess/css/_blindfold.scss
+++ b/ui/chess/css/_blindfold.scss
@@ -4,6 +4,6 @@
     opacity: 0;
   }
   &.main-board .check {
-    background: none;
+    background-image: none;
   }
 }


### PR DESCRIPTION
Resolves https://github.com/ornicar/lila/issues/6450.

In blindfold mode when the king is in check, suppress only the `background-image`.  The red `background-image` representing "check" will remain hidden, while the `background-color` representing square selection will now be visible.

Before (King square not highlighted at 0:19): https://vimeo.com/412988808
After (King square highlighted at 0:19): https://vimeo.com/412990317