### PR TITLE
Do not show game id while puzzle is not solved

### DIFF
--- a/translation/dest/site/en-US.xml
+++ b/translation/dest/site/en-US.xml
@@ -478,7 +478,7 @@ computer analysis, game chat and shareable URL.</string>
     <item quantity="one">Played %s time</item>
     <item quantity="other">Played %s times</item>
   </plurals>
-  <string name="fromGameLink">From game %s</string>
+  <string name="fromGameLink">From game: %s</string>
   <string name="continueTraining">Continue training</string>
   <string name="retryThisPuzzle">Retry this puzzle</string>
   <string name="thisPuzzleIsCorrect">This puzzle is correct and interesting</string>

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -478,7 +478,7 @@ computer analysis, game chat and shareable URL.</string>
     <item quantity="one">Played %s time</item>
     <item quantity="other">Played %s times</item>
   </plurals>
-  <string name="fromGameLink">From game %s</string>
+  <string name="fromGameLink">From game: %s</string>
   <string name="continueTraining">Continue training</string>
   <string name="retryThisPuzzle">Retry this puzzle</string>
   <string name="thisPuzzleIsCorrect">This puzzle is correct and interesting</string>

--- a/ui/puzzle/css/_side.scss
+++ b/ui/puzzle/css/_side.scss
@@ -1,4 +1,7 @@
 .puzzle__side {
+  // avoid layout jumps when showing game id
+  min-width: 270px; 
+
 
   &__metas {
     @extend %box-neat-force;
@@ -19,15 +22,15 @@
         font-size: 3rem;
         margin-right: 1vw;
       }
+      .hidden {
+        opacity: 0.7;
+      }
       &.puzzle {
         padding-bottom: 2vh;
         border-bottom: $border;
         margin-bottom: 2vh;
         a {
           font-size: 1.2em;
-        }
-        .hidden {
-          opacity: 0.7;
         }
       }
       .players {

--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -27,7 +27,7 @@ function gameInfos(ctrl: Controller, game, puzzle): VNode {
   return h('div.infos', {
     attrs: dataIcon(game.perf.icon)
   }, [h('div', [
-    h('p', ctrl.trans.vdom('fromGameLink', h('a', {
+    h('p', ctrl.trans.vdom('fromGameLink', ctrl.vm.mode === 'play' ? h('span.hidden', ctrl.trans.noarg('hidden')) : h('a', {
       attrs: { href: `/${game.id}/${puzzle.color}#${puzzle.initialPly}` }
     }, '#' + game.id))),
     h('p', [


### PR DESCRIPTION
Hi all.

When doing the lichess puzzles on the web, the game link is always visible, which as far as I can tell does not provide any value towards solving the puzzle. 

At times, I've found myself to be a bit more than curious about what the move is before attempting the solution. This PR makes a simple change in hiding the game link while the puzzle is still going on. After that it will be revealed in the same way the rating is.

This is more of a "scratching my itch" as I've since hidden the game link using custom css rules on my browser, however I went ahead and implemented it because I thought it might be a useful addition.

This PR introduces a slight translation change which I wasn't sure on how to follow up with, as in some languages the game link is before the text. A possibility is also to introduce a new translation string "Game" and then display link as `Game: {gameid,hidden}` in the same fashion rating and other stats are presented.