### PR TITLE
Hide the scrollbar on the lobby graph

### DIFF
--- a/ui/lobby/css/app/_hook-chart.scss
+++ b/ui/lobby/css/app/_hook-chart.scss
@@ -2,6 +2,7 @@
   @extend %abs-100;
   bottom: 0;
   right: 0;
+  overflow: hidden;
   .label {
     color: $c-font-dim;
     font-size: .7em;


### PR DESCRIPTION
When hovering over a hook bordering the bottom of the lobby graph, a
scrollbar appears, probably because the icon grows in size to expand
below the box.

![low_scrollbar](https://user-images.githubusercontent.com/395175/87238339-634f2800-c3cf-11ea-950a-cc3222d06cbb.png)
![low_scrollbar_fixed](https://user-images.githubusercontent.com/395175/87238340-63e7be80-c3cf-11ea-9a60-c1f83ba6ee1a.png)

I have not tested my change other than adding the style to lichess.org website from Firefox's developer tools