### PR TITLE
[RFC] add EvalCacheEntry.updatedAt (to recover from future bugs)

### DIFF
--- a/modules/evalCache/src/main/EvalCacheApi.scala
+++ b/modules/evalCache/src/main/EvalCacheApi.scala
@@ -77,7 +77,8 @@ final class EvalCacheApi(
               _id = input.id,
               nbMoves = destSize(input.fen),
               evals = List(input.eval),
-              usedAt = DateTime.now
+              usedAt = DateTime.now,
+              updatedAt = DateTime.now
             )
             coll.insert.one(entry).recover(lila.db.recoverDuplicateKey(_ => ())) >>-
               cache.put(input.id, fuccess(entry.some)) >>-

--- a/modules/evalCache/src/main/EvalCacheEntry.scala
+++ b/modules/evalCache/src/main/EvalCacheEntry.scala
@@ -12,7 +12,8 @@ case class EvalCacheEntry(
     _id: EvalCacheEntry.Id,
     nbMoves: Int, // multipv cannot be greater than number of legal moves
     evals: List[EvalCacheEntry.Eval],
-    usedAt: DateTime
+    usedAt: DateTime,
+    updatedAt: DateTime
 ) {
 
   import EvalCacheEntry._
@@ -22,7 +23,8 @@ case class EvalCacheEntry(
   def add(eval: Eval) =
     copy(
       evals = EvalCacheSelector(eval :: evals),
-      usedAt = DateTime.now
+      usedAt = DateTime.now,
+      updatedAt = DateTime.now
     )
 
   // finds the best eval with at least multiPv pvs,


### PR DESCRIPTION
In the aftermath of #7086, we should probably flush the eval cache.

Unfortunately there is no good way to find entries that are affected by the bug, other than *usedAt* after 1e5543eac7898e67819e883f5eb28aaf97e27d57, which is basically all entries.

Should we remember the time entries were written, to have a better way to recover from future bugs?