### PR TITLE
Remove "reportable && exceptionalDif" condition

### DIFF
--- a/modules/evaluation/src/main/PlayerAggregateAssessment.scala
+++ b/modules/evaluation/src/main/PlayerAggregateAssessment.scala
@@ -74,7 +74,6 @@ case class PlayerAggregateAssessment(
     if (actionable) {
       if (markable && bannable) EngineAndBan
       else if (markable) Engine
-      else if (reportable && exceptionalDif && weightedCheatingSum >= 1) Engine
       else if (reportable) reportVariousReasons
       else Nothing
     } else {


### PR DESCRIPTION
I didn't know that this happened -- but, this may cause false positives or very borderline cases, and otherwise it's confusing that tweaking `reportable` also affects this. Either way it gives too much importance to `exceptionalDif`, imo, and with the improved `markable` it also should no longer be needed, and just having these as a report is fine.