### PR TITLE
Use solid lines and distinct colors, closes #6743

### DIFF
--- a/public/javascripts/chart/ratingHistory.js
+++ b/public/javascripts/chart/ratingHistory.js
@@ -38,33 +38,14 @@ lichess.ratingHistoryChart = function(data, singlePerfName) {
         text: null
       };
       $el.each(function() {
-        var dashStyles = [
-          // order of perfs from RatingChartApi.scala
-          'Solid', // Bullet
-          'Solid', // Blitz
-          'Solid', // Rapid
-          'Solid', // Classical
-          'ShortDash', // Correspondence
-          'ShortDash', // Chess960
-          'ShortDash', // KotH
-          'ShortDot', // 3+
-          'ShortDot', // Anti
-          'ShortDot', // Atomic
-          'Dash', // Horde
-          'ShortDot', // Racing Kings
-          'Dash', // Crazyhouse
-          'Dash', // Puzzle
-          'Dash' // Ultrabullet
-        ].filter(indexFilter);
         $(this).highcharts('StockChart', {
           yAxis: {
             title: noText
           },
           credits: disabled,
           legend: disabled,
-          colors: ["#56B4E9", "#0072B2", "#009E73", "#459F3B", "#F0E442", "#E69F00", "#D55E00",
-            "#CC79A7", "#DF5353", "#66558C", "#99E699", "#FFAEAA", "#56B4E9", "#0072B2", "#009E73"
-          ].filter(indexFilter),
+          colors: ["#4363D8", "#42D4F4", "#E6194B", "#3CB44B", "#F58231", "#F032E6", "#FABED4", "#469990",
+          "#DCBEFF", "#9A6324", "#800000", "#AAFFC3", "#BFEF45", "#808000", "#911EB4"].filter(indexFilter),
           rangeSelector: {
             enabled: true,
             selected: 1,
@@ -96,7 +77,7 @@ lichess.ratingHistoryChart = function(data, singlePerfName) {
             return {
               name: serie.name,
               type: 'line',
-              dashStyle: dashStyles[i],
+              dashStyle: 'Solid',
               marker: disabled,
               data: smoothDates(originalDatesAndRatings)
             };


### PR DESCRIPTION
Some colors are repeated, i.e. bullet and crazyhouse, and rapid and ultrabullet, have the same colors, respectively.

<img width="273" alt="Screen Shot 2020-07-02 at 5 46 00 PM" src="https://user-images.githubusercontent.com/28961086/86420754-7144d080-bc8c-11ea-9623-e4c85e5affd6.png">

I think it would look better if they are all solid lines instead of various random patterns, and if the colors are all distinct. I chose the colors mentioned in [this article](https://sashamaps.net/docs/tools/20-colors/), trying to avoid the lightest and darkest of the bunch and using the blueish ones for bullet and blitz.

Of course, this is all subjective ... just one person's opinion. It's probably hard to make a chart with 10-15 lines look nice no matter what you do.