### PR TITLE
Load and save incomplete messages

### DIFF
--- a/ui/chat/src/discussion.ts
+++ b/ui/chat/src/discussion.ts
@@ -84,11 +84,18 @@ function renderInput(ctrl: Ctrl): VNode | undefined {
 let mouchListener: EventListener;
 
 const setupHooks = (ctrl: Ctrl, chatEl: HTMLElement) => {
-  chatEl.addEventListener('keypress',
+  chatEl.addEventListener('keydown',
     (e: KeyboardEvent) => setTimeout(() => {
       const el = e.target as HTMLInputElement,
         txt = el.value,
         pub = ctrl.opts.public;
+      if(sessionStorage.getItem("txt") != null && sessionStorage.getItem("txt") != "") {
+        el.value = sessionStorage.getItem("txt")!
+        sessionStorage.removeItem("txt")
+      }
+      window.addEventListener('beforeunload', () => {
+        sessionStorage.setItem("txt", el.value);
+      });
       if (e.which == 10 || e.which == 13) {
         if (txt === '') $('.keyboard-move input').focus();
         else {
@@ -105,6 +112,13 @@ const setupHooks = (ctrl: Ctrl, chatEl: HTMLElement) => {
       }
     })
   );
+
+  if(sessionStorage.getItem("txt") != null && sessionStorage.getItem("txt") != "") {
+    chatEl.focus();
+    var event = new KeyboardEvent("keydown", {key : " "});
+    chatEl.dispatchEvent(event);
+  }
+
 
   window.Mousetrap.bind('c', () => {
     chatEl.focus();

--- a/ui/chat/src/discussion.ts
+++ b/ui/chat/src/discussion.ts
@@ -84,10 +84,10 @@ function renderInput(ctrl: Ctrl): VNode | undefined {
 let mouchListener: EventListener;
 
 const setupHooks = (ctrl: Ctrl, chatEl: HTMLElement) => {
-  let tempChat = window.lichess.tempStorage.get("tempChatStorage");
-  if(tempChat !== null && tempChat !== ""){
+  const tempChat = window.lichess.tempStorage.get("tempChatStorage");
+  if(tempChat !== null){
     (chatEl as HTMLInputElement).value = window.lichess.tempStorage.get("tempChatStorage")!;
-    window.lichess.tempStorage.set("tempChatStorage", "");
+    window.lichess.tempStorage.remove("tempChatStorage");
     chatEl.focus();
   }
 
@@ -96,7 +96,7 @@ const setupHooks = (ctrl: Ctrl, chatEl: HTMLElement) => {
       const el = e.target as HTMLInputElement,
         txt = el.value,
         pub = ctrl.opts.public;
-      window.lichess.tempStorage.set("tempChatStorage", el.value)
+      window.lichess.tempStorage.set("tempChatStorage", el.value);
       if (e.which == 10 || e.which == 13) {
         if (txt === '') $('.keyboard-move input').focus();
         else {
@@ -104,6 +104,7 @@ const setupHooks = (ctrl: Ctrl, chatEl: HTMLElement) => {
           if (pub && spam.hasTeamUrl(txt)) alert("Please don't advertise teams in the chat.");
           else ctrl.post(txt);
           el.value = '';
+          window.lichess.tempStorage.remove("tempChatStorage");
           if (!pub) el.classList.remove('whisper');
         }
       }

--- a/ui/chat/src/discussion.ts
+++ b/ui/chat/src/discussion.ts
@@ -84,18 +84,19 @@ function renderInput(ctrl: Ctrl): VNode | undefined {
 let mouchListener: EventListener;
 
 const setupHooks = (ctrl: Ctrl, chatEl: HTMLElement) => {
-  chatEl.addEventListener('keydown',
+  let tempChat = window.lichess.tempStorage.get("tempChatStorage");
+  if(tempChat !== null && tempChat !== ""){
+    (chatEl as HTMLInputElement).value = window.lichess.tempStorage.get("tempChatStorage")!;
+    window.lichess.tempStorage.set("tempChatStorage", "");
+    chatEl.focus();
+  }
+
+  chatEl.addEventListener('keypress',
     (e: KeyboardEvent) => setTimeout(() => {
       const el = e.target as HTMLInputElement,
         txt = el.value,
         pub = ctrl.opts.public;
-      if(sessionStorage.getItem("txt") != null && sessionStorage.getItem("txt") != "") {
-        el.value = sessionStorage.getItem("txt")!
-        sessionStorage.removeItem("txt")
-      }
-      window.addEventListener('beforeunload', () => {
-        sessionStorage.setItem("txt", el.value);
-      });
+      window.lichess.tempStorage.set("tempChatStorage", el.value)
       if (e.which == 10 || e.which == 13) {
         if (txt === '') $('.keyboard-move input').focus();
         else {
@@ -112,13 +113,6 @@ const setupHooks = (ctrl: Ctrl, chatEl: HTMLElement) => {
       }
     })
   );
-
-  if(sessionStorage.getItem("txt") != null && sessionStorage.getItem("txt") != "") {
-    chatEl.focus();
-    var event = new KeyboardEvent("keydown", {key : " "});
-    chatEl.dispatchEvent(event);
-  }
-
 
   window.Mousetrap.bind('c', () => {
     chatEl.focus();


### PR DESCRIPTION
Fixes: #3490

This PR adds sessionStorage to discussion.ts, which loads and saves messages on reloads, tourney redirects, tv redirects, and any links the user inputs/follows.

Ex:
![beforeafter](https://user-images.githubusercontent.com/52363406/82245679-69fe7900-9911-11ea-8dad-40f54cd0b996.png)

A debatable aspect of this branch is that all chat boxes are treated equally, leaving a game with an incomplete message and joining another will have the input box restored and ready to type in with the old unsent message. Since it is saved in sessionStorage, this does not work across tabs or through closing the browser
