### PR TITLE
Move 2fa clear/focus into raf to match .show()

### DIFF
--- a/public/javascripts/login.js
+++ b/public/javascripts/login.js
@@ -12,7 +12,9 @@ function load($f) {
       if (res === 'MissingTotpToken' || res === 'InvalidTotpToken') {
         $f.find('.one-factor').hide();
         $f.find('.two-factor').show();
-        $f.find('.two-factor input').val('').focus();
+        lichess.raf(function() {
+          $f.find('.two-factor input').val('').focus();
+        });
         $f.find('.submit').attr('disabled', false);
         if (res === 'InvalidTotpToken') $f.find('.two-factor .error').show();
       }


### PR DESCRIPTION
- Fix `.focus()` on 2FA input when form is initially shown
    - [`$.fn.show()` is overriden](https://github.com/ornicar/lila/blob/a9285b36fcd3727ff8e927abb9d11580759c51e7/ui/site/src/jquery.fill.js#L28) and its code is run in a `requestAnimationFrame`.
    - We need to delay our 2FA input logic until after `.show()` runs.

---

Let me know if there's a better way to do this. I saw that `.show()` will accept a callback, but I can't find any other usages of that parameter so I kept it simple and left this code using the public jQuery API.