### PR TITLE
fix #6948

### DIFF
--- a/modules/tournament/src/main/PlayerRepo.scala
+++ b/modules/tournament/src/main/PlayerRepo.scala
@@ -89,7 +89,7 @@ final class PlayerRepo(coll: Coll)(implicit ec: scala.concurrent.ExecutionContex
                 } yield TeamLeader(id, magic)
             }
           } yield new RankedTeam(0, teamId, leaders)
-        }.sortBy(-_.magicScore).zipWithIndex map {
+        }.sorted.zipWithIndex map {
           case (rt, pos) => rt.updateRank(pos + 1)
         }
       } map { ranked =>

--- a/modules/tournament/src/main/TeamBattle.scala
+++ b/modules/tournament/src/main/TeamBattle.scala
@@ -23,12 +23,17 @@ object TeamBattle {
       val rank: Int,
       val teamId: TeamID,
       val leaders: List[TeamLeader],
-      val magicScore: Int
-  ) {
+      val score: Int
+  ) extends Ordered[RankedTeam] {
+    private def magicScore = leaders.foldLeft(0)(_ + _.magicScore)
     def this(rank: Int, teamId: TeamID, leaders: List[TeamLeader]) =
-      this(rank, teamId, leaders, leaders.foldLeft(0)(_ + _.magicScore))
-    def score                    = leaders.foldLeft(0)(_ + _.score)
-    def updateRank(newRank: Int) = new RankedTeam(newRank, teamId, leaders, magicScore)
+      this(rank, teamId, leaders, leaders.foldLeft(0)(_ + _.score))
+    def updateRank(newRank: Int) = new RankedTeam(newRank, teamId, leaders, score)
+    override def compare(that: RankedTeam) = {
+      if (this.score > that.score) -1
+      else if (this.score < that.score) 1
+      else that.magicScore - this.magicScore
+    }
   }
 
   case class TeamLeader(userId: User.ID, magicScore: Int) {


### PR DESCRIPTION
sort team by score and then by magicScore
team score cached in val of RankedTeam,
magicScore recomputed but not too often (only in the case of tie of team scores)