### PR TITLE
noImplicitReturns in ui/analyse

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -850,5 +850,6 @@ export default class AnalyseCtrl {
   withCg<A>(f: (cg: ChessgroundApi) => A): A | undefined {
     if (this.chessground && this.cgVersion.js === this.cgVersion.dom)
       return f(this.chessground);
+    return undefined;
   }
 };

--- a/ui/analyse/src/explorer/explorerUtil.ts
+++ b/ui/analyse/src/explorer/explorerUtil.ts
@@ -10,4 +10,5 @@ export function winnerOf(fen: Fen, move: TablebaseMoveStats): Color | undefined 
     return 'white';
   if ((stm[0] == 'b' && move.wdl! < 0) || (stm[0] == 'w' && move.wdl! > 0))
     return 'black';
+  return undefined;
 }

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -181,6 +181,7 @@ function showDtm(ctrl: AnalyseCtrl, fen: Fen, move: TablebaseMoveStats) {
       title: ctrl.trans.plural('mateInXHalfMoves', Math.abs(move.dtm)) + ' (Depth To Mate)'
     }
   }, 'DTM ' + Math.abs(move.dtm));
+  return undefined;
 }
 
 function showDtz(ctrl: AnalyseCtrl, fen: Fen, move: TablebaseMoveStats): VNode | null {

--- a/ui/analyse/src/fork.ts
+++ b/ui/analyse/src/fork.ts
@@ -40,12 +40,14 @@ export function make(root: AnalyseCtrl): ForkCtrl {
         selected = Math.min(root.node.children.length - 1, selected + 1);
         return true;
       }
+      return undefined;
     },
     prev() {
       if (displayed()) {
         selected = Math.max(0, selected - 1);
         return true;
       }
+      return undefined;
     },
     proceed(it) {
       if (displayed()) {
@@ -53,6 +55,7 @@ export function make(root: AnalyseCtrl): ForkCtrl {
         root.userJumpIfCan(root.path + root.node.children[it].id);
         return true;
       }
+      return undefined;
     }
   };
 }
@@ -85,6 +88,7 @@ export function view(root: AnalyseCtrl, concealOf?: ConcealOf) {
         showEval: root.showComputer(),
         showGlyphs: root.showComputer()
       }, node)!);
+      return undefined;
     })
   );
 }

--- a/ui/analyse/src/retrospect/retroCtrl.ts
+++ b/ui/analyse/src/retrospect/retroCtrl.ts
@@ -161,6 +161,7 @@ export function make(root: AnalyseCtrl, color: Color): RetroCtrl {
   function showBadNode(): Tree.Node | undefined {
     const cur = current();
     if (cur && isSolving() && cur.prev.path === root.path) return cur.fault.node;
+    return undefined;
   }
 
   function isSolving(): boolean {

--- a/ui/analyse/src/socket.ts
+++ b/ui/analyse/src/socket.ts
@@ -55,6 +55,7 @@ export function make(send: SocketSend, ctrl: AnalyseCtrl): Socket {
 
   function currentChapterId(): string | undefined {
     if (ctrl.study) return ctrl.study.vm.chapterId;
+    return undefined;
   };
 
   function addStudyData(req, isWrite = false): void {

--- a/ui/analyse/src/study/gamebook/gamebookButtons.ts
+++ b/ui/analyse/src/study/gamebook/gamebookButtons.ts
@@ -46,4 +46,5 @@ export function overrideButton(study: StudyCtrl): VNode | undefined {
       }, 'Analyse');
     }
   }
+  return undefined;
 }

--- a/ui/analyse/src/study/gamebook/gamebookPlayView.ts
+++ b/ui/analyse/src/study/gamebook/gamebookPlayView.ts
@@ -45,6 +45,7 @@ function hintZone(ctrl: GamebookPlayCtrl) {
     h('div.hint', { hook: richHTML(state.hint!) })
   ]);
   if (state.hint) return h('a.hint', clickHook(), 'Get a hint');
+  return undefined;
 }
 
 function renderFeedback(ctrl: GamebookPlayCtrl, state: State) {

--- a/ui/analyse/src/study/practice/studyPracticeView.ts
+++ b/ui/analyse/src/study/practice/studyPracticeView.ts
@@ -46,6 +46,8 @@ function renderGoal(practice: StudyPracticeCtrl, inMoves: number) {
       return 'Defend for ' + plural('move', inMoves);
     case 'promotion':
       return 'Safely promote your pawn';
+    default:
+      return undefined;
   }
 }
 

--- a/ui/analyse/src/study/relay/relayIntroView.ts
+++ b/ui/analyse/src/study/relay/relayIntroView.ts
@@ -16,4 +16,5 @@ export default function(ctrl: AnalyseCtrl): VNode | undefined {
     ]),
     multiBoardView(study.multiBoard, study)
   ]);
+  return undefined;
 }

--- a/ui/analyse/src/study/relay/relayManagerView.ts
+++ b/ui/analyse/src/study/relay/relayManagerView.ts
@@ -20,6 +20,7 @@ export default function(ctrl: RelayCtrl): VNode | undefined {
     ctrl.data.sync.url ? (ctrl.data.sync.ongoing ? stateOn : stateOff)(ctrl) : null,
     renderLog(ctrl)
   ]);
+  return undefined;
 }
 
 function logSuccess(e: LogEvent) {

--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -247,6 +247,7 @@ export default function(data: StudyData, ctrl: AnalyseCtrl, tagTypes: TagTypes, 
     if (gamebookPlay && gamebookPlay.chapterId === vm.chapterId) return;
     gamebookPlay = new GamebookPlayCtrl(ctrl, vm.chapterId, ctrl.trans, redraw);
     vm.mode.sticky = false;
+    return undefined;
   }
   instanciateGamebookPlay();
 
@@ -269,6 +270,7 @@ export default function(data: StudyData, ctrl: AnalyseCtrl, tagTypes: TagTypes, 
       if (vm.mode.sticky && serverData.sticky) xhrReload();
       return true;
     }
+    return undefined;
   }
 
   function setMemberActive(who?: {u: string}) {
@@ -591,6 +593,7 @@ export default function(data: StudyData, ctrl: AnalyseCtrl, tagTypes: TagTypes, 
         currentId = currentChapter().id;
       for (let i in chapters)
         if (chapters[i].id === currentId) return chapters[parseInt(i) + 1];
+      return undefined;
     },
     setGamebookOverride(o) {
       vm.gamebookOverride = o;

--- a/ui/analyse/src/study/studyMembers.ts
+++ b/ui/analyse/src/study/studyMembers.ts
@@ -196,6 +196,7 @@ export function view(ctrl: StudyCtrl): VNode {
         },
         hook: bind('click', members.leave, ctrl.redraw)
       });
+      return undefined;
   };
 
   function memberConfig(member: StudyMember): VNode {

--- a/ui/analyse/src/study/studyTags.ts
+++ b/ui/analyse/src/study/studyTags.ts
@@ -60,6 +60,7 @@ function renderPgnTags(chapter: StudyChapter, submit, types: string[], trans: Tr
         h('option', trans.noarg('newTag')),
         ...types.map(t => {
           if (!existingTypes.includes(t)) return option(t, '', t);
+          return undefined;
         })
       ]),
       editable('', (value, el) => {

--- a/ui/analyse/src/study/studyView.ts
+++ b/ui/analyse/src/study/studyView.ts
@@ -203,6 +203,7 @@ export function overboard(ctrl: StudyCtrl) {
   if (ctrl.members.inviteForm.open()) return inviteFormView(ctrl.members.inviteForm);
   if (ctrl.topics.open()) return topicsFormView(ctrl.topics, ctrl.members.myId);
   if (ctrl.form.open()) return studyFormView(ctrl.form);
+  return undefined;
 }
 
 export function underboard(ctrl: AnalyseCtrl): MaybeVNodes {

--- a/ui/analyse/src/util.ts
+++ b/ui/analyse/src/util.ts
@@ -116,6 +116,7 @@ export function baseUrl() {
 export function toYouTubeEmbed(url: string): string | undefined {
   const embedUrl = toYouTubeEmbedUrl(url);
   if (embedUrl) return `<div class="embed"><iframe width="100%" src="${embedUrl}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>`;
+  return undefined;
 }
 
 function toYouTubeEmbedUrl(url: string) {
@@ -140,12 +141,14 @@ function toYouTubeEmbedUrl(url: string) {
 export function toTwitchEmbed(url: string): string | undefined {
   const embedUrl = toTwitchEmbedUrl(url);
   if (embedUrl) return `<div class="embed"><iframe width="100%" src="${embedUrl}" frameborder=0 allowfullscreen></iframe></div>`;
+  return undefined;
 }
 
 function toTwitchEmbedUrl(url: string) {
   if (!url) return;
   const m = url.match(/(?:https?:\/\/)?(?:www\.)?(?:twitch.tv)\/([^"&?/ ]+)/i);
   if (m) return `https://player.twitch.tv/?channel=${m[1]}&parent=${location.hostname}&autoplay=false`;
+  return undefined;
 }
 
 const commentYoutubeRegex = /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:.*?(?:[?&]v=)|v\/)|youtu\.be\/)(?:[^"&?\/ ]{11})\b/i;

--- a/ui/analyse/src/view.ts
+++ b/ui/analyse/src/view.ts
@@ -75,6 +75,7 @@ function makeConcealOf(ctrl: AnalyseCtrl): ConcealOf | undefined {
       return conceal.owner ? 'conceal' : 'hide';
     };
   };
+  return undefined;
 }
 
 function renderAnalyse(ctrl: AnalyseCtrl, concealOf?: ConcealOf) {

--- a/ui/analyse/tsconfig.json
+++ b/ui/analyse/tsconfig.json
@@ -3,7 +3,6 @@
   "include": ["src/**/*.ts", "src/**/*.js"],
   "compilerOptions": {
     "allowJs": false,
-    "noImplicitAny": false,
-    "noImplicitReturns": false
+    "noImplicitAny": false
   }
 }


### PR DESCRIPTION
`noImplicitReturns` is `true` is the global config but was overridden in `ui/analyse`. If you'd rather keep the code less verbose, feel free to reject this PR.