### PR TITLE
Analysis import/export PGN variations

### DIFF
--- a/app/controllers/UserAnalysis.scala
+++ b/app/controllers/UserAnalysis.scala
@@ -142,7 +142,7 @@ final class UserAnalysis(
               .fold(
                 err => BadRequest(jsonError(err.toString)).fuccess,
                 {
-                  case (game, fen) =>
+                  case (game, fen, root) =>
                     val pov = Pov(game, chess.White)
                     env.api.roundApi.userAnalysisJson(
                       pov,

--- a/app/controllers/UserAnalysis.scala
+++ b/app/controllers/UserAnalysis.scala
@@ -150,7 +150,8 @@ final class UserAnalysis(
                       initialFen = fen,
                       pov.color,
                       owner = false,
-                      me = ctx.me
+                      me = ctx.me,
+                      root = root.some
                     ) map { data =>
                       Ok(data)
                     }

--- a/modules/importer/src/main/Importer.scala
+++ b/modules/importer/src/main/Importer.scala
@@ -1,8 +1,10 @@
 package lila.importer
 
-import chess.format.FEN
+import chess.format.{ FEN, Forsyth, Uci, UciCharPair }
+import chess.format.pgn.{ Dumper, San }
 
 import lila.game.{ Game, GameRepo }
+import lila.tree.{ Branch, Node, Root }
 
 final class Importer(gameRepo: GameRepo)(implicit ec: scala.concurrent.ExecutionContext) {
 
@@ -29,8 +31,65 @@ final class Importer(gameRepo: GameRepo)(implicit ec: scala.concurrent.Execution
     }
   }
 
-  def inMemory(data: ImportData): Valid[(Game, Option[FEN])] =
+  def inMemory(data: ImportData): Valid[(Game, Option[FEN], Root)] =
     data.preprocess(user = none).map {
-      case Preprocessed(game, _, fen, _) => (game withId "synthetic", fen)
+      case preprocessed @ Preprocessed(game, _, fen, _) =>
+        (game withId "synthetic", fen, makeRoot(preprocessed))
+    }
+
+  private def makeRoot(preprocessed: Preprocessed): Root =
+    preprocessed match {
+      case Preprocessed(game, replay, initialFen, parsed) =>
+        val variations = makeVariations(replay.setup, parsed.sans.value)
+        Root(
+          ply = replay.setup.turns,
+          fen = (initialFen | FEN(game.variant.initialFen)).value,
+          check = replay.setup.situation.check,
+          clock = parsed.tags.clockConfig.map(_.limit),
+          crazyData = replay.setup.situation.board.crazyData,
+          children = makeNode(replay.setup, parsed.sans.value).fold(variations)(_ :: variations)
+        )
+    }
+
+  private def makeNode(prev: chess.Game, sans: List[San]): Option[Branch] =
+    sans match {
+      case Nil => none
+      case san :: rest =>
+        san(prev.situation).fold(
+          _ => none,
+          moveOrDrop => {
+            val game       = moveOrDrop.fold(prev.apply, prev.applyDrop)
+            val uci        = moveOrDrop.fold(_.toUci, _.toUci)
+            val sanStr     = moveOrDrop.fold(Dumper.apply, Dumper.apply)
+            val variations = makeVariations(game, rest)
+            Branch(
+              id = UciCharPair(uci),
+              ply = game.turns,
+              move = Uci.WithSan(uci, sanStr),
+              fen = Forsyth >> game,
+              check = game.situation.check,
+              comments = makeComments(san.metas.comments),
+              glyphs = san.metas.glyphs,
+              crazyData = game.situation.board.crazyData,
+              children = makeNode(game, rest).fold(variations)(_ :: variations)
+            ).some
+          }
+        )
+    }
+
+  private def makeComments(comments: List[String]) =
+    Node.Comments {
+      comments.map(text =>
+        Node.Comment(
+          Node.Comment.Id.make,
+          Node.Comment.Text(text),
+          Node.Comment.Author.Lichess
+        )
+      )
+    }
+
+  private def makeVariations(game: chess.Game, sans: List[San]) =
+    sans.headOption ?? {
+      _.metas.variations.flatMap(variation => makeNode(game, variation.value))
     }
 }

--- a/ui/analyse/src/forecast/forecastView.ts
+++ b/ui/analyse/src/forecast/forecastView.ts
@@ -27,15 +27,18 @@ function onMyTurn(ctrl: AnalyseCtrl, fctrl: ForecastCtrl, cNodes: ForecastStep[]
   ]);
 }
 
+const nodeToForecastStep = (node: Tree.Node): ForecastStep => ({
+  ply: node.ply,
+  fen: node.fen,
+  uci: node.uci!,
+  san: node.san!,
+  check: node.check,
+  children: node.children.map(nodeToForecastStep),
+})
+
 function makeCnodes(ctrl: AnalyseCtrl, fctrl: ForecastCtrl): ForecastStep[] {
   const afterPly = ctrl.tree.getCurrentNodesAfterPly(ctrl.nodeList, ctrl.mainline, ctrl.data.game.turns);
-  return fctrl.truncate(afterPly.map(node => ({
-    ply: node.ply,
-    fen: node.fen,
-    uci: node.uci!,
-    san: node.san!,
-    check: node.check
-  })));
+  return fctrl.truncate(afterPly.map(nodeToForecastStep));
 }
 
 export default function(ctrl: AnalyseCtrl, fctrl: ForecastCtrl): VNode {

--- a/ui/analyse/src/forecast/interfaces.ts
+++ b/ui/analyse/src/forecast/interfaces.ts
@@ -11,6 +11,7 @@ export interface ForecastStep {
   san: San;
   fen: Fen;
   check?: Key;
+  children: ForecastStep[],
 }
 
 export interface ForecastCtrl {

--- a/ui/analyse/src/pgnExport.ts
+++ b/ui/analyse/src/pgnExport.ts
@@ -1,7 +1,7 @@
 import AnalyseCtrl from './ctrl';
-import { h } from 'snabbdom'
-import { initialFen, fixCrazySan } from 'chess';
-import { MaybeVNodes } from './interfaces';
+import {h} from 'snabbdom';
+import {initialFen, fixCrazySan} from 'chess';
+import {MaybeVNodes} from './interfaces';
 
 interface PgnNode {
   ply: Ply;
@@ -11,38 +11,40 @@ interface PgnNode {
 
 function renderNode(node?: PgnNode): string {
   if (!node || !node.san || node.ply === 0) return '';
-  let s = ''
+  let s = '';
   if (node.ply % 2 === 1)
-    s += ((node.ply + 1) / 2) + '. '
-  return s + fixCrazySan(node.san) + ' '
+    s += ((node.ply + 1) / 2) + '. ';
+  return s + fixCrazySan(node.san) + ' ';
 }
 
-function firstMovePrefix(node: PgnNode): string {
-  return node.ply % 2 === 1 ? '' : Math.floor((node.ply + 1) / 2) + '... '
+function rootNodePrefix(node: PgnNode): string {
+  return node.ply % 2 === 1 ? '' : Math.floor((node.ply + 1) / 2) + '... ';
 }
 
-function renderChildren(children: PgnNode[], firstMove: boolean = false): string {
+function renderChildren(children: PgnNode[], isRoot: boolean = false): string {
   if (!children.length)
-    return ''
+    return '';
 
-  let s = ''
-  if (firstMove)
-    s += firstMovePrefix(children[0]);
-  s += renderNode(children[0])
+  let s = '';
+  const firstChild = children[0];
+
+  if (isRoot)
+    s += rootNodePrefix(firstChild);
+  s += renderNode(firstChild);
 
   children.slice(1).forEach(child => {
-    s += '('
-    if (firstMove)
-      s += firstMovePrefix(child);
-    s += renderNode(child)
-    s += renderChildren(child.children)
-    s = s.trim()
-    s += ') '
-  })
+    s += '(';
+    if (isRoot)
+      s += rootNodePrefix(child);
+    s += renderNode(child);
+    s += renderChildren(child.children);
+    s = s.trim();
+    s += ') ';
+  });
 
-  s += renderChildren(children[0].children)
+  s += renderChildren(firstChild.children);
 
-  return s
+  return s;
 }
 
 export function renderFullTxt(ctrl: AnalyseCtrl): string {


### PR DESCRIPTION
Fixes: https://github.com/ornicar/lila/issues/6595

<img width="901" alt="Screen Shot 2020-05-17 at 08 30 18" src="https://user-images.githubusercontent.com/8725423/82146479-bc0fa380-9818-11ea-8707-df6fe640018c.png">

This PR does 2 things
1. Upgrades the PGN importer for analysis mode to add variations and comments to the tree. This was done by upgrading `importer/Importer.scala` to use `ParsedPgn` to return a regular `tree.Node`. This node is then passed to `RoundAPI` where it is used for the `"treeParts"` section of the json. Previously, the tree was created by `TreeBuilder`, which only takes a `Game`, which does not contain variations.
2. Upgrades the PGN exporter on the frontend to write variations. Previously, it would be rendered by iterating through `tree.getNodeList`, which is the path that the user is currently focused on. Now, I render recursively from `root.children`.

Notes
1. This is my first scala PR! Took me many hours to complete it, most of them spent simply reading and attempting understand the existing code.
2. I understand there is a lot of duplication between Analysis and Study. Most of the code I wrote in `Importer.scala` was copied from `study/PgnImport.scala`. If there are plans for somehow merging their codebases together, then we can just close this PR completely. Or maybe you don't even want this feature in Analysis? Maybe you want people to go to Study if they want variations?
3. Upgrading PGN importer has the side effect of also importing comments!
4. Previously, the frontend PGN exporter would create a newline every 8 plies. I can't figure out a clean way to do that with nesting. Doesn't look too shabby though.

Questions
1. Am I doing any Scala things completely wrong?
2. Is building the `Root` in `Importer` correct? Or should the `ParsedPgn` be passed into `RoundApi`, then make the `Root` from there?
3. If (2) is fine, then is the way I passed `root` into `UserAnalysis` as an optional parameter with default value `none` ok?
4. On the frontend, I had to add `children` as a property of `ForecastStep` since they both use the same interface that converts to `PgnNode` node. Semantically it's fine since everything comes from `Node`, but not sure if it's the right thing to do.

I still need to address a couple things before making this a full PR
1. ~~Remove duplicate entries, same as Study's `removeDuplicatedChildrenFirstNode`. I tried already but was struggling. Will get it done!~~ Not doing this. (1) None of the other PGN exporters I tried on the web do it. It seems pretty useless. (2) It causes weird misalignments (see below). (3) It only works 1 turn deep anyway. Maybe there was a specific reason to do it for studies?
<img width="389" alt="Screen Shot 2020-05-18 at 09 52 24" src="https://user-images.githubusercontent.com/8725423/82221295-cea7dc80-98ed-11ea-974b-2b36adb72edb.png">

2. ~~Test on more data samples. I will use https://github.com/ornicar/scalachess/blob/master/src/test/scala/format/pgn/Fixtures.scala~~ Tested every one with no issues!