### PR TITLE
Send empty games every 70 seconds to keep the connection alive.

### DIFF
--- a/modules/api/src/main/GameApiV2.scala
+++ b/modules/api/src/main/GameApiV2.scala
@@ -194,7 +194,7 @@ final class GameApiV2(
 
   private def emptyMsgFor(config: Config) =
     config.format match {
-      case Format.PGN  => " \n"
+      case Format.PGN  => "\n"
       case Format.JSON => "{}\n"
     }
 

--- a/modules/api/src/main/GameApiV2.scala
+++ b/modules/api/src/main/GameApiV2.scala
@@ -102,7 +102,7 @@ final class GameApiV2(
       .mapConcat(_ filter config.postFilter)
       .take(config.max | Int.MaxValue)
       .via(preparationFlow(config))
-      .merge(Source.tick(keepAliveInterval, keepAliveInterval, emptyMsgFor(config)))
+      .keepAlive(keepAliveInterval, () => emptyMsgFor(config))
 
   def exportByIds(config: ByIdsConfig): Source[String, _] =
     gameRepo

--- a/modules/api/src/main/GameApiV2.scala
+++ b/modules/api/src/main/GameApiV2.scala
@@ -29,6 +29,8 @@ final class GameApiV2(
 
   import GameApiV2._
 
+  private val keepAliveInterval = 70.seconds // play's idleTimeout = 75s 
+
   def exportOne(game: Game, configInput: OneConfig): Fu[String] = {
     val config = configInput.copy(
       flags = configInput.flags.copy(
@@ -100,6 +102,7 @@ final class GameApiV2(
       .mapConcat(_ filter config.postFilter)
       .take(config.max | Int.MaxValue)
       .via(preparationFlow(config))
+      .merge(Source.tick(keepAliveInterval, keepAliveInterval, emptyMsgFor(config)))
 
   def exportByIds(config: ByIdsConfig): Source[String, _] =
     gameRepo
@@ -187,6 +190,12 @@ final class GameApiV2(
     config.format match {
       case Format.PGN  => pgnDump.formatter(config.flags)
       case Format.JSON => jsonFormatter(config.flags)
+    }
+
+  private def emptyMsgFor(config: Config) =
+    config.format match {
+      case Format.PGN  => " \n"
+      case Format.JSON => "{}\n"
     }
 
   private def jsonFormatter(flags: WithFlags) =

--- a/modules/game/src/main/GamesByUsersStream.scala
+++ b/modules/game/src/main/GamesByUsersStream.scala
@@ -23,7 +23,7 @@ final class GamesByUsersStream(gameRepo: lila.game.GameRepo)(implicit
     .mapAsync(1)(gameRepo.withInitialFen)
     .map(gameWithInitialFenWriter.writes)
     .map(some)
-    .merge(Source.tick(keepAliveInterval, keepAliveInterval, none))
+    .keepAlive(keepAliveInterval, () => none)
 
   def apply(userIds: Set[User.ID]): Source[Option[JsValue], _] =
     blueprint mapMaterializedValue { queue =>


### PR DESCRIPTION
As discussed in discord, if you heavily filter games for a player with a lot of games, there will be periods where nothing is sent for over 75s, which is the play timeout for connections. 

This PR takes the same approach as the previous game-stream fix by sending empty messages every 70 seconds.  In the case of the PGN format, this is an empty line. In the case of the `application/x-ndjson` version this is an empty json object.