### PR TITLE
ThreadLocalRandom

### DIFF
--- a/modules/api/src/main/InfluxEvent.scala
+++ b/modules/api/src/main/InfluxEvent.scala
@@ -9,7 +9,7 @@ final class InfluxEvent(
     env: String
 )(implicit ec: scala.concurrent.ExecutionContext) {
 
-  private val seed = ornicar.scalalib.Random.nextString(6)
+  private val seed = lila.common.ThreadLocalRandom.nextString(6)
 
   def start() = apply("lila_start", s"Lila starts: $seed")
 

--- a/modules/bot/src/main/GameStateStream.scala
+++ b/modules/bot/src/main/GameStateStream.scala
@@ -2,7 +2,6 @@ package lila.bot
 
 import akka.actor._
 import akka.stream.scaladsl._
-import ornicar.scalalib.Random
 import play.api.i18n.Lang
 import play.api.libs.json._
 
@@ -40,7 +39,7 @@ final class GameStateStream(
     blueprint mapMaterializedValue { queue =>
       val actor = system.actorOf(
         Props(mkActor(init, as, User(u.id, u.isBot), queue)),
-        name = s"GameStateStream:${init.game.id}:${Random nextString 8}"
+        name = s"GameStateStream:${init.game.id}:${lila.common.ThreadLocalRandom nextString 8}"
       )
       queue.watchCompletion().foreach { _ =>
         actor ! PoisonPill

--- a/modules/challenge/src/main/Challenge.scala
+++ b/modules/challenge/src/main/Challenge.scala
@@ -169,12 +169,12 @@ object Challenge {
 
   private val idSize = 8
 
-  private def randomId = ornicar.scalalib.Random nextString idSize
+  private def randomId = lila.common.ThreadLocalRandom nextString idSize
 
   def toRegistered(variant: Variant, timeControl: TimeControl)(u: User) =
     Challenger.Registered(u.id, Rating(u.perfs(perfTypeOf(variant, timeControl))))
 
-  def randomColor = chess.Color(scala.util.Random.nextBoolean())
+  def randomColor = chess.Color(lila.common.ThreadLocalRandom.nextBoolean())
 
   def make(
       variant: Variant,

--- a/modules/chat/src/main/ChatTimeout.scala
+++ b/modules/chat/src/main/ChatTimeout.scala
@@ -61,7 +61,7 @@ final class ChatTimeout(
 
   private val idSize = 8
 
-  private def makeId = scala.util.Random.alphanumeric take idSize mkString
+  private def makeId = lila.common.ThreadLocalRandom nextString idSize
 }
 
 object ChatTimeout {

--- a/modules/clas/src/main/Clas.scala
+++ b/modules/clas/src/main/Clas.scala
@@ -30,7 +30,7 @@ object Clas {
 
   def make(teacher: User, name: String, desc: String) =
     Clas(
-      _id = Id(scala.util.Random.alphanumeric take 8 mkString),
+      _id = Id(lila.common.ThreadLocalRandom nextString 8),
       name = name,
       desc = desc,
       teachers = NonEmptyList.one(teacher.id),

--- a/modules/clas/src/main/ClasInvite.scala
+++ b/modules/clas/src/main/ClasInvite.scala
@@ -19,7 +19,7 @@ object ClasInvite {
 
   def make(clas: Clas, user: User, realName: String, teacher: User) =
     ClasInvite(
-      _id = Id(scala.util.Random.alphanumeric take 8 mkString),
+      _id = Id(lila.common.ThreadLocalRandom nextString 8),
       userId = user.id,
       realName = realName,
       clasId = clas.id,

--- a/modules/clas/src/main/NameGenerator.scala
+++ b/modules/clas/src/main/NameGenerator.scala
@@ -1,6 +1,5 @@
 package lila.clas
 
-import scala.util.Random
 import scala.concurrent.ExecutionContext
 
 final class NameGenerator(userRepo: lila.user.UserRepo)(implicit ec: ExecutionContext) {
@@ -16,7 +15,7 @@ final class NameGenerator(userRepo: lila.user.UserRepo)(implicit ec: ExecutionCo
   }
 
   private def anyOf[A](vec: Vector[A]): A =
-    vec(Random.between(0, vec.size))
+    vec(lila.common.ThreadLocalRandom.nextInt(vec.size))
 
   lazy val combinations = Vector(
     List(adjectives, nouns)

--- a/modules/common/src/main/GreatPlayer.scala
+++ b/modules/common/src/main/GreatPlayer.scala
@@ -604,7 +604,7 @@ object GreatPlayer {
     case (k, _) => k
   }.toVector
 
-  def randomName: String = names(scala.util.Random nextInt size)
+  def randomName: String = names(lila.common.ThreadLocalRandom nextInt size)
 
   def wikiUrl(name: String) =
     all get name map { s =>

--- a/modules/common/src/main/ThreadLocalRandom.scala
+++ b/modules/common/src/main/ThreadLocalRandom.scala
@@ -1,6 +1,6 @@
 package lila.common
 
-import scala.collection.mutable.{ ArrayBuffer, StringBuilder }
+import scala.collection.mutable.StringBuilder
 
 object ThreadLocalRandom {
   private[this] def current()             = java.util.concurrent.ThreadLocalRandom.current()
@@ -20,27 +20,8 @@ object ThreadLocalRandom {
      else i - 4).toChar
   }
   def alphanumeric: LazyList[Char] = LazyList.continually(nextChar())
-
-  /** Returns a new collection of the same type in a randomly chosen order.
-    *
-    *  @return         the shuffled collection
-    */
-  def shuffle[T, C](xs: IterableOnce[T])(implicit bf: scala.collection.BuildFrom[xs.type, T, C]): C = {
-    val buf = new ArrayBuffer[T] ++= xs
-
-    def swap(i1: Int, i2: Int): Unit = {
-      val tmp = buf(i1)
-      buf(i1) = buf(i2)
-      buf(i2) = tmp
-    }
-
-    for (n <- buf.length to 2 by -1) {
-      val k = nextInt(n)
-      swap(n - 1, k)
-    }
-
-    (bf.newBuilder(xs) ++= buf).result()
-  }
+  def shuffle[T, C](xs: IterableOnce[T])(implicit bf: scala.collection.BuildFrom[xs.type, T, C]): C =
+    new scala.util.Random(current()).shuffle(xs)
   def nextString(len: Int): String = {
     val sb = new StringBuilder(len)
     for (_ <- 0 until len) sb += nextChar()

--- a/modules/common/src/main/ThreadLocalRandom.scala
+++ b/modules/common/src/main/ThreadLocalRandom.scala
@@ -1,0 +1,49 @@
+package lila.common
+
+import scala.collection.mutable.{ ArrayBuffer, StringBuilder }
+
+object ThreadLocalRandom {
+  private[this] def current()             = java.util.concurrent.ThreadLocalRandom.current()
+  def nextBoolean(): Boolean              = current().nextBoolean()
+  def nextBytes(bytes: Array[Byte]): Unit = current().nextBytes(bytes)
+  def nextDouble(): Double                = current().nextDouble()
+  def nextFloat(): Float                  = current().nextFloat()
+  def nextGaussian(): Double              = current().nextGaussian()
+  def nextInt(): Int                      = current().nextInt()
+  def nextInt(n: Int): Int                = current().nextInt(n)
+  def nextLong(): Long                    = current().nextLong()
+  def setSeed(seed: Long): Unit           = current().setSeed(seed)
+  def nextChar(): Char = {
+    val i = nextInt(62)
+    (if (i < 26) i + 65
+     else if (i < 52) i + 71
+     else i - 4).toChar
+  }
+  def alphanumeric: LazyList[Char] = LazyList.continually(nextChar())
+
+  /** Returns a new collection of the same type in a randomly chosen order.
+    *
+    *  @return         the shuffled collection
+    */
+  def shuffle[T, C](xs: IterableOnce[T])(implicit bf: scala.collection.BuildFrom[xs.type, T, C]): C = {
+    val buf = new ArrayBuffer[T] ++= xs
+
+    def swap(i1: Int, i2: Int): Unit = {
+      val tmp = buf(i1)
+      buf(i1) = buf(i2)
+      buf(i2) = tmp
+    }
+
+    for (n <- buf.length to 2 by -1) {
+      val k = nextInt(n)
+      swap(n - 1, k)
+    }
+
+    (bf.newBuilder(xs) ++= buf).result()
+  }
+  def nextString(len: Int): String = {
+    val sb = new StringBuilder(len)
+    for (_ <- 0 until len) sb += nextChar()
+    sb.result()
+  }
+}

--- a/modules/event/src/main/Event.scala
+++ b/modules/event/src/main/Event.scala
@@ -45,7 +45,7 @@ case class Event(
 
 object Event {
 
-  def makeId = ornicar.scalalib.Random nextString 8
+  def makeId = lila.common.ThreadLocalRandom nextString 8
 
   case class UserId(value: String) extends AnyVal
 }

--- a/modules/explorer/src/main/ExplorerIndexer.scala
+++ b/modules/explorer/src/main/ExplorerIndexer.scala
@@ -5,7 +5,7 @@ import chess.format.pgn.Tag
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 import play.api.libs.ws.DefaultBodyWritables._
-import scala.util.Random.nextFloat
+import lila.common.ThreadLocalRandom.nextFloat
 import scala.util.{ Failure, Success, Try }
 
 import lila.common.LilaStream

--- a/modules/fishnet/src/main/Monitor.scala
+++ b/modules/fishnet/src/main/Monitor.scala
@@ -68,7 +68,7 @@ final private class Monitor(
   }
 
   private def sample[A](elems: List[A], n: Int) =
-    if (elems.sizeIs <= n) elems else scala.util.Random shuffle elems take n
+    if (elems.sizeIs <= n) elems else lila.common.ThreadLocalRandom shuffle elems take n
 
   private def monitorClients(): Funit =
     repo.allRecentClients map { clients =>

--- a/modules/fishnet/src/main/Work.scala
+++ b/modules/fishnet/src/main/Work.scala
@@ -113,5 +113,5 @@ object Work {
     override def toString = s"id:$id game:${game.id} tries:$tries requestedBy:$sender acquired:$acquired"
   }
 
-  def makeId = Id(scala.util.Random.alphanumeric take 8 mkString)
+  def makeId = Id(lila.common.ThreadLocalRandom nextString 8)
 }

--- a/modules/forum/src/main/Post.scala
+++ b/modules/forum/src/main/Post.scala
@@ -2,7 +2,6 @@ package lila.forum
 
 import lila.user.User
 import org.joda.time.DateTime
-import ornicar.scalalib.Random
 import scala.concurrent.duration._
 
 case class OldVersion(text: String, createdAt: DateTime)
@@ -96,7 +95,7 @@ object Post {
   ): Post = {
 
     Post(
-      _id = Random nextString idSize,
+      _id = lila.common.ThreadLocalRandom nextString idSize,
       topicId = topicId,
       author = author,
       userId = userId.some,

--- a/modules/forum/src/main/Topic.scala
+++ b/modules/forum/src/main/Topic.scala
@@ -1,7 +1,7 @@
 package lila.forum
 
 import org.joda.time.DateTime
-import ornicar.scalalib.Random
+import lila.common.ThreadLocalRandom
 import scala.util.chaining._
 
 import lila.user.User
@@ -64,7 +64,7 @@ object Topic {
   def nameToId(name: String) =
     (lila.common.String slugify name) pipe { slug =>
       // if most chars are not latin, go for random slug
-      if (slug.lengthIs > (name.lengthIs / 2)) slug else Random nextString 8
+      if (slug.lengthIs > (name.lengthIs / 2)) slug else ThreadLocalRandom nextString 8
     }
 
   val idSize = 8
@@ -78,7 +78,7 @@ object Topic {
       hidden: Boolean
   ): Topic =
     Topic(
-      _id = Random nextString idSize,
+      _id = ThreadLocalRandom nextString idSize,
       categId = categId,
       slug = slug,
       name = name,

--- a/modules/game/src/main/GameRepo.scala
+++ b/modules/game/src/main/GameRepo.scala
@@ -1,6 +1,6 @@
 package lila.game
 
-import scala.util.Random
+import lila.common.ThreadLocalRandom
 
 import chess.format.{ FEN, Forsyth }
 import chess.{ Color, Status }
@@ -343,7 +343,7 @@ final class GameRepo(val coll: Coll)(implicit ec: scala.concurrent.ExecutionCont
         Query.mate ++ Query.variantStandard
       )
       .sort(Query.sortCreated)
-      .skip(Random nextInt distribution)
+      .skip(ThreadLocalRandom nextInt distribution)
       .one[Game]
 
   def insertDenormalized(g: Game, initialFen: Option[chess.format.FEN] = None): Funit = {
@@ -459,7 +459,7 @@ final class GameRepo(val coll: Coll)(implicit ec: scala.concurrent.ExecutionCont
     coll.ext
       .find($empty)
       .sort(Query.sortCreated)
-      .skip(Random nextInt 1000)
+      .skip(ThreadLocalRandom nextInt 1000)
       .one[Game]
 
   def findPgnImport(pgn: String): Fu[Option[Game]] =

--- a/modules/game/src/main/IdGenerator.scala
+++ b/modules/game/src/main/IdGenerator.scala
@@ -36,7 +36,7 @@ object IdGenerator {
   private[this] val whiteSuffixChars = ('0' to '4') ++ ('A' to 'Z') mkString
   private[this] val blackSuffixChars = ('5' to '9') ++ ('a' to 'z') mkString
 
-  def uncheckedGame: Game.ID = Random nextString Game.gameIdSize
+  def uncheckedGame: Game.ID = lila.common.ThreadLocalRandom nextString Game.gameIdSize
 
   def player(color: Color): Player.ID = {
     // Trick to avoid collisions between player ids in the same game.

--- a/modules/insight/src/main/InsightApi.scala
+++ b/modules/insight/src/main/InsightApi.scala
@@ -30,7 +30,7 @@ final class InsightApi(
       .aggregate(question, user)
       .flatMap { aggDocs =>
         val clusters = AggregationClusters(question, aggDocs)
-        val gameIds  = scala.util.Random.shuffle(clusters.flatMap(_.gameIds)) take 4
+        val gameIds  = lila.common.ThreadLocalRandom.shuffle(clusters.flatMap(_.gameIds)) take 4
         gameRepo.userPovsByGameIds(gameIds, user) map { povs =>
           Answer(question, clusters, povs)
         }

--- a/modules/lobby/src/main/Color.scala
+++ b/modules/lobby/src/main/Color.scala
@@ -1,6 +1,6 @@
 package lila.lobby
 
-import scala.util.Random.nextBoolean
+import lila.common.ThreadLocalRandom.nextBoolean
 
 sealed abstract class Color(val name: String) {
 

--- a/modules/lobby/src/main/Hook.scala
+++ b/modules/lobby/src/main/Hook.scala
@@ -2,7 +2,6 @@ package lila.lobby
 
 import chess.{ Clock, Mode, Speed }
 import org.joda.time.DateTime
-import ornicar.scalalib.Random
 import play.api.i18n.Lang
 import play.api.libs.json._
 
@@ -123,7 +122,7 @@ object Hook {
       boardApi: Boolean = false
   ): Hook =
     new Hook(
-      id = Random nextString idSize,
+      id = lila.common.ThreadLocalRandom nextString idSize,
       sri = sri,
       variant = variant.id,
       clock = clock,

--- a/modules/lobby/src/main/Seek.scala
+++ b/modules/lobby/src/main/Seek.scala
@@ -2,7 +2,6 @@ package lila.lobby
 
 import chess.{ Mode, Speed }
 import org.joda.time.DateTime
-import ornicar.scalalib.Random
 import play.api.libs.json._
 import play.api.i18n.Lang
 
@@ -87,7 +86,7 @@ object Seek {
       blocking: Set[String]
   ): Seek =
     new Seek(
-      _id = Random nextString idSize,
+      _id = lila.common.ThreadLocalRandom nextString idSize,
       variant = variant.id,
       daysPerTurn = daysPerTurn,
       mode = mode.id,
@@ -99,7 +98,7 @@ object Seek {
 
   def renew(seek: Seek) =
     new Seek(
-      _id = Random nextString idSize,
+      _id = lila.common.ThreadLocalRandom nextString idSize,
       variant = seek.variant,
       daysPerTurn = seek.daysPerTurn,
       mode = seek.mode,

--- a/modules/mod/src/main/AssessApi.scala
+++ b/modules/mod/src/main/AssessApi.scala
@@ -20,7 +20,7 @@ import lila.user.User
 import org.joda.time.DateTime
 import reactivemongo.api.ReadPreference
 import reactivemongo.api.bson._
-import scala.util.Random
+import lila.common.ThreadLocalRandom
 
 import chess.Color
 
@@ -151,7 +151,7 @@ final class AssessApi(
   private val assessableSources: Set[Source] = Set(Source.Lobby, Source.Pool, Source.Tournament)
 
   private def randomPercent(percent: Int): Boolean =
-    Random.nextInt(100) < percent
+    ThreadLocalRandom.nextInt(100) < percent
 
   def onGameReady(game: Game, white: User, black: User): Funit = {
 
@@ -178,7 +178,7 @@ final class AssessApi(
 
     def suspCoefVariation(c: Color) = {
       val x = noFastCoefVariation(game player c)
-      x.filter(_ < 0.45f) orElse x.filter(_ < 0.5f).ifTrue(Random.nextBoolean())
+      x.filter(_ < 0.45f) orElse x.filter(_ < 0.5f).ifTrue(ThreadLocalRandom.nextBoolean())
     }
     lazy val whiteSuspCoefVariation = suspCoefVariation(chess.White)
     lazy val blackSuspCoefVariation = suspCoefVariation(chess.Black)

--- a/modules/msg/src/main/BsonHandlers.scala
+++ b/modules/msg/src/main/BsonHandlers.scala
@@ -38,7 +38,7 @@ private object BsonHandlers {
 
   def writeMsg(msg: Msg, threadId: MsgThread.Id): Bdoc =
     msgHandler.writeTry(msg).get ++ $doc(
-      "_id" -> ornicar.scalalib.Random.nextString(10),
+      "_id" -> lila.common.ThreadLocalRandom.nextString(10),
       "tid" -> threadId
     )
 

--- a/modules/notify/src/main/Notification.scala
+++ b/modules/notify/src/main/Notification.scala
@@ -3,7 +3,6 @@ package lila.notify
 import lila.common.paginator.Paginator
 import lila.notify.MentionedInThread.PostId
 import org.joda.time.DateTime
-import ornicar.scalalib.Random
 
 case class NewNotification(notification: Notification, unreadNotifications: Int)
 
@@ -34,7 +33,7 @@ object Notification {
 
   def make(notifies: Notification.Notifies, content: NotificationContent): Notification = {
     val idSize = 8
-    val id     = Random nextString idSize
+    val id     = lila.common.ThreadLocalRandom nextString idSize
     new Notification(id, notifies, content, NotificationRead(false), DateTime.now)
   }
 }

--- a/modules/plan/src/main/Charge.scala
+++ b/modules/plan/src/main/Charge.scala
@@ -1,7 +1,6 @@
 package lila.plan
 
 import org.joda.time.DateTime
-import ornicar.scalalib.Random
 
 case class Charge(
     _id: String, // random
@@ -34,7 +33,7 @@ object Charge {
       cents: Cents
   ) =
     Charge(
-      _id = Random nextString 8,
+      _id = lila.common.ThreadLocalRandom nextString 8,
       userId = userId,
       stripe = stripe,
       payPal = payPal,

--- a/modules/pool/src/main/PoolActor.scala
+++ b/modules/pool/src/main/PoolActor.scala
@@ -1,7 +1,7 @@
 package lila.pool
 
 import scala.concurrent.duration._
-import scala.util.Random
+import lila.common.ThreadLocalRandom
 
 import akka.actor._
 import akka.pattern.pipe
@@ -25,7 +25,7 @@ final private class PoolActor(
 
   def scheduleWave() =
     nextWave = context.system.scheduler.scheduleOnce(
-      config.wave.every + Random.nextInt(1000).millis,
+      config.wave.every + ThreadLocalRandom.nextInt(1000).millis,
       self,
       ScheduledWave
     )

--- a/modules/puzzle/src/main/Selector.scala
+++ b/modules/puzzle/src/main/Selector.scala
@@ -1,6 +1,6 @@
 package lila.puzzle
 
-import scala.util.Random
+import lila.common.ThreadLocalRandom
 import reactivemongo.api.ReadPreference
 
 import lila.db.AsyncColl
@@ -33,7 +33,7 @@ final private[puzzle] class Selector(
       case None =>
         anonIdsCache flatMap { ids =>
           puzzleColl {
-            _.byId[Puzzle, Int](ids(Random nextInt ids.size))
+            _.byId[Puzzle, Int](ids(ThreadLocalRandom nextInt ids.size))
           }
         }
       // user

--- a/modules/quote/src/main/Quote.scala
+++ b/modules/quote/src/main/Quote.scala
@@ -1,7 +1,7 @@
 package lila.quote
 
-import play.api.libs.json._
 import scala.util.Random
+import play.api.libs.json._
 
 final class Quote(val text: String, val author: String)
 

--- a/modules/relay/src/main/Relay.scala
+++ b/modules/relay/src/main/Relay.scala
@@ -68,7 +68,7 @@ object Relay {
 
   case class Id(value: String) extends AnyVal with StringValue
 
-  def makeId = Id(ornicar.scalalib.Random nextString 8)
+  def makeId = Id(lila.common.ThreadLocalRandom nextString 8)
 
   case class Sync(
       upstream: Option[Sync.Upstream], // if empty, needs a client to push PGN

--- a/modules/report/src/main/Report.scala
+++ b/modules/report/src/main/Report.scala
@@ -1,7 +1,6 @@
 package lila.report
 
 import org.joda.time.DateTime
-import ornicar.scalalib.Random
 import cats.data.NonEmptyList
 
 import lila.user.User
@@ -162,7 +161,7 @@ object Report {
       case c @ Candidate.Scored(candidate, score) =>
         existing.fold(
           Report(
-            _id = Random nextString 8,
+            _id = lila.common.ThreadLocalRandom nextString 8,
             user = candidate.suspect.user.id,
             reason = candidate.reason,
             room = Room(candidate.reason),

--- a/modules/security/src/main/GarbageCollector.scala
+++ b/modules/security/src/main/GarbageCollector.scala
@@ -4,7 +4,7 @@ import org.joda.time.DateTime
 import play.api.mvc.RequestHeader
 import scala.concurrent.duration._
 
-import lila.common.{ Bus, EmailAddress, HTTPRequest, IpAddress }
+import lila.common.{ Bus, EmailAddress, HTTPRequest, IpAddress, ThreadLocalRandom }
 import lila.user.User
 
 // codename UGC
@@ -97,7 +97,7 @@ final class GarbageCollector(
     !done.get(user.id) ?? {
       done put user.id
       val armed = isArmed()
-      val wait  = (30 + scala.util.Random.nextInt(300)).seconds
+      val wait  = (30 + ThreadLocalRandom.nextInt(300)).seconds
       val message =
         s"Will dispose of @${user.username} in $wait. Email: ${email.value}. $msg${!armed ?? " [SIMULATION]"}"
       logger.info(message)

--- a/modules/security/src/main/SecurityApi.scala
+++ b/modules/security/src/main/SecurityApi.scala
@@ -99,7 +99,7 @@ final class SecurityApi(
   def saveSignup(userId: User.ID, apiVersion: Option[ApiVersion], fp: Option[FingerPrint])(implicit
       req: RequestHeader
   ): Funit = {
-    val sessionId = Random nextString 22
+    val sessionId = lila.common.ThreadLocalRandom nextString 22
     store.save(s"SIG-$sessionId", userId, req, apiVersion, up = false, fp = fp)
   }
 

--- a/modules/security/src/main/Store.scala
+++ b/modules/security/src/main/Store.scala
@@ -7,9 +7,8 @@ import reactivemongo.api.CursorProducer
 import reactivemongo.api.ReadPreference
 import scala.concurrent.blocking
 import scala.concurrent.duration._
-import scala.util.Random
 
-import lila.common.{ ApiVersion, HTTPRequest, IpAddress }
+import lila.common.{ ApiVersion, HTTPRequest, IpAddress, ThreadLocalRandom }
 import lila.db.dsl._
 import lila.user.User
 
@@ -66,8 +65,9 @@ final class Store(val coll: Coll, cacheApi: lila.memo.CacheApi, localIp: IpAddre
           "user" -> userId,
           "ip" -> (HTTPRequest.lastRemoteAddress(req) match {
             // randomize stresser IPs to relieve mod tools
-            case ip if ip == localIp => IpAddress(s"127.0.${Random nextInt 256}.${Random nextInt 256}")
-            case ip                  => ip
+            case ip if ip == localIp =>
+              IpAddress(s"127.0.${ThreadLocalRandom nextInt 256}.${ThreadLocalRandom nextInt 256}")
+            case ip => ip
           }),
           "ua"   -> HTTPRequest.userAgent(req).|("?"),
           "date" -> DateTime.now,

--- a/modules/simul/src/main/Simul.scala
+++ b/modules/simul/src/main/Simul.scala
@@ -5,7 +5,6 @@ import chess.{ Speed, StartingPosition }
 import lila.rating.PerfType
 import lila.user.User
 import org.joda.time.DateTime
-import ornicar.scalalib.Random
 import chess.Color
 
 case class Simul(
@@ -154,7 +153,7 @@ object Simul {
       team: Option[String]
   ): Simul =
     Simul(
-      _id = Random nextString 8,
+      _id = lila.common.ThreadLocalRandom nextString 8,
       name = name,
       status = SimulStatus.Created,
       clock = clock,

--- a/modules/socket/src/main/RemoteSocket.scala
+++ b/modules/socket/src/main/RemoteSocket.scala
@@ -38,7 +38,7 @@ final class RemoteSocket(
   private val requests = new ConcurrentHashMap[Int, Promise[String]](32)
 
   def request[R](sendReq: Int => Unit, readRes: String => R): Fu[R] = {
-    val id = Math.abs(scala.util.Random.nextInt())
+    val id = Math.abs(lila.common.ThreadLocalRandom.nextInt())
     sendReq(id)
     val promise = Promise[String]()
     requests.put(id, promise)

--- a/modules/streamer/src/main/Streaming.scala
+++ b/modules/streamer/src/main/Streaming.scala
@@ -54,7 +54,7 @@ final private class Streaming(
       (twitchStreams, youTubeStreams) <-
         fetchTwitchStreams(streamers, 0, None, Nil) zip fetchYouTubeStreams(streamers)
       streams = LiveStreams {
-        scala.util.Random.shuffle {
+        lila.common.ThreadLocalRandom.shuffle {
           (twitchStreams ::: youTubeStreams) pipe dedupStreamers
         }
       }

--- a/modules/study/src/main/Chapter.scala
+++ b/modules/study/src/main/Chapter.scala
@@ -163,7 +163,7 @@ object Chapter {
 
   val idSize = 8
 
-  def makeId = Id(scala.util.Random.alphanumeric take idSize mkString)
+  def makeId = Id(lila.common.ThreadLocalRandom nextString idSize)
 
   def make(
       studyId: Study.Id,

--- a/modules/study/src/main/Study.scala
+++ b/modules/study/src/main/Study.scala
@@ -167,7 +167,7 @@ object Study {
 
   val idSize = 8
 
-  def makeId = Id(scala.util.Random.alphanumeric take idSize mkString)
+  def makeId = Id(lila.common.ThreadLocalRandom nextString idSize)
 
   def make(
       user: User,

--- a/modules/swiss/src/main/Swiss.scala
+++ b/modules/swiss/src/main/Swiss.scala
@@ -117,7 +117,7 @@ object Swiss {
       (points.value * 10000000 + tieBreak.value * 10000 + perf.value).toInt
     )
 
-  def makeId = Id(scala.util.Random.alphanumeric take 8 mkString)
+  def makeId = Id(lila.common.ThreadLocalRandom nextString 8)
 
   case class PastAndNext(past: List[Swiss], next: List[Swiss])
 

--- a/modules/team/src/main/Team.scala
+++ b/modules/team/src/main/Team.scala
@@ -1,7 +1,6 @@
 package lila.team
 
 import org.joda.time.DateTime
-import ornicar.scalalib.Random
 import scala.util.chaining._
 
 import lila.user.User
@@ -93,6 +92,6 @@ object Team {
   def nameToId(name: String) =
     (lila.common.String slugify name) pipe { slug =>
       // if most chars are not latin, go for random slug
-      if (slug.lengthIs > (name.lengthIs / 2)) slug else Random nextString 8
+      if (slug.lengthIs > (name.lengthIs / 2)) slug else lila.common.ThreadLocalRandom nextString 8
     }
 }

--- a/modules/tournament/src/main/Pairing.scala
+++ b/modules/tournament/src/main/Pairing.scala
@@ -86,7 +86,7 @@ private[tournament] object Pairing {
   }
 
   def prepWithColor(tour: Tournament, p1: RankedPlayerWithColorHistory, p2: RankedPlayerWithColorHistory) =
-    if (p1.colorHistory.firstGetsWhite(p2.colorHistory)(() => scala.util.Random.nextBoolean()))
+    if (p1.colorHistory.firstGetsWhite(p2.colorHistory)(() => lila.common.ThreadLocalRandom.nextBoolean()))
       Prep(tour.id, p1.player.userId, p2.player.userId)
     else Prep(tour.id, p2.player.userId, p1.player.userId)
 }

--- a/modules/tournament/src/main/Player.scala
+++ b/modules/tournament/src/main/Player.scala
@@ -5,8 +5,6 @@ import lila.hub.LightTeam.TeamID
 import lila.rating.Perf
 import lila.user.{ Perfs, User }
 
-import ornicar.scalalib.Random
-
 private[tournament] case class Player(
     _id: Player.ID, // random
     tourId: Tournament.ID,
@@ -51,7 +49,7 @@ private[tournament] object Player {
       team: Option[TeamID]
   ): Player =
     new Player(
-      _id = Random.nextString(8),
+      _id = lila.common.ThreadLocalRandom.nextString(8),
       tourId = tourId,
       userId = user.id,
       rating = perfLens(user.perfs).intRating,

--- a/modules/tournament/src/main/StartedOrganizer.scala
+++ b/modules/tournament/src/main/StartedOrganizer.scala
@@ -3,7 +3,7 @@ package lila.tournament
 import akka.actor._
 import akka.stream.scaladsl._
 import scala.concurrent.duration._
-import scala.util.Random
+import lila.common.ThreadLocalRandom
 
 final private class StartedOrganizer(
     api: TournamentApi,
@@ -57,7 +57,7 @@ final private class StartedOrganizer(
 
   private def processTour(tour: Tournament): Fu[Int] =
     if (tour.secondsToFinish <= 0) api finish tour inject 0
-    else if (!tour.isScheduled && tour.nbPlayers < 30 && Random.nextInt(10) == 0) {
+    else if (!tour.isScheduled && tour.nbPlayers < 30 && ThreadLocalRandom.nextInt(10) == 0) {
       playerRepo nbActiveUserIds tour.id flatMap { nb =>
         (nb >= 2) ?? startPairing(tour)
       }

--- a/modules/tournament/src/main/Tournament.scala
+++ b/modules/tournament/src/main/Tournament.scala
@@ -1,7 +1,7 @@
 package lila.tournament
 
 import org.joda.time.{ DateTime, Duration, Interval }
-import ornicar.scalalib.Random
+import lila.common.ThreadLocalRandom
 import play.api.i18n.Lang
 import scala.util.chaining._
 
@@ -190,7 +190,7 @@ object Tournament {
       noStreak = !streakable,
       schedule = None,
       startsAt = startDate match {
-        case Some(startDate) => startDate plusSeconds scala.util.Random.nextInt(60)
+        case Some(startDate) => startDate plusSeconds ThreadLocalRandom.nextInt(60)
         case None            => DateTime.now plusMinutes waitMinutes
       },
       description = description,
@@ -212,12 +212,12 @@ object Tournament {
       mode = Mode.Rated,
       conditions = sched.conditions,
       schedule = Some(sched),
-      startsAt = sched.at plusSeconds scala.util.Random.nextInt(60)
+      startsAt = sched.at plusSeconds ThreadLocalRandom.nextInt(60)
     )
 
   def tournamentUrl(tourId: String): String = s"https://lichess.org/tournament/$tourId"
 
-  def makeId = Random nextString 8
+  def makeId = ThreadLocalRandom nextString 8
 
   case class PastAndNext(past: List[Tournament], next: List[Tournament])
 }

--- a/modules/tree/src/main/tree.scala
+++ b/modules/tree/src/main/tree.scala
@@ -131,7 +131,7 @@ object Node {
   object Comment {
     case class Id(value: String) extends AnyVal
     object Id {
-      def make = Id(scala.util.Random.alphanumeric take 4 mkString)
+      def make = Id(lila.common.ThreadLocalRandom nextString 4)
     }
     private val metaReg = """\[%[^\]]+\]""".r
     case class Text(value: String) extends AnyVal {

--- a/modules/user/src/main/NoteApi.scala
+++ b/modules/user/src/main/NoteApi.scala
@@ -63,7 +63,7 @@ final class NoteApi(
   def write(to: User, text: String, from: User, modOnly: Boolean, dox: Boolean) = {
 
     val note = Note(
-      _id = ornicar.scalalib.Random nextString 8,
+      _id = lila.common.ThreadLocalRandom nextString 8,
       from = from.id,
       to = to.id,
       text = text,

--- a/modules/user/src/main/TrophyApi.scala
+++ b/modules/user/src/main/TrophyApi.scala
@@ -64,7 +64,7 @@ final class TrophyApi(
     coll.insert
       .one(
         $doc(
-          "_id"  -> ornicar.scalalib.Random.nextString(8),
+          "_id"  -> lila.common.ThreadLocalRandom.nextString(8),
           "user" -> userId,
           "kind" -> kindKey,
           "url"  -> trophyUrl,

--- a/modules/user/src/main/UserRepo.scala
+++ b/modules/user/src/main/UserRepo.scala
@@ -143,7 +143,7 @@ final class UserRepo(val coll: Coll)(implicit ec: scala.concurrent.ExecutionCont
       .sort($doc(F.colorIt -> 1))
       .one[Bdoc]
       .map {
-        _.fold(scala.util.Random.nextBoolean()) { doc =>
+        _.fold(lila.common.ThreadLocalRandom.nextBoolean()) { doc =>
           doc.string("_id") contains u1
         }
       }

--- a/modules/video/src/main/Youtube.scala
+++ b/modules/video/src/main/Youtube.scala
@@ -54,7 +54,7 @@ final private[video] class Youtube(
     api.video.allIds flatMap { ids =>
       ws.url(url)
         .withQueryStringParameters(
-          "id"   -> scala.util.Random.shuffle(ids).take(max.value).mkString(","),
+          "id"   -> lila.common.ThreadLocalRandom.shuffle(ids).take(max.value).mkString(","),
           "part" -> "id,statistics,snippet,contentDetails",
           "key"  -> apiKey.value
         )


### PR DESCRIPTION
replace scala.util.Random.{nextInt, nextBoolean, shuffle} by lila.common.ThreadLocalRandom._
replace ornicar.scalalib.Random.nextString by lila.common.ThreadLocalRandom.nextString
nextString has mutable realization without boxing/unboxing Chars
Ref: https://stackoverflow.com/questions/9600114/parallel-random-number-generation-with-akka-futures
https://stackoverflow.com/questions/49801698/scala-parallel-collections