### PR TITLE
Accusing other players is rude

### DIFF
--- a/modules/shutup/src/main/Dictionary.scala
+++ b/modules/shutup/src/main/Dictionary.scala
@@ -39,7 +39,7 @@ buk?kake
 bull?shit
 cancer
 cawk
-cheat(er|)
+cheat(ed|er|s|)
 chess(|-|_)bot(.?com)?
 chicken
 chink


### PR DESCRIPTION
The word "cheated" keeps appearing in forum posts and likely elsewhere.