### PR TITLE
use long for paginator results and plurals (#6786)

### DIFF
--- a/app/templating/NumberHelper.scala
+++ b/app/templating/NumberHelper.scala
@@ -21,4 +21,8 @@ trait NumberHelper { self: I18nHelper =>
   implicit final class RichInt(number: Int) {
     def localize(implicit lang: Lang): String = formatter format number
   }
+
+  implicit final class RichLong(number: Long) {
+    def localize(implicit lang: Lang): String = formatter format number
+  }
 }

--- a/app/templating/StringHelper.scala
+++ b/app/templating/StringHelper.scala
@@ -11,7 +11,7 @@ trait StringHelper { self: NumberHelper =>
 
   def shorten(text: String, length: Int, sep: String = "…") = lila.common.String.shorten(text, length, sep)
 
-  def pluralize(s: String, n: Int) = s"$n $s${if (n > 1) "s" else ""}"
+  def pluralize(s: String, n: Long) = s"$n $s${if (n > 1) "s" else ""}"
 
   def showNumber(n: Int): String = if (n > 0) s"+$n" else n.toString
 

--- a/app/templating/UserHelper.scala
+++ b/app/templating/UserHelper.scala
@@ -257,7 +257,7 @@ trait UserHelper { self: I18nHelper with StringHelper with NumberHelper =>
   ): String =
     filter match {
       case GameFilter.All      => trans.nbGames.pluralSameTxt(u.count.game)
-      case GameFilter.Me       => nbs.withMe ?? trans.nbGamesWithYou.pluralSameTxt
+      case GameFilter.Me       => nbs.withMe.map(_.toLong) ?? trans.nbGamesWithYou.pluralSameTxt
       case GameFilter.Rated    => trans.nbRated.pluralSameTxt(u.count.rated)
       case GameFilter.Win      => trans.nbWins.pluralSameTxt(u.count.win)
       case GameFilter.Loss     => trans.nbLosses.pluralSameTxt(u.count.loss)

--- a/app/views/search/index.scala
+++ b/app/views/search/index.scala
@@ -13,7 +13,7 @@ object index {
 
   import trans.search._
 
-  def apply(form: Form[_], paginator: Option[Paginator[lila.game.Game]] = None, nbGames: Int)(implicit
+  def apply(form: Form[_], paginator: Option[Paginator[lila.game.Game]] = None, nbGames: Long)(implicit
       ctx: Context
   ) = {
     val commons = bits of form

--- a/app/views/video/index.scala
+++ b/app/views/video/index.scala
@@ -9,7 +9,7 @@ import controllers.routes
 
 object index {
 
-  def apply(videos: Paginator[lila.video.VideoView], count: Int, control: lila.video.UserControl)(implicit
+  def apply(videos: Paginator[lila.video.VideoView], count: Long, control: lila.video.UserControl)(implicit
       ctx: Context
   ) = {
 

--- a/modules/api/src/main/GameApi.scala
+++ b/modules/api/src/main/GameApi.scala
@@ -63,15 +63,14 @@ final private[api] class GameApi(
           sort = $doc(G.createdAt -> -1),
           readPreference = ReadPreference.secondaryPreferred
         ),
-        nbResults =
-          if (~playing) gameCache.nbPlaying(user.id)
-          else
-            fuccess {
-              rated.fold(user.count.game) {
-                case true => user.count.rated
-                case _    => user.count.casual
-              }
-            }
+        nbResults = (if (~playing) gameCache.nbPlaying(user.id)
+                     else
+                       fuccess {
+                         rated.fold(user.count.game) {
+                           case true => user.count.rated
+                           case _    => user.count.casual
+                         }
+                       }).dmap(_.toLong)
       ),
       currentPage = page,
       maxPerPage = nb
@@ -121,9 +120,8 @@ final private[api] class GameApi(
           sort = $doc(G.createdAt -> -1),
           readPreference = ReadPreference.secondaryPreferred
         ),
-        nbResults =
-          if (~playing) gameCache.nbPlaying(users._1.id)
-          else crosstableApi(users._1.id, users._2.id).dmap(_.nbGames)
+        nbResults = (if (~playing) gameCache.nbPlaying(users._1.id)
+                     else crosstableApi(users._1.id, users._2.id).dmap(_.nbGames)).dmap(_.toLong)
       ),
       currentPage = page,
       maxPerPage = nb

--- a/modules/bookmark/src/main/PaginatorBuilder.scala
+++ b/modules/bookmark/src/main/PaginatorBuilder.scala
@@ -23,7 +23,7 @@ final class PaginatorBuilder(
 
   final class UserAdapter(user: User) extends AdapterLike[Bookmark] {
 
-    def nbResults: Fu[Int] = coll countSel selector
+    def nbResults: Fu[Long] = coll.countSel(selector).dmap(_.toLong)
 
     def slice(offset: Int, length: Int): Fu[Seq[Bookmark]] =
       for {

--- a/modules/common/src/main/paginator/Adapter.scala
+++ b/modules/common/src/main/paginator/Adapter.scala
@@ -6,7 +6,7 @@ abstract class AdapterLike[A](implicit ec: scala.concurrent.ExecutionContext) {
   /**
     * Returns the total number of results.
     */
-  def nbResults: Fu[Int]
+  def nbResults: Fu[Long]
 
   /**
     * Returns a slice of the results.

--- a/modules/common/src/main/paginator/Paginator.scala
+++ b/modules/common/src/main/paginator/Paginator.scala
@@ -17,7 +17,7 @@ final class Paginator[A] private[paginator] (
       * Returns the number of results.
       * The result is cached.
       */
-    val nbResults: Int
+    val nbResults: Long
 ) {
 
   /**
@@ -33,7 +33,7 @@ final class Paginator[A] private[paginator] (
   /**
     * Returns the number of pages.
     */
-  def nbPages: Int = scala.math.ceil(nbResults.toFloat / maxPerPage.value).toInt
+  def nbPages: Int = ((nbResults + maxPerPage.value - 1) / maxPerPage.value).toInt
 
   /**
     * Returns whether we have to paginate or not.
@@ -79,7 +79,7 @@ object Paginator {
 
   def fromResults[A](
       currentPageResults: Seq[A],
-      nbResults: Int,
+      nbResults: Long,
       currentPage: Int,
       maxPerPage: MaxPerPage
   ): Paginator[A] =

--- a/modules/db/src/main/CollExt.scala
+++ b/modules/db/src/main/CollExt.scala
@@ -64,7 +64,7 @@ trait CollExt { self: dsl with QueryBuilderExt =>
         )
         .dmap(_.toInt)
 
-    def countAll: Fu[Int] =
+    def countAll: Fu[Long] =
       coll
         .count(
           selector = none,
@@ -73,7 +73,6 @@ trait CollExt { self: dsl with QueryBuilderExt =>
           hint = None,
           readConcern = ReadConcern.Local
         )
-        .dmap(_.toInt)
 
     def exists(selector: Bdoc): Fu[Boolean] = countSel(selector).dmap(0 !=)
 

--- a/modules/db/src/main/PaginatorAdapter.scala
+++ b/modules/db/src/main/PaginatorAdapter.scala
@@ -10,7 +10,7 @@ import lila.common.paginator.AdapterLike
 
 final class CachedAdapter[A](
     adapter: AdapterLike[A],
-    val nbResults: Fu[Int]
+    val nbResults: Fu[Long]
 )(implicit ec: scala.concurrent.ExecutionContext)
     extends AdapterLike[A] {
 
@@ -28,7 +28,7 @@ final class Adapter[A: BSONDocumentReader](
 )(implicit ec: scala.concurrent.ExecutionContext)
     extends AdapterLike[A] {
 
-  def nbResults: Fu[Int] = collection.secondaryPreferred.countSel(selector)
+  def nbResults: Fu[Long] = collection.secondaryPreferred.countSel(selector).dmap(_.toLong)
 
   def slice(offset: Int, length: Int): Fu[List[A]] =
     collection
@@ -61,7 +61,7 @@ final class MapReduceAdapter[A: BSONDocumentReader](
 )(implicit ec: scala.concurrent.ExecutionContext)
     extends AdapterLike[A] {
 
-  def nbResults: Fu[Int] = collection.secondaryPreferred.countSel(selector)
+  def nbResults: Fu[Long] = collection.secondaryPreferred.countSel(selector).dmap(_.toLong)
 
   def slice(offset: Int, length: Int): Fu[List[A]] =
     collection

--- a/modules/fishnet/src/main/FishnetRepo.scala
+++ b/modules/fishnet/src/main/FishnetRepo.scala
@@ -77,7 +77,7 @@ final private class FishnetRepo(
 
     def compute =
       for {
-        all            <- analysisColl.countAll
+        all            <- analysisColl.countAll.dmap(_.toInt)
         userAcquired   <- analysisColl.countSel(system(false) ++ acquired(true))
         userQueued     <- analysisColl.countSel(system(false) ++ acquired(false))
         userOldest     <- oldestSeconds(false)

--- a/modules/forum/src/main/PostApi.scala
+++ b/modules/forum/src/main/PostApi.scala
@@ -180,8 +180,7 @@ final class PostApi(
   def lastNumberOf(topic: Topic): Fu[Int] =
     env.postRepo lastByTopic topic dmap { _ ?? (_.number) }
 
-  def lastPageOf(topic: Topic) =
-    math.ceil(topic.nbPosts / maxPerPage.value.toFloat).toInt
+  def lastPageOf(topic: Topic) = (topic.nbPosts + maxPerPage.value - 1) / maxPerPage.value
 
   def paginator(topic: Topic, page: Int, me: Option[User]): Fu[Paginator[Post]] =
     Paginator(

--- a/modules/game/src/main/Cached.scala
+++ b/modules/game/src/main/Cached.scala
@@ -16,7 +16,7 @@ final class Cached(
   def nbImportedBy(userId: User.ID): Fu[Int] = nbImportedCache.get(userId)
   def clearNbImportedByCache                 = nbImportedCache invalidate _
 
-  def nbTotal: Fu[Int] = nbTotalCache.get {}
+  def nbTotal: Fu[Long] = nbTotalCache.get {}
 
   def nbPlaying = nbPlayingCache.get _
 
@@ -52,14 +52,14 @@ final class Cached(
       }
   }
 
-  private val nbTotalCache = mongoCache.unit[Int](
+  private val nbTotalCache = mongoCache.unit[Long](
     "game:total",
     29 minutes
   ) { loader =>
     _.refreshAfterWrite(30 minutes)
       .buildAsyncFuture {
         loader { _ =>
-          gameRepo.coll.countSel($empty)
+          gameRepo.coll.countAll
         }
       }
   }

--- a/modules/game/src/main/PaginatorBuilder.scala
+++ b/modules/game/src/main/PaginatorBuilder.scala
@@ -25,7 +25,7 @@ final class PaginatorBuilder(
   private def apply(adapter: AdapterLike[Game])(page: Int): Fu[Paginator[Game]] =
     paginator(adapter, page)
 
-  private def cacheAdapter(selector: Bdoc, sort: Bdoc, nbResults: Fu[Int]): AdapterLike[Game] =
+  private def cacheAdapter(selector: Bdoc, sort: Bdoc, nbResults: Fu[Long]): AdapterLike[Game] =
     new CachedAdapter(
       adapter = noCacheAdapter(selector, sort),
       nbResults = nbResults

--- a/modules/gameSearch/src/main/GameSearchApi.scala
+++ b/modules/gameSearch/src/main/GameSearchApi.scala
@@ -45,7 +45,7 @@ final class GameSearchApi(
           case s if s.is(_.NoStart) => chess.Status.Resign
           case _                    => game.status
         }).id,
-        Fields.turns         -> math.ceil(game.turns.toFloat / 2),
+        Fields.turns         -> (game.turns + 1) / 2,
         Fields.rated         -> game.rated,
         Fields.perf          -> game.perfType.map(_.id),
         Fields.uids          -> game.userIds.toArray.some.filterNot(_.isEmpty),

--- a/modules/i18n/src/main/I18nKey.scala
+++ b/modules/i18n/src/main/I18nKey.scala
@@ -11,7 +11,7 @@ final class I18nKey(val key: String) {
   def plural(count: Count, args: Any*)(implicit lang: Lang): RawFrag =
     Translator.frag.plural(key, count, args, lang)
 
-  def pluralSame(count: Int)(implicit lang: Lang): RawFrag = plural(count, count)
+  def pluralSame(count: Count)(implicit lang: Lang): RawFrag = plural(count, count)
 
   def txt(args: Any*)(implicit lang: Lang): String =
     Translator.txt.literal(key, args, lang)
@@ -19,7 +19,7 @@ final class I18nKey(val key: String) {
   def pluralTxt(count: Count, args: Any*)(implicit lang: Lang): String =
     Translator.txt.plural(key, count, args, lang)
 
-  def pluralSameTxt(count: Int)(implicit lang: Lang): String = pluralTxt(count, count)
+  def pluralSameTxt(count: Count)(implicit lang: Lang): String = pluralTxt(count, count)
 }
 
 object I18nKey {

--- a/modules/i18n/src/main/package.scala
+++ b/modules/i18n/src/main/package.scala
@@ -4,7 +4,7 @@ import play.api.i18n.Lang
 
 package object i18n extends PackageObject {
 
-  type Count      = Int
+  type Count      = Long
   type MessageKey = String
 
   private[i18n] type MessageMap = java.util.Map[MessageKey, Translation]

--- a/modules/relation/src/main/RelationApi.scala
+++ b/modules/relation/src/main/RelationApi.scala
@@ -114,7 +114,7 @@ final class RelationApi(
         projection = $doc("u2" -> true, "_id" -> false).some,
         sort = $empty
       ),
-      nbResults = countFollowing(userId)
+      nbResults = countFollowing(userId).dmap(_.toLong)
     ).map(_.userId)
 
   def followersPaginatorAdapter(userId: ID) =
@@ -125,7 +125,7 @@ final class RelationApi(
         projection = $doc("u1" -> true, "_id" -> false).some,
         sort = $empty
       ),
-      nbResults = countFollowers(userId)
+      nbResults = countFollowers(userId).dmap(_.toLong)
     ).map(_.userId)
 
   def blockingPaginatorAdapter(userId: ID) =

--- a/modules/relay/src/main/RelayPager.scala
+++ b/modules/relay/src/main/RelayPager.scala
@@ -20,14 +20,14 @@ final class RelayPager(
       repo.selectors finished true,
       me,
       page,
-      fuccess(9999).some
+      fuccess(9999L).some
     )
 
   private def paginator(
       selector: Bdoc,
       me: Option[User],
       page: Int,
-      nbResults: Option[Fu[Int]]
+      nbResults: Option[Fu[Long]]
   ): Fu[Paginator[Relay.WithStudyAndLiked]] = {
     val adapter = new Adapter[Relay](
       collection = repo.coll,

--- a/modules/search/src/main/PaginatorBuilder.scala
+++ b/modules/search/src/main/PaginatorBuilder.scala
@@ -19,7 +19,7 @@ final class PaginatorBuilder[A, Q: Writes](
 
   final private class ESAdapter(query: Q) extends AdapterLike[A] {
 
-    def nbResults = searchApi count query
+    def nbResults = searchApi.count(query)
 
     def slice(offset: Int, length: Int) =
       searchApi.search(query, From(offset), Size(length))

--- a/modules/search/src/main/SearchReadApi.scala
+++ b/modules/search/src/main/SearchReadApi.scala
@@ -4,5 +4,5 @@ trait SearchReadApi[A, Q] {
 
   def search(query: Q, from: From, size: Size): Fu[List[A]]
 
-  def count(query: Q): Fu[Int]
+  def count(query: Q): Fu[Long]
 }

--- a/modules/search/src/main/model.scala
+++ b/modules/search/src/main/model.scala
@@ -14,8 +14,8 @@ object SearchResponse {
   def apply(txt: String): SearchResponse = SearchResponse(txt.split(',').toList)
 }
 
-case class CountResponse(count: Int) extends AnyVal
+case class CountResponse(count: Long) extends AnyVal
 
 object CountResponse {
-  def apply(txt: String): CountResponse = CountResponse(~txt.toIntOption)
+  def apply(txt: String): CountResponse = CountResponse(~txt.toLongOption)
 }

--- a/modules/study/src/main/StudyPager.scala
+++ b/modules/study/src/main/StudyPager.scala
@@ -30,7 +30,7 @@ final class StudyPager(
       me,
       order,
       page,
-      fuccess(9999).some
+      fuccess(9999L).some
     )
 
   def byOwner(owner: User, me: Option[User], order: Order, page: Int) =
@@ -102,7 +102,7 @@ final class StudyPager(
       me: Option[User],
       order: Order,
       page: Int,
-      nbResults: Option[Fu[Int]] = none,
+      nbResults: Option[Fu[Long]] = none,
       hint: Option[Bdoc] = none
   ): Fu[Paginator[Study.WithChaptersAndLiked]] = {
     val adapter = new Adapter[Study](

--- a/modules/video/src/main/VideoApi.scala
+++ b/modules/video/src/main/VideoApi.scala
@@ -165,12 +165,12 @@ final private[video] class VideoApi(
 
     object count {
 
-      private val cache = cacheApi.unit[Int] {
+      private val cache = cacheApi.unit[Long] {
         _.refreshAfterWrite(3 hours)
           .buildAsyncFuture(_ => videoColl.countAll)
       }
 
-      def apply: Fu[Int] = cache.getUnit
+      def apply: Fu[Long] = cache.getUnit
     }
   }
 


### PR DESCRIPTION
The search paginator is broken now that we have more than `Integer.MAX_VALUE` indexed games.

This PR is one possible approach to fix this:

* Touches pluralization because the total number of games is displayed. Simply changing the API (instead of adding a separate long version) works and leads to implicit widening almost everywhere.
* Touches `nbResults` in paginator, for a single use. All other uses need explicit `Fu[Int] -> Fu[Long]` conversions.