### PR TITLE
Query live Twitch streams by game instead of channel ids

### DIFF
--- a/modules/streamer/src/main/Stream.scala
+++ b/modules/streamer/src/main/Stream.scala
@@ -27,7 +27,8 @@ object Stream {
       def name   = user_name
       def isLive = `type` == "live"
     }
-    case class Result(data: Option[List[TwitchStream]]) {
+    case class Pagination(cursor: Option[String])
+    case class Result(data: Option[List[TwitchStream]], pagination: Option[Pagination]) {
       def liveStreams = (~data).filter(_.isLive)
       def streams(keyword: Keyword, streamers: List[Streamer], alwaysFeatured: List[User.ID]): List[Stream] =
         liveStreams.collect {
@@ -45,6 +46,7 @@ object Stream {
     }
     object Reads {
       implicit private val twitchStreamReads = Json.reads[TwitchStream]
+      implicit private val paginationReads   = Json.reads[Pagination]
       implicit val twitchResultReads         = Json.reads[Result]
     }
   }

--- a/translation/source/streamer.xml
+++ b/translation/source/streamer.xml
@@ -15,7 +15,7 @@
   <string name="downloadKit">Download streamer kit</string>
   <string name="xIsStreaming">%s is streaming</string>
   <string name="rules">Streaming rules</string>
-  <string name="rule1">Include the keyword \"lichess.org\" in your stream title when you stream on Lichess.</string>
+  <string name="rule1">Include the keyword \"lichess.org\" in your stream title and use the category \"Chess\" when you stream on Lichess.</string>
   <string name="rule2">Remove the keyword when you stream non-Lichess stuff.</string>
   <string name="rule3">Lichess will detect your stream automatically and enable the following perks:</string>
   <string name="perks">Benefits of streaming with the keyword</string>


### PR DESCRIPTION
Half of chess on Twitch is Lichess anyway, so instead of doing many
requests for channels that are probably offline, query for chess then
filter by channel.

Even at peak time there are usually less than 200 streamers, so all can
be fetched with only two requests:

https://dev.twitch.tv/docs/v5/reference/streams#get-live-streams