### PR TITLE
Nudge Swiss pageof index, closes #6841

### DIFF
--- a/modules/swiss/src/main/SwissApi.scala
+++ b/modules/swiss/src/main/SwissApi.scala
@@ -252,7 +252,7 @@ final class SwissApi(
   def pageOf(swiss: Swiss, userId: User.ID): Fu[Option[Int]] =
     rankingApi(swiss) map {
       _ get userId map { rank =>
-        (Math.floor(rank / 10) + 1).toInt
+        (Math.floor((rank-1) / 10) + 1).toInt
       }
     }
 


### PR DESCRIPTION
I couldn't get a Swiss tourney running in dev, so this is speculative. But I'm thinking maybe Swiss ranking is 1-indexed and Arena ranking is 0-indexed. Instead of rewriting Swiss rankings in the db, probably best to just account for it in the `pageof` method?

```
scala> def rank(rank: Int) = (Math.floor((rank -1) / 10) + 1).toInt
rank: (rank: Int)Int

scala> rank(1)
res0: Int = 1

scala> rank(0)
res1: Int = 1

scala> rank(10)
res2: Int = 1

scala> rank(11)
res3: Int = 2

scala> rank(20)
res4: Int = 2

scala> rank(21)
res5: Int = 3

scala> rank(30)
res6: Int = 3
```