### PR TITLE
tiny perf opt: bestTeamIdsByTour #6793

### DIFF
--- a/modules/tournament/src/main/PlayerRepo.scala
+++ b/modules/tournament/src/main/PlayerRepo.scala
@@ -88,9 +88,9 @@ final class PlayerRepo(coll: Coll)(implicit ec: scala.concurrent.ExecutionContex
                   magic <- p.int("m")
                 } yield TeamLeader(id, magic)
             }
-          } yield RankedTeam(0, teamId, leaders)
+          } yield new RankedTeam(0, teamId, leaders)
         }.sortBy(-_.magicScore).zipWithIndex map {
-          case (rt, pos) => rt.copy(rank = pos + 1)
+          case (rt, pos) => rt.updateRank(pos + 1)
         }
       } map { ranked =>
       if (ranked.size == battle.teams.size) ranked
@@ -98,7 +98,7 @@ final class PlayerRepo(coll: Coll)(implicit ec: scala.concurrent.ExecutionContex
         ranked ::: battle.teams
           .foldLeft(List.empty[RankedTeam]) {
             case (missing, team) if !ranked.exists(_.teamId == team) =>
-              RankedTeam(missing.headOption.fold(ranked.size)(_.rank) + 1, team, Nil) :: missing
+              new RankedTeam(missing.headOption.fold(ranked.size)(_.rank) + 1, team, Nil, 0) :: missing
             case (acc, _) => acc
           }
           .reverse

--- a/modules/tournament/src/main/TeamBattle.scala
+++ b/modules/tournament/src/main/TeamBattle.scala
@@ -19,13 +19,16 @@ object TeamBattle {
 
   case class TeamVs(teams: chess.Color.Map[TeamID])
 
-  case class RankedTeam(
-      rank: Int,
-      teamId: TeamID,
-      leaders: List[TeamLeader]
+  class RankedTeam(
+      val rank: Int,
+      val teamId: TeamID,
+      val leaders: List[TeamLeader],
+      val magicScore: Int
   ) {
-    def magicScore = leaders.foldLeft(0)(_ + _.magicScore)
-    def score      = leaders.foldLeft(0)(_ + _.score)
+    def this(rank: Int, teamId: TeamID, leaders: List[TeamLeader]) =
+      this(rank, teamId, leaders, leaders.foldLeft(0)(_ + _.magicScore))
+    def score                    = leaders.foldLeft(0)(_ + _.score)
+    def updateRank(newRank: Int) = new RankedTeam(newRank, teamId, leaders, magicScore)
   }
 
   case class TeamLeader(userId: User.ID, magicScore: Int) {


### PR DESCRIPTION
avoid recomputations of RankedTeam.magicScore during sorting