### PR TITLE
NVUI: return `blank` instead of an error when line/rank empty for `scan`

### DIFF
--- a/ui/nvui/src/chess.ts
+++ b/ui/nvui/src/chess.ts
@@ -93,7 +93,7 @@ export function renderPiecesOn(pieces: Pieces, rankOrFile: string, style: Style)
       if (piece) res.push(`${renderKey(k, style)} ${piece.color} ${piece.role}`);
     }
   }
-  return res.join(', ');
+  return res.length ? res.join(', ') : 'blank';
 }
 
 export function renderBoard(pieces: Pieces, pov: Color): string {


### PR DESCRIPTION
> I've just noticed, that whenever scan command is used and the file or rank requested is currently empty, we get a negative outpood instead of getting 'blank' message for example.
Actual result: scan a = 'invalid command: scan a' (only if the a file is empty)
Expected result: scan a = 'blank'

Current behaviour 
![Screen Shot 2020-05-02 at 10 36 50](https://user-images.githubusercontent.com/56031107/80860670-13cade00-8c61-11ea-8ce5-7186cc0de83f.png)

After the patch
![Screen Shot 2020-05-02 at 10 34 10](https://user-images.githubusercontent.com/56031107/80860668-12011a80-8c61-11ea-8803-3b9af64e38cb.png)
