### PR TITLE
Add types to ui/analyse

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -200,6 +200,9 @@ declare type Perf = 'bullet' | 'blitz' | 'classical' | 'correspondence' | 'chess
 declare type Color = 'white' | 'black';
 
 declare type Key = 'a0' | 'a1' | 'b1' | 'c1' | 'd1' | 'e1' | 'f1' | 'g1' | 'h1' | 'a2' | 'b2' | 'c2' | 'd2' | 'e2' | 'f2' | 'g2' | 'h2' | 'a3' | 'b3' | 'c3' | 'd3' | 'e3' | 'f3' | 'g3' | 'h3' | 'a4' | 'b4' | 'c4' | 'd4' | 'e4' | 'f4' | 'g4' | 'h4' | 'a5' | 'b5' | 'c5' | 'd5' | 'e5' | 'f5' | 'g5' | 'h5' | 'a6' | 'b6' | 'c6' | 'd6' | 'e6' | 'f6' | 'g6' | 'h6' | 'a7' | 'b7' | 'c7' | 'd7' | 'e7' | 'f7' | 'g7' | 'h7' | 'a8' | 'b8' | 'c8' | 'd8' | 'e8' | 'f8' | 'g8' | 'h8';
+declare type Crazy = 'P@' | 'N@' | 'B@' | 'R@' | 'Q@';
+declare type KeyOrCrazy = Key | Crazy;
+declare type Promotion = 'n' | 'b' | 'r' | 'q' | 'k' | undefined;
 declare type Uci = string;
 declare type San = string;
 declare type Fen = string;

--- a/ui/analyse/src/acpl.ts
+++ b/ui/analyse/src/acpl.ts
@@ -6,6 +6,14 @@ import * as game from 'game';
 import { defined } from 'common';
 import { bind, dataIcon } from './util';
 
+type AdviceKind = 'inaccuracy' | 'mistake' | 'blunder';
+
+interface Advice {
+  kind: AdviceKind;
+  plural: string;
+  symbol: string;
+}
+
 function renderRatingDiff(rd: number | undefined): VNode | undefined {
   if (rd === 0) return h('span', '±0');
   if (rd && rd > 0) return h('good', '+' + rd);
@@ -28,10 +36,10 @@ function renderPlayer(ctrl: AnalyseCtrl, color: Color): VNode {
     'Anonymous');
 }
 
-const advices = [
-  ['inaccuracy', 'inaccuracies', '?!'],
-  ['mistake', 'mistakes', '?'],
-  ['blunder', 'blunders', '??']
+const advices: Advice[] = [
+  { kind: 'inaccuracy', plural: 'inaccuracies', symbol: '?!' },
+  { kind: 'mistake', plural: 'mistakes', symbol: '?' },
+  { kind: 'blunder', plural: 'blunders', symbol: '??' },
 ];
 
 function playerTable(ctrl: AnalyseCtrl, color: Color): VNode {
@@ -50,14 +58,14 @@ function playerTable(ctrl: AnalyseCtrl, color: Color): VNode {
     ])),
     h('tbody',
       advices.map(a => {
-        const nb: number = d.analysis![color][a[0]];
+        const nb: number = d.analysis![color][a.kind];
         const attrs: VNodeData = nb ? {
           'data-color': color,
-          'data-symbol': a[2]
+          'data-symbol': a.symbol
         } : {};
         return h('tr' + (nb ? '.symbol' : ''), { attrs }, [
           h('td', '' + nb),
-          h('th', trans(a[1]))
+          h('th', trans(a.plural))
         ]);
       }).concat(
         h('tr', [

--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -4,6 +4,7 @@ import * as cg from 'chessground/types';
 import { opposite } from 'chessground/util';
 import { DrawShape } from 'chessground/draw';
 import AnalyseCtrl from './ctrl';
+import { isCrazy, crazyToSan } from './util';
 
 function pieceDrop(key: cg.Key, role: cg.Role, color: Color): DrawShape {
   return {
@@ -19,15 +20,16 @@ function pieceDrop(key: cg.Key, role: cg.Role, color: Color): DrawShape {
 
 export function makeShapesFromUci(color: Color, uci: Uci, brush: string, modifiers?: any): DrawShape[] {
   const move = decomposeUci(uci);
-  if (uci[1] === '@') return [
+  const keyOrCrazy = move[0];
+  if (isCrazy(keyOrCrazy)) return [
     {
       orig: move[1],
       brush
     },
-    pieceDrop(move[1] as cg.Key, sanToRole[uci[0].toUpperCase()], color)
+    pieceDrop(move[1] as cg.Key, sanToRole[crazyToSan(keyOrCrazy)], color)
   ];
   const shapes: DrawShape[] = [{
-    orig: move[0],
+    orig: keyOrCrazy,
     dest: move[1],
     brush,
     modifiers

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -751,15 +751,16 @@ export default class AnalyseCtrl {
 
   playUci(uci: Uci): void {
     const move = chessUtil.decomposeUci(uci);
-    if (uci[1] === '@') this.chessground.newPiece({
+    const keyOrCrazy = move[0];
+    if (util.isCrazy(keyOrCrazy)) this.chessground.newPiece({
       color: this.chessground.state.movable.color as Color,
-      role: chessUtil.sanToRole[uci[0]]
+      role: chessUtil.sanToRole[util.crazyToSan(keyOrCrazy)]
     }, move[1]);
     else {
       const piece = this.chessground.state.pieces[move[0]];
       const capture = this.chessground.state.pieces[move[1]];
       const promotion = move[2] && chessUtil.sanToRole[move[2].toUpperCase()];
-      this.sendMove(move[0], move[1], (capture && piece && capture.color !== piece.color) ? capture : undefined, promotion);
+      this.sendMove(keyOrCrazy, move[1], (capture && piece && capture.color !== piece.color) ? capture : undefined, promotion);
     }
   }
 

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -8,7 +8,7 @@ import { isOpening, isTablebase, TablebaseMoveStats, OpeningData, OpeningMoveSta
 
 function resultBar(move: OpeningMoveStats): VNode {
   const sum = move.white + move.draws + move.black;
-  function section(key) {
+  function section(key: 'white' | 'black' | 'draws') {
     const percent = move[key] * 100 / sum;
     return percent === 0 ? null : h('span.' + key, {
       attrs: { style: 'width: ' + (Math.round(move[key] * 1000 / sum) / 10) + '%' },

--- a/ui/analyse/src/moveView.ts
+++ b/ui/analyse/src/moveView.ts
@@ -14,7 +14,7 @@ export function plyToTurn(ply: Ply): number {
   return Math.floor((ply - 1) / 2) + 1;
 }
 
-export function renderGlyphs(glyphs): VNode[] {
+export function renderGlyphs(glyphs: Tree.Glyph[]): VNode[] {
   return glyphs.map(glyph => h('glyph', {
     attrs: { title: glyph.name }
   }, glyph.symbol));
@@ -43,7 +43,7 @@ export function renderMove(ctx: Ctx, node: Tree.Node): VNode[] {
     ) : []);
 }
 
-export function renderIndexAndMove(ctx: Ctx, node): VNode[] | undefined {
+export function renderIndexAndMove(ctx: Ctx, node: Tree.Node): VNode[] | undefined {
   if (!node.san) return; // initial position
   return [renderIndex(node.ply, ctx.withDots), ...renderMove(ctx, node)];
 }

--- a/ui/analyse/src/nodeFinder.ts
+++ b/ui/analyse/src/nodeFinder.ts
@@ -35,11 +35,11 @@ export function evalSwings(mainline: Tree.Node[], nodeFilter: (node: Tree.Node) 
   return found;
 }
 
-function threefoldFen(fen) {
+function threefoldFen(fen: Fen) {
   return fen.split(' ').slice(0, 4).join(' ');
 }
 
-export function detectThreefold(nodeList, node): void {
+export function detectThreefold(nodeList: Tree.Node[], node: Tree.Node): void {
   if (defined(node.threefold)) return;
   const currentFen = threefoldFen(node.fen);
   let nbSimilarPositions = 0, i;

--- a/ui/analyse/src/practice/practiceCtrl.ts
+++ b/ui/analyse/src/practice/practiceCtrl.ts
@@ -10,11 +10,13 @@ import { altCastles } from 'chess';
 import { parseUci } from 'chessops/util';
 import { makeSan } from 'chessops/san';
 
+declare type Verdict = 'goodMove' | 'inaccuracy' | 'mistake' | 'blunder';
+
 export interface Comment {
   prev: Tree.Node;
   node: Tree.Node;
   path: Tree.Path;
-  verdict: 'goodMove' | 'inaccuracy' | 'mistake' | 'blunder';
+  verdict: Verdict;
   best?: {
     uci: Uci;
     san: San;
@@ -89,7 +91,7 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
   }
 
   function makeComment(prev: Tree.Node, node: Tree.Node, path: Tree.Path): Comment {
-    let verdict, best;
+    let verdict: Verdict, best;
     const over = root.gameOver(node);
 
     if (over === 'checkmate') verdict = 'goodMove';

--- a/ui/analyse/src/promotion.ts
+++ b/ui/analyse/src/promotion.ts
@@ -35,7 +35,7 @@ export function start(ctrl: AnalyseCtrl, orig: Key, dest: Key, capture: JustCapt
   return false;
 }
 
-function finish(ctrl: AnalyseCtrl, role) {
+function finish(ctrl: AnalyseCtrl, role: Role) {
   if (promoting) {
     ground.promote(ctrl.chessground, promoting.dest, role);
     if (promoting.callback) promoting.callback(promoting.orig, promoting.dest, promoting.capture, role);
@@ -51,7 +51,7 @@ export function cancel(ctrl: AnalyseCtrl) {
   }
 }
 
-function renderPromotion(ctrl: AnalyseCtrl, dest: Key, pieces, color: Color, orientation: Color) {
+function renderPromotion(ctrl: AnalyseCtrl, dest: Key, pieces: string[], color: Color, orientation: Color) {
   if (!promoting) return;
 
   let left = (8 - util.key2pos(dest)[0]) * 12.5;
@@ -64,7 +64,7 @@ function renderPromotion(ctrl: AnalyseCtrl, dest: Key, pieces, color: Color, ori
       el.addEventListener('click', _ => cancel(ctrl));
       el.oncontextmenu = () => false;
     })
-  }, pieces.map(function(serverRole, i) {
+  }, pieces.map(function(serverRole: Role, i) {
     const top = (color === orientation ? i : 7 - i) * 12.5;
     return h('square', {
       attrs: {

--- a/ui/analyse/src/socket.ts
+++ b/ui/analyse/src/socket.ts
@@ -30,8 +30,8 @@ export interface Socket {
 
 export function make(send: SocketSend, ctrl: AnalyseCtrl): Socket {
 
-  let anaMoveTimeout;
-  let anaDestsTimeout;
+  let anaMoveTimeout: number;
+  let anaDestsTimeout: number;
 
   let anaDestsCache: DestCache = {};
 

--- a/ui/analyse/src/socket.ts
+++ b/ui/analyse/src/socket.ts
@@ -30,8 +30,8 @@ export interface Socket {
 
 export function make(send: SocketSend, ctrl: AnalyseCtrl): Socket {
 
-  let anaMoveTimeout: number;
-  let anaDestsTimeout: number;
+  let anaMoveTimeout: number | undefined;
+  let anaDestsTimeout: number | undefined;
 
   let anaDestsCache: DestCache = {};
 

--- a/ui/analyse/src/study/chapterEditForm.ts
+++ b/ui/analyse/src/study/chapterEditForm.ts
@@ -34,7 +34,7 @@ export function ctrl(send: SocketSend, chapterConfig: (string) => JQueryPromise<
     });
   };
 
-  function isEditing(id) {
+  function isEditing(id: string) {
     const c = current();
     return c ? c.id === id : false;
   };
@@ -127,7 +127,7 @@ export function view(ctrl: StudyChapterEditFormCtrl): VNode | undefined {
 }
 
 function isLoaded(data: StudyChapterMeta | StudyChapterConfig): data is StudyChapterConfig {
-  return !!data['orientation'];
+  return data.hasOwnProperty('orientation');
 }
 
 function viewLoaded(ctrl: StudyChapterEditFormCtrl, data: StudyChapterConfig): VNode[] {

--- a/ui/analyse/src/study/gamebook/gamebookPlayCtrl.ts
+++ b/ui/analyse/src/study/gamebook/gamebookPlayCtrl.ts
@@ -117,7 +117,7 @@ export default class GamebookPlayCtrl {
     setTimeout(() => this.root.withCg(cg => cg.playPremove()), 100);
   }
 
-  onShapeChange = shapes => {
+  onShapeChange = (shapes: Tree.Shape[]) => {
     const node = this.root.node;
     if (node.gamebook && node.gamebook.shapes && !shapes.length) {
       node.shapes = node.gamebook.shapes.slice(0);

--- a/ui/analyse/src/study/interfaces.ts
+++ b/ui/analyse/src/study/interfaces.ts
@@ -121,7 +121,7 @@ export interface ReloadData {
   study: StudyData;
 }
 
-interface Position {
+export interface Position {
   chapterId: string;
   path: Tree.Path;
 }

--- a/ui/analyse/src/study/inviteForm.ts
+++ b/ui/analyse/src/study/inviteForm.ts
@@ -7,8 +7,8 @@ import { StudyMemberMap } from './interfaces';
 
 export function ctrl(send: SocketSend, members: Prop<StudyMemberMap>, setTab: () => void, redraw: () => void, trans: Trans) {
   const open = prop(false);
-  let followings = [];
-  let spectators = [];
+  let followings: string[] = [];
+  let spectators: string[] = [];
   function updateFollowings(f) {
     followings = f(followings);
     if (open()) redraw();
@@ -23,21 +23,21 @@ export function ctrl(send: SocketSend, members: Prop<StudyMemberMap>, setTab: ()
       }).sort();
     },
     members,
-    setSpectators(usernames) {
+    setSpectators(usernames: string[]) {
       spectators = usernames;
     },
-    setFollowings(usernames) {
-      updateFollowings(_ => usernames)
+    setFollowings(usernames: string[]) {
+      updateFollowings((_: string[])  => usernames)
     },
-    delFollowing(username) {
-      updateFollowings(function(prevs) {
-        return prevs.filter(function(u) {
+    delFollowing(username: string) {
+      updateFollowings(function(prevs: string[]) {
+        return prevs.filter(function(u: string) {
           return username !== u;
         });
       });
     },
-    addFollowing(username) {
-      updateFollowings(function(prevs) {
+    addFollowing(username: string) {
+      updateFollowings(function(prevs: string[]) {
         return prevs.concat([username]);
       });
     },
@@ -45,7 +45,7 @@ export function ctrl(send: SocketSend, members: Prop<StudyMemberMap>, setTab: ()
       open(!open());
       if (open()) send('following_onlines');
     },
-    invite(titleName) {
+    invite(titleName: string) {
       send("invite", titleNameToId(titleName));
       setTab();
     },
@@ -81,7 +81,7 @@ export function view(ctrl): VNode {
           })
         })
       ]),
-      candidates.length ? h('div.users', candidates.map(function(username) {
+      candidates.length ? h('div.users', candidates.map(function(username: string) {
         return h('span.button.button-metal', {
           key: username,
           hook: bind('click', _ => ctrl.invite(username))

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -2,7 +2,7 @@ import { h } from 'snabbdom'
 import { VNode } from 'snabbdom/vnode'
 import { Chessground } from 'chessground';
 import { opposite } from 'chessground/util';
-import { StudyCtrl, ChapterPreview, ChapterPreviewPlayer } from './interfaces';
+import { StudyCtrl, ChapterPreview, ChapterPreviewPlayer, Position } from './interfaces';
 import { MaybeVNodes } from '../interfaces';
 import { multiBoard as xhrLoad } from './studyXhr';
 import { bind, spinner } from '../util';
@@ -16,7 +16,7 @@ export class MultiBoardCtrl {
 
   constructor(readonly studyId: string, readonly redraw: () => void, readonly trans: Trans) {}
 
-  addNode(pos, node) {
+  addNode(pos: Position, node: Tree.Node) {
     const cp = this.pager && this.pager.currentPageResults.find(cp => cp.id == pos.chapterId);
     if (cp && cp.playing) {
       cp.fen = node.fen;

--- a/ui/analyse/src/study/practice/sound.ts
+++ b/ui/analyse/src/study/practice/sound.ts
@@ -1,6 +1,6 @@
 let baseUrl: string;
 
-function make(file) {
+function make(file: string) {
   baseUrl = baseUrl || $('body').data('asset-url') + '/assets/sound/';
   const sound = new window.Howl({
     src: [

--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -79,7 +79,7 @@ export default function(data: StudyData, ctrl: AnalyseCtrl, tagTypes: TagTypes, 
     data.chapters,
     send,
     () => vm.tab('chapters'),
-    chapterId => xhr.chapterConfig(data.id, chapterId),
+    (chapterId: string) => xhr.chapterConfig(data.id, chapterId),
     ctrl);
 
   function currentChapter(): StudyChapterMeta {
@@ -251,7 +251,7 @@ export default function(data: StudyData, ctrl: AnalyseCtrl, tagTypes: TagTypes, 
   instanciateGamebookPlay();
 
   function mutateCgConfig(config) {
-    config.drawable.onChange = shapes => {
+    config.drawable.onChange = (shapes: Tree.Shape[]) => {
       if (vm.mode.write) {
         ctrl.tree.setShapes(shapes, ctrl.path);
         makeChange("shapes", addChapterId({
@@ -483,7 +483,7 @@ export default function(data: StudyData, ctrl: AnalyseCtrl, tagTypes: TagTypes, 
     crowd(d) {
       members.setSpectators(d.users);
     },
-    error(msg) {
+    error(msg: string) {
       alert(msg);
     }
   };

--- a/ui/analyse/src/study/studyForm.ts
+++ b/ui/analyse/src/study/studyForm.ts
@@ -77,7 +77,7 @@ export function ctrl(save: (data: FormData, isNew: boolean) => void, getData: ()
 export function view(ctrl: StudyFormCtrl): VNode {
   const data = ctrl.getData();
   const isNew = ctrl.isNew();
-  const updateName = function(vnode, isUpdate) {
+  const updateName = function(vnode: VNode, isUpdate: boolean) {
     const el = vnode.elm as HTMLInputElement;
     if (!isUpdate && !el.value) {
       el.value = data.name;

--- a/ui/analyse/src/study/studyGlyph.ts
+++ b/ui/analyse/src/study/studyGlyph.ts
@@ -21,7 +21,7 @@ export interface GlyphCtrl {
 }
 
 function renderGlyph(ctrl: GlyphCtrl, node: Tree.Node) {
-  return function(glyph) {
+  return function(glyph: Tree.Glyph) {
     return h('a', {
       hook: bind('click', _ => {
         ctrl.toggleGlyph(glyph.id);

--- a/ui/analyse/src/study/studyMembers.ts
+++ b/ui/analyse/src/study/studyMembers.ts
@@ -5,6 +5,7 @@ import { prop, Prop } from 'common';
 import { ctrl as inviteFormCtrl } from './inviteForm';
 import { StudyCtrl, StudyMember, StudyMemberMap, Tab } from './interfaces';
 import { NotifCtrl } from './notif';
+import { Role } from 'chessground/types';
 
 interface Opts {
   initDict: StudyMemberMap;
@@ -58,7 +59,7 @@ export function ctrl(opts: Opts) {
 
   const inviteForm = inviteFormCtrl(opts.send, dict, () => opts.tab('members'), opts.redraw, opts.trans);
 
-  function setActive(id) {
+  function setActive(id: string) {
     if (opts.tab() !== 'members') return;
     if (active[id]) active[id]();
     else active[id] = memberActivity(function() {
@@ -103,7 +104,7 @@ export function ctrl(opts: Opts) {
       updateOnline();
     },
     setActive,
-    isActive(id) {
+    isActive(id: string) {
       return !!active[id];
     },
     owner,
@@ -111,7 +112,7 @@ export function ctrl(opts: Opts) {
     isOwner,
     canContribute,
     max,
-    setRole(id, role) {
+    setRole(id: string, role: Role) {
       setActive(id);
       opts.send("setRole", {
         userId: id,
@@ -119,7 +120,7 @@ export function ctrl(opts: Opts) {
       });
       confing(undefined);
     },
-    kick(id) {
+    kick(id: string) {
       opts.send("kick", id);
       confing(undefined);
     },

--- a/ui/analyse/src/util.ts
+++ b/ui/analyse/src/util.ts
@@ -118,7 +118,7 @@ export function toYouTubeEmbed(url: string): string | undefined {
   if (embedUrl) return `<div class="embed"><iframe width="100%" src="${embedUrl}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>`;
 }
 
-function toYouTubeEmbedUrl(url) {
+function toYouTubeEmbedUrl(url: string) {
   if (!url) return;
   var m = url.match(/(?:https?:\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be)\/(?:watch)?(?:\?v=)?([^"&?\/ ]{11})(?:\?|&|)(\S*)/i);
   if (!m) return;
@@ -128,8 +128,8 @@ function toYouTubeEmbedUrl(url) {
     if (s[0] === 't' || s[0] === 'start') {
       if (s[1].match(/^\d+$/)) start = parseInt(s[1]);
       else {
-        var n = s[1].match(/(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?/);
-        start = (parseInt(n[1]) || 0) * 3600 + (parseInt(n[2]) || 0) * 60 + (parseInt(n[3]) || 0);
+        const n = s[1].match(/(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?/);
+        start = (parseInt(n![1]) || 0) * 3600 + (parseInt(n![2]) || 0) * 60 + (parseInt(n![3]) || 0);
       }
     }
   });
@@ -142,7 +142,7 @@ export function toTwitchEmbed(url: string): string | undefined {
   if (embedUrl) return `<div class="embed"><iframe width="100%" src="${embedUrl}" frameborder=0 allowfullscreen></iframe></div>`;
 }
 
-function toTwitchEmbedUrl(url) {
+function toTwitchEmbedUrl(url: string) {
   if (!url) return;
   var m = url.match(/(?:https?:\/\/)?(?:www\.)?(?:twitch.tv)\/([^"&?/ ]+)/i);
 if (m) return `https://player.twitch.tv/?channel=${m[1]}&parent=${location.hostname}&autoplay=false`;
@@ -188,4 +188,12 @@ export function option(value: string, current: string | undefined, name: string)
 
 export function scrollTo(el: HTMLElement | undefined, target: HTMLElement |  null) {
   if (el && target) el.scrollTop = target.offsetTop - el.offsetHeight / 2 + target.offsetHeight / 2;
+}
+
+export function isCrazy(x: KeyOrCrazy): x is Crazy {
+  return ['P@', 'N@', 'B@', 'R@', 'Q@'].includes(x);
+}
+
+export function crazyToSan(crazy: Crazy) {
+  return crazy[0].toUpperCase() as 'P' | 'N' | 'B' | 'R' | 'Q';
 }

--- a/ui/chess/src/main.ts
+++ b/ui/chess/src/main.ts
@@ -1,4 +1,5 @@
 import { piotr } from './piotr';
+import { Role } from 'chessground/types';
 
 export const initialFen: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 
@@ -6,8 +7,8 @@ export function fixCrazySan(san: San): San {
   return san[0] === 'P' ? san.slice(1) : san;
 }
 
-export function decomposeUci(uci: Uci): [Key, Key, string] {
-  return [uci.slice(0, 2) as Key, uci.slice(2, 4) as Key, uci.slice(4, 5)];
+export function decomposeUci(uci: Uci): [KeyOrCrazy, Key, Promotion] {
+  return [uci.slice(0, 2) as KeyOrCrazy, uci.slice(2, 4) as Key, uci.slice(4, 5) as Promotion];
 }
 
 export interface Dests {
@@ -37,7 +38,7 @@ export const roleToSan = {
   king: 'K'
 };
 
-export const sanToRole = {
+export const sanToRole: { [key: string]: Role; } = {
   P: 'pawn',
   N: 'knight',
   B: 'bishop',


### PR DESCRIPTION
On a lark, I toggled on `noImplicitAny` for `ui/analyse` (in retrospect, not the best one to start with).

I added about half the types and made the rest `any`.

I think will not break anything but did not know how to fully test it.