### PR TITLE
Render decimal point in evaluations

### DIFF
--- a/ui/chess/src/main.ts
+++ b/ui/chess/src/main.ts
@@ -12,7 +12,7 @@ export function decomposeUci(uci: Uci): [Key, Key, string] {
 
 export function renderEval(e: number): string {
   e = Math.max(Math.min(Math.round(e / 10) / 10, 99), -99);
-  return (e > 0 ? '+' : '') + e;
+  return (e > 0 ? '+' : '') + e.toFixed(1);
 }
 
 export interface Dests {


### PR DESCRIPTION
Previously, evaluation renderings included at most one digit after the
decimal point, but omitted it if it would be zero: so, `+1.2`, but `+1`.
This is unambiguous, but a little confusing at a glance because `#1`
means “mate in one” while `+1` merely means “advantage to white”, and
the symbols are similar. This patch causes the decimal point to always
be included, so that it’s easier to immediately read the evaluation.

Test Plan:
After `cd ui/chess && yarn compile && cd dist`, checked in a Node shell:

```
> [0, 10, 90, 100, 105, 666, 6666, 66666].map(require("./main").renderEval)
[ '0.0', '+0.1', '+0.9', '+1.0', '+1.1', '+6.7', '+66.7', '+99.0' ]
```

wchargin-branch: ui-render-fixed-point-eval