### PR TITLE
Incremental compile ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ dist/
 node_modules/
 local/
 ui/*/npm-debug.log
+ui/*/tsconfig.tsbuildinfo
 hs_*.log
 yarn-error.log
 

--- a/ui/ceval/package.json
+++ b/ui/ceval/package.json
@@ -14,7 +14,7 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "compile": "../../node_modules/typescript/bin/tsc",
+    "compile": "../../node_modules/typescript/bin/tsc --incremental",
     "dev": "yarn run compile",
     "prod": "yarn run compile"
   },

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -8,7 +8,7 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "compile": "../../node_modules/typescript/bin/tsc --outDir ./dist --declaration --inlineSourceMap",
+    "compile": "../../node_modules/typescript/bin/tsc --incremental --outDir ./dist --declaration --inlineSourceMap",
     "dev": "yarn run compile && rollup --config",
     "prod": "yarn run compile && rollup --config --config-prod"
   },

--- a/ui/chess/package.json
+++ b/ui/chess/package.json
@@ -12,7 +12,7 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "compile": "../../node_modules/typescript/bin/tsc",
+    "compile": "../../node_modules/typescript/bin/tsc --incremental",
     "dev": "yarn run compile",
     "prod": "yarn run compile"
   },

--- a/ui/common/package.json
+++ b/ui/common/package.json
@@ -11,7 +11,7 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "compile": "../../node_modules/typescript/bin/tsc",
+    "compile": "../../node_modules/typescript/bin/tsc --incremental",
     "dev": "yarn run compile",
     "prod": "yarn run compile"
   },

--- a/ui/game/package.json
+++ b/ui/game/package.json
@@ -13,7 +13,7 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "compile": "../../node_modules/typescript/bin/tsc",
+    "compile": "../../node_modules/typescript/bin/tsc --incremental",
     "dev": "yarn run compile",
     "prod": "yarn run compile"
   },

--- a/ui/nvui/package.json
+++ b/ui/nvui/package.json
@@ -15,7 +15,7 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "compile": "../../node_modules/typescript/bin/tsc",
+    "compile": "../../node_modules/typescript/bin/tsc --incremental",
     "dev": "yarn run compile",
     "prod": "yarn run compile"
   },

--- a/ui/tree/package.json
+++ b/ui/tree/package.json
@@ -12,7 +12,7 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "compile": "../../node_modules/typescript/bin/tsc",
+    "compile": "../../node_modules/typescript/bin/tsc --incremental",
     "dev": "yarn run compile",
     "prod": "yarn run compile"
   },


### PR DESCRIPTION
For just building these in `ui/build`:

```
apps1="common"
apps2="chess ceval game tree chat nvui"
```

... seems marginally faster.

Before:
`ui/build  31.85s user 2.59s system 352% cpu 9.774 total`

After:
`ui/build  27.74s user 2.38s system 362% cpu 8.314 total`