### PR TITLE
change instance of "title" to "utitle"

### DIFF
--- a/ui/round/src/view/user.ts
+++ b/ui/round/src/view/user.ts
@@ -41,7 +41,7 @@ export function userHtml(ctrl: RoundController, player: Player, position: Positi
         }
       }, user.title ? [
         h(
-          'span.title',
+          'span.utitle',
           user.title == 'BOT' ? { attrs: {'data-bot': true } } : {},
           user.title
         ), ' ', user.username


### PR DESCRIPTION
image worth more than a thousand words, maybe:

![utitle-bug](https://i.imgur.com/UXJ7zuX.png)

everywhere else seems to be using the correct `utitle`, except for this instance.