### PR TITLE
tournament schedule filters

### DIFF
--- a/modules/tournament/src/main/ApiJsonView.scala
+++ b/modules/tournament/src/main/ApiJsonView.scala
@@ -19,7 +19,8 @@ final class ApiJsonView(lightUserApi: LightUserApi)(implicit ec: scala.concurren
     } yield Json.obj(
       "created"  -> created,
       "started"  -> started,
-      "finished" -> finished
+      "finished" -> finished,
+      "perfs"    -> JsArray(PerfType.all.map(perfJson))
     )
 
   private def visibleJson(implicit lang: Lang): PartialFunction[Tournament, Fu[JsObject]] = {

--- a/ui/analyse/src/util.ts
+++ b/ui/analyse/src/util.ts
@@ -116,6 +116,7 @@ export function baseUrl() {
 export function toYouTubeEmbed(url: string): string | undefined {
   const embedUrl = toYouTubeEmbedUrl(url);
   if (embedUrl) return `<div class="embed"><iframe width="100%" src="${embedUrl}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>`;
+  return undefined;
 }
 
 function toYouTubeEmbedUrl(url) {
@@ -140,12 +141,14 @@ function toYouTubeEmbedUrl(url) {
 export function toTwitchEmbed(url: string): string | undefined {
   const embedUrl = toTwitchEmbedUrl(url);
   if (embedUrl) return `<div class="embed"><iframe width="100%" src="${embedUrl}" frameborder=0 allowfullscreen></iframe></div>`;
+  return undefined;
 }
 
 function toTwitchEmbedUrl(url) {
   if (!url) return;
   var m = url.match(/(?:https?:\/\/)?(?:www\.)?(?:twitch.tv)\/([^"&?/ ]+)/i);
 if (m) return 'https://player.twitch.tv/?channel=' + m[1] + '&autoplay=false';
+  return undefined;
 }
 
 const commentYoutubeRegex = /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:.*?(?:[?&]v=)|v\/)|youtu\.be\/)(?:[^"&?\/ ]{11})\b/i;
@@ -155,6 +158,7 @@ const newLineRegex = /\n/g;
 
 function imageTag(url: string): string | undefined {
   if (imgUrlRegex.test(url)) return `<img src="${url}" class="embed"/>`;
+  return undefined;
 }
 
 function toLink(url: string) {

--- a/ui/common/src/inputs.ts
+++ b/ui/common/src/inputs.ts
@@ -1,0 +1,42 @@
+import { h } from 'snabbdom';
+import { bind } from './util';
+import { VNode } from 'snabbdom/src/vnode';
+
+export interface CheckboxInputProps {
+  id: string,
+  name: string,
+  checked: boolean;
+  change(v: boolean): void;
+}
+
+export function checkboxInput(o: CheckboxInputProps, trans: Trans, redraw: () => void): VNode {
+  return h('div.' + o.id, {}, [
+    h('label', {attrs: {'for': o.id}}, trans.noarg(o.name)),
+    h('div.switch', [
+      h('input#' + o.id + '.cmn-toggle', {
+        attrs: {
+          type: 'checkbox',
+          checked: o.checked
+        },
+        hook: bind('change', e => o.change((e.target as HTMLInputElement).checked), redraw)
+      }),
+      h('label', {attrs: {'for': o.id}})
+    ])
+  ]);
+}
+
+export interface TextInputProps {
+  id: string;
+  value: string;
+  placeholder: string;
+  input(v: string): void;
+}
+
+export function textInput(o: TextInputProps, redraw: () => void): VNode {
+  return h('input#' + o.id + '.copyable', {
+    attrs: {
+      placeholder: o.placeholder
+    },
+    hook: bind('input', e => o.input((e.target as HTMLInputElement).value), redraw)
+  })
+}

--- a/ui/common/src/util.ts
+++ b/ui/common/src/util.ts
@@ -1,0 +1,20 @@
+import { Hooks } from 'snabbdom/hooks'
+
+function listenTo(el: HTMLElement, eventName: string, f: (e: Event) => any, redraw?: () => void) {
+  el.addEventListener(eventName, e => {
+    const res = f(e);
+    if (res === false) e.preventDefault();
+    if (redraw) redraw();
+    return res;
+  })
+}
+
+export function bind(eventName: string, f: (e: Event) => any, redraw?: () => void): Hooks {
+  return onInsert(el => listenTo(el, eventName, f, redraw));
+}
+
+export function onInsert<A extends HTMLElement>(f: (element: A) => void): Hooks {
+  return {
+    insert: vnode => f(vnode.elm as A)
+  };
+}

--- a/ui/tournamentSchedule/css/_schedule.scss
+++ b/ui/tournamentSchedule/css/_schedule.scss
@@ -21,6 +21,29 @@ $c-tour-battle: hsl(49, 74%, 37%);
     padding-top: 120px;
     opacity: 0.7;
   }
+  &__filters {
+    @extend %flex-between;
+    padding: 0 10px 10px 10px;
+    &__right {
+      @extend %flex-wrap;
+      @include breakpoint($mq-not-x-small) {
+        display: none;
+      }
+      .user-created {
+        @extend %flex-center;
+        label {
+          margin-right: 5px;
+        }
+      }
+    }
+    .icon {
+      font-size: 2.4em;
+      cursor: pointer;
+      &.active {
+        color: orange;
+      }
+    }
+  }
   &__inner {
     position: relative;
     overflow-x: scroll;

--- a/ui/tournamentSchedule/package.json
+++ b/ui/tournamentSchedule/package.json
@@ -17,6 +17,7 @@
     "@types/lichess": "2.0.0"
   },
   "dependencies": {
+    "common": "2.0.0",
     "dragscroll": "^0.0.8",
     "snabbdom": "ornicar/snabbdom#0.7.1-lichess"
   }

--- a/ui/tournamentSchedule/src/ctrl.ts
+++ b/ui/tournamentSchedule/src/ctrl.ts
@@ -1,0 +1,20 @@
+import {Data} from './interfaces';
+
+export type Redraw = () => void
+
+export class Ctrl {
+  data: () => Data;
+  trans: Trans;
+  filter: string = "";
+  showUserCreated: boolean = true;
+  selectedPerf: Perf|null = null;
+
+  constructor(readonly env: any, readonly redraw: Redraw) {
+    this.data = () => env.data;
+    this.trans = window.lichess.trans(env.i18n);
+  }
+
+  togglePerfVisibility(perf: Perf) {
+    this.selectedPerf = this.selectedPerf === perf ? null : perf
+  }
+};

--- a/ui/tournamentSchedule/src/interfaces.ts
+++ b/ui/tournamentSchedule/src/interfaces.ts
@@ -1,0 +1,41 @@
+export interface TournamentPerf {
+  icon: string
+  key: Perf
+  name: string
+  position: number
+}
+
+export interface Tournament {
+  battle: boolean
+  clock: {
+    limit: number
+    increment: number
+  }
+  createdBy: string
+  finishesAt: number
+  fullName: string
+  hasMaxRating: boolean
+  id: string
+  major: boolean
+  minutes: number
+  nbPlayers: number
+  perf: TournamentPerf
+  position: number
+  rated: boolean
+  schedule: {
+    freq: string
+    speed: Speed
+  }
+  secondsToStart: number
+  startsAt: number
+  status: number
+  system: string
+  variant: Variant
+}
+
+export interface Data {
+  finished: Tournament[]
+  started: Tournament[]
+  created: Tournament[]
+  perfs: TournamentPerf[]
+}

--- a/ui/tournamentSchedule/src/main.ts
+++ b/ui/tournamentSchedule/src/main.ts
@@ -1,4 +1,5 @@
 import view from './view';
+import { Ctrl } from './ctrl';
 
 import { init } from 'snabbdom';
 import { VNode } from 'snabbdom/vnode'
@@ -12,14 +13,13 @@ dragscroll // required to include the dependency :( :( :(
 
 export function app(element: HTMLElement, env: any) {
 
-  let vnode: VNode, ctrl = {
-    data: () => env.data,
-    trans: window.lichess.trans(env.i18n)
-  };
+  let vnode: VNode, ctrl: Ctrl
 
   function redraw() {
     vnode = patch(vnode || element, view(ctrl));
   }
+
+  ctrl = new Ctrl(env, redraw)
 
   redraw();
 


### PR DESCRIPTION
Partly addresses: #6214 
If this PR is successful, I may do something similar for the calendar.

Tournament schedule filters!
- Filter by variant by clicking on the appropriate icon
- Toggle to show/hide user created tournaments
- A single search box that filters by name, rating, creator, variant, or clock.

Regarding style
- I think I managed to do it in a non-obnoxious way that doesn't distract the user too much from the page.
- The user-created toggle and search box are hidden on mobile

Regarding code
- I added types for `ui/tournamentSchedule`, and a `Ctrl` class.
- I added a couple input functions to `ui/common`. I'm surprised they didn't already exist. But there's a good reason for that?
- I needed to explicitly `return undefined` in `analyse/src/util.ts`, or TS wouldn't compile. No idea how this is working for others. Will happily revert that change.

Filtering for Blitz and "super", hiding user created tournaments
![Screen Shot 2020-05-26 at 18 35 27](https://user-images.githubusercontent.com/8725423/82957198-75d8e380-9f80-11ea-98f3-12a6baa95726.png)

Filtering for "aoeu" (there's a user named "aoeu" who created a tournament)
![Screen Shot 2020-05-26 at 18 35 56](https://user-images.githubusercontent.com/8725423/82957202-770a1080-9f80-11ea-8242-8d1d18dea929.png)

Light theme:
![Screen Shot 2020-05-26 at 18 45 23](https://user-images.githubusercontent.com/8725423/82957488-1202ea80-9f81-11ea-9b51-afa267b18e26.png)

iPhone X:
![Screen Shot 2020-05-26 at 18 40 57](https://user-images.githubusercontent.com/8725423/82957240-89844a00-9f80-11ea-8c2f-3a7cc3fbc3d9.png)
