### PR TITLE
Types for ui/puzzle, for #6939

### DIFF
--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -1,11 +1,11 @@
 import { build as treeBuild, ops as treeOps, path as treePath, TreeWrapper } from 'tree';
 import { ctrl as cevalCtrl, CevalCtrl } from 'ceval';
 import keyboard from './keyboard';
-import moveTestBuild from './moveTest';
+import { moveTestBuild, MoveTestFn } from './moveTest';
 import mergeSolution from './solution';
 import makePromotion from './promotion';
 import computeAutoShapes from './autoShape';
-import { defined, prop } from 'common';
+import { defined, prop, Prop } from 'common';
 import { storedProp } from 'common/storage';
 import throttle from 'common/throttle';
 import * as xhr from './xhr';
@@ -24,8 +24,8 @@ import { Redraw, Vm, Controller, PuzzleOpts, PuzzleData, PuzzleRound, PuzzleVote
 export default function(opts: PuzzleOpts, redraw: Redraw): Controller {
 
   let vm: Vm = {} as Vm;
-  var data: PuzzleData, tree: TreeWrapper, ceval: CevalCtrl, moveTest;
-  const ground = prop<CgApi | undefined>(undefined);
+  var data: PuzzleData, tree: TreeWrapper, ceval: CevalCtrl, moveTest: MoveTestFn;
+  const ground = prop<CgApi | undefined>(undefined) as Prop<CgApi>;
   const threatMode = prop(false);
 
   // required by ceval

--- a/ui/puzzle/src/moveTest.ts
+++ b/ui/puzzle/src/moveTest.ts
@@ -2,6 +2,9 @@ import { path as pathOps } from 'tree';
 import { parseUci } from 'chessops/util';
 import { Vm, Puzzle, MoveTest } from './interfaces';
 
+type MoveTestReturn = undefined | 'fail' | 'win' | MoveTest;
+export type MoveTestFn = () => MoveTestReturn;
+
 const altCastles = {
   e1a1: 'e1c1',
   e1h1: 'e1g1',
@@ -9,8 +12,15 @@ const altCastles = {
   e8h8: 'e8g8'
 };
 
-export default function(vm: Vm, puzzle: Puzzle): () => undefined | 'fail' | 'win' | MoveTest {
-  return function(): undefined | 'fail' | 'win' | MoveTest {
+type AltCastle = keyof typeof altCastles;
+
+function isAltCastle(str: string | undefined): str is AltCastle {
+  if (str) return altCastles.hasOwnProperty(str);
+  return false;
+}
+
+export function moveTestBuild(vm: Vm, puzzle: Puzzle): MoveTestFn {
+  return function(): MoveTestReturn {
     if (vm.mode === 'view') return;
     if (!pathOps.contains(vm.path, vm.initialPath)) return;
 
@@ -26,8 +36,9 @@ export default function(vm: Vm, puzzle: Puzzle): () => undefined | 'fail' | 'win
 
     let progress = puzzle.lines;
     for (const i in nodes) {
-      if (progress[nodes[i].uci!]) progress = progress[nodes[i].uci!];
-      else if (nodes[i].castle) progress = progress[altCastles[nodes[i].uci!]] || 'fail';
+      const uci = nodes[i].uci;
+      if (typeof progress === 'object' && uci && progress[uci]) progress = progress[uci];
+      else if (typeof progress === 'object' && nodes[i].castle && isAltCastle(uci)) progress = progress[altCastles[uci]];
       else progress = 'fail';
       if (typeof progress === 'string') break;
     }

--- a/ui/puzzle/src/promotion.ts
+++ b/ui/puzzle/src/promotion.ts
@@ -1,10 +1,12 @@
 import { h } from 'snabbdom';
 import { bind, onInsert } from './util';
+import { Api as CgApi } from 'chessground/api';
 import * as cgUtil from 'chessground/util';
 import { Role } from 'chessground/types';
 import { MaybeVNode, Vm, Redraw, Promotion } from './interfaces';
+import { Prop } from 'common';
 
-export default function(vm: Vm, getGround, redraw: Redraw): Promotion {
+export default function(vm: Vm, getGround: Prop<CgApi>, redraw: Redraw): Promotion {
 
   let promoting: any = false;
 
@@ -25,7 +27,7 @@ export default function(vm: Vm, getGround, redraw: Redraw): Promotion {
     return false;
   }
 
-  function promote(g, key: Key, role: Role): void {
+  function promote(g: CgApi, key: Key, role: Role): void {
     const piece = g.state.pieces[key];
     if (piece && piece.role == 'pawn') {
       g.setPieces({

--- a/ui/puzzle/src/view/tree.ts
+++ b/ui/puzzle/src/view/tree.ts
@@ -16,6 +16,11 @@ interface RenderOpts {
   withIndex?: boolean;
 }
 
+interface Glyph {
+  name: string;
+  symbol: string;
+}
+
 const autoScroll = throttle(150, (ctrl: Controller, el) => {
   var cont = el.parentNode;
   var target = el.querySelector('.active');
@@ -106,7 +111,7 @@ function renderMainlineMoveOf(ctx: Ctx, node: Tree.Node, opts: RenderOpts): VNod
   }, renderMove(ctx, node));
 }
 
-function renderGlyph(glyph): VNode {
+function renderGlyph(glyph: Glyph): VNode {
   return h('glyph', {
     attrs: { title: glyph.name }
   }, glyph.symbol);
@@ -179,7 +184,7 @@ function emptyMove(): VNode {
   return h('move.empty', '...');
 }
 
-function renderEval(e): VNode {
+function renderEval(e: string): VNode {
   return h('eval', e);
 }
 


### PR DESCRIPTION
Solved as much as I could in `ui/puzzle`.

There's not too much remaining in `ui/puzzle`. Below are some examples:

```
function eventPath(e): string {
  return e.target.getAttribute('p') || e.target.parentNode.getAttribute('p');
}
```

Seems like `e` should be `Event`, but if you do `if (e.target) return e.target.getAttribute...` doesn't seem like `getAttribute` is a valid key.

```
function puzzleInfos(ctrl: Controller, puzzle): VNode {
  return h('div.infos.puzzle', {
    attrs: dataIcon('-')
  }, [h('div', [
    h('a.title', {
      attrs: { href: '/training/' + puzzle.id }
    }, ctrl.trans('puzzleId', puzzle.id)),
    h('p', ctrl.trans.vdom('ratingX', ctrl.vm.mode === 'play' ? h('span.hidden', ctrl.trans.noarg('hidden')) : h('strong', puzzle.rating))),
    h('p', ctrl.trans.vdom('playedXTimes', h('strong', window.lichess.numberFormat(puzzle.attempts))))
  ])]);
}
```

It's called with the `Puzzle` type, but this type doesn't have `rating` or `attempts` keys.