### PR TITLE
redirect /username to /@/username when possible

### DIFF
--- a/app/controllers/Round.scala
+++ b/app/controllers/Round.scala
@@ -2,16 +2,16 @@ package controllers
 
 import play.api.libs.json._
 import play.api.mvc._
+import views._
 
 import lila.api.Context
 import lila.app._
 import lila.chat.Chat
 import lila.common.HTTPRequest
 import lila.game.{ Pov, Game => GameModel, PgnDump }
-import lila.tournament.{ Tournament => Tour }
 import lila.swiss.Swiss.{ Id => SwissId }
+import lila.tournament.{ Tournament => Tour }
 import lila.user.{ User => UserModel }
-import views._
 
 final class Round(
     env: Env,
@@ -19,7 +19,8 @@ final class Round(
     challengeC: => Challenge,
     analyseC: => Analyse,
     tournamentC: => Tournament,
-    swissC: => Swiss
+    swissC: => Swiss,
+    userC: => User
 ) extends LilaController(env)
     with TheftPrevention {
 
@@ -143,7 +144,7 @@ final class Round(
             case None =>
               watch(pov)
           }
-        case None => challengeC showId gameId
+        case None => userC.tryRedirect(gameId) getOrElse challengeC.showId(gameId)
       }
     }
 

--- a/app/controllers/User.scala
+++ b/app/controllers/User.scala
@@ -10,6 +10,7 @@ import scala.concurrent.duration._
 import scala.language.existentials
 import scala.util.chaining._
 import scalatags.Text.Frag
+import views._
 
 import lila.api.{ BodyContext, Context }
 import lila.app._
@@ -20,7 +21,6 @@ import lila.game.{ Pov, Game => GameModel }
 import lila.rating.PerfType
 import lila.socket.UserLagCache
 import lila.user.{ User => UserModel }
-import views._
 
 final class User(
     env: Env,
@@ -551,5 +551,15 @@ final class User(
   def myself =
     Auth { _ => me =>
       fuccess(Redirect(routes.User.show(me.username)))
+    }
+
+  def redirect(username: String) =
+    Open { implicit ctx =>
+      tryRedirect(username) getOrElse notFound
+    }
+
+  def tryRedirect(username: String)(implicit ctx: Context): Fu[Option[Result]] =
+    env.user.repo named username map2 { user =>
+      Redirect(routes.User.show(user.username))
     }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -719,5 +719,7 @@ GET   /assets/*file                    controllers.ExternalAssets.at(path="publi
 GET   /manifest.json                   controllers.Main.manifest
 GET   /robots.txt                      controllers.Main.robots
 
+GET   /$username<\w{2,30}>             controllers.User.redirect(username: String)
+
 OPTIONS /                              controllers.Options.root
 OPTIONS /*url                          controllers.Options.all(url: String)


### PR DESCRIPTION
but never actually link to it, because these URLs may break
when we add root-level URLs or when a game ID is generated.