### PR TITLE
Increase the maxChapters allowed per study to 1024

### DIFF
--- a/modules/study/src/main/Study.scala
+++ b/modules/study/src/main/Study.scala
@@ -80,7 +80,7 @@ case class Study(
 
 object Study {
 
-  val maxChapters = 64
+  val maxChapters = 1024
 
   case class Id(value: String) extends AnyVal with StringValue
   implicit val idIso = lila.common.Iso.string[Id](Id.apply, _.value)


### PR DESCRIPTION
I've been frequently running out of chapters in the studies I use for puzzles, so I figure it is good to increase the limit unless there's some reason not to.