### PR TITLE
Types for ui/round for ornicar#6939

### DIFF
--- a/ui/round/src/plugins/keyboardMove.ts
+++ b/ui/round/src/plugins/keyboardMove.ts
@@ -1,4 +1,4 @@
-import sanWriter from './sanWriter';
+import { sanWriter, SanToUci } from './sanWriter';
 import { Dests } from '../interfaces';
 
 const keyRegex = /^[a-h][1-8]$/;
@@ -17,32 +17,32 @@ type Submit = (v: string, submitOpts: SubmitOpts) => void;
 window.lichess.keyboardMove = function(opts: any) {
   if (opts.input.classList.contains('ready')) return;
   opts.input.classList.add('ready');
-  let sans: any = null;
+  let legalSans: SanToUci | null = null;
 
   const submit: Submit = function(v: string, submitOpts: SubmitOpts) {
     // consider 0's as O's for castling
     v = v.replace(/0/g, 'O');
-    const foundUci = v.length >= 2 && sans && sanToUci(v, sans);
+    const foundUci = v.length >= 2 && legalSans && sanToUci(v, legalSans);
     if (v == 'resign') {
       opts.ctrl.resign(true, true);
       clear();
     }
-    else if (foundUci) {
+    else if (legalSans && foundUci) {
       // ambiguous castle
-      if (v.toLowerCase() === 'o-o' && sans['O-O-O'] && !submitOpts.force) return;
+      if (v.toLowerCase() === 'o-o' && legalSans['O-O-O'] && !submitOpts.force) return;
       // ambiguous UCI
       if (v.match(keyRegex) && opts.ctrl.hasSelected()) opts.ctrl.select(v);
-      // ambiguous promotion (also check sans[v] here because bc8 could mean Bc8)
-      if (v.match(ambiguousPromotionCaptureRegex) && sans[v] && !submitOpts.force) return;
+      // ambiguous promotion (also check legalSans[v] here because bc8 could mean Bc8)
+      if (v.match(ambiguousPromotionCaptureRegex) && legalSans[v] && !submitOpts.force) return;
       else opts.ctrl.san(foundUci.slice(0, 2), foundUci.slice(2));
       clear();
-    } else if (sans && v.match(keyRegex)) {
+    } else if (legalSans && v.match(keyRegex)) {
       opts.ctrl.select(v);
       clear();
-    } else if (sans && v.match(fileRegex)) {
+    } else if (legalSans && v.match(fileRegex)) {
       // do nothing
-    } else if (sans && v.match(promotionRegex)) {
-      const foundUci = sanToUci(v.replace('=', '').slice(0, -1), sans);
+    } else if (legalSans && v.match(promotionRegex)) {
+      const foundUci = sanToUci(v.replace('=', '').slice(0, -1), legalSans);
       if (!foundUci) return;
       opts.ctrl.promote(foundUci.slice(0, 2), foundUci.slice(2), v.slice(-1).toUpperCase());
       clear();
@@ -60,7 +60,7 @@ window.lichess.keyboardMove = function(opts: any) {
       opts.input.value = '';
     }
     else {
-      const wrong = v.length && sans && !sanCandidates(v, sans).length;
+      const wrong = v.length && legalSans && !sanCandidates(v, legalSans).length;
       if (wrong && !opts.input.classList.contains('wrong')) window.lichess.sound.error();
       opts.input.classList.toggle('wrong', wrong);
     }
@@ -71,7 +71,7 @@ window.lichess.keyboardMove = function(opts: any) {
   };
   makeBindings(opts, submit, clear);
   return function(fen: string, dests: Dests | undefined, yourMove: boolean) {
-    sans = dests && dests.size > 0 ? sanWriter(fen, destsToUcis(dests)) : null;
+    legalSans = dests && dests.size > 0 ? sanWriter(fen, destsToUcis(dests)) : null;
     submit(opts.input.value, {
       server: true,
       yourMove: yourMove
@@ -117,22 +117,22 @@ function makeBindings(opts: any, submit: Submit, clear: Function) {
   });
 }
 
-function sanToUci(san: string, sans): Key[] | undefined {
-  if (san in sans) return sans[san];
+function sanToUci(san: string, legalSans: SanToUci): Uci | undefined {
+  if (san in legalSans) return legalSans[san];
   const lowered = san.toLowerCase();
-  for (let i in sans)
-    if (i.toLowerCase() === lowered) return sans[i];
+  for (let i in legalSans)
+    if (i.toLowerCase() === lowered) return legalSans[i];
   return;
 }
 
-function sanCandidates(san: string, sans) {
+function sanCandidates(san: string, legalSans: SanToUci): San[] {
   const lowered = san.toLowerCase();
-  return Object.keys(sans).filter(function(s) {
+  return Object.keys(legalSans).filter(function(s) {
     return s.toLowerCase().startsWith(lowered);
   });
 }
 
-function destsToUcis(dests: Dests) {
+function destsToUcis(dests: Dests): Uci[] {
   const ucis: string[] = [];
   for (const [orig, d] of dests) {
     d.forEach(function(dest) {

--- a/ui/round/src/plugins/sanWriter.ts
+++ b/ui/round/src/plugins/sanWriter.ts
@@ -1,4 +1,5 @@
 type Board = {pieces: {[key: number]: string}, turn: boolean};
+export type SanToUci = {[key: string]: Uci};
 
 function fixCrazySan(san: string) {
   return san[0] === 'P' ? san.slice(1) : san;
@@ -126,9 +127,9 @@ function sanOf(board: Board, uci: string) {
   return san;
 }
 
-export default function sanWriter(fen: string, ucis: string[]) {
+export function sanWriter(fen: string, ucis: string[]): SanToUci {
   var board = readFen(fen);
-  var sans: {[key: string]: string} = {}
+  var sans: SanToUci = {}
   ucis.forEach(function(uci) {
     var san = sanOf(board, uci);
     sans[san] = uci;


### PR DESCRIPTION
Fixing types for https://github.com/ornicar/lila/issues/6939

1. Added new type `SanToUci`
2. Renamed variable `sans` to `legalSans` because the object only contains legal moves.
3. First time contributor. Hi!

Note: Now the last remaining violation of noImplicitAny for ui/round is importing the ab module.