### PR TITLE
ceval always off by default (fixes #5528)

### DIFF
--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -81,9 +81,8 @@ export default function(opts: CevalOpts): CevalCtrl {
   const multiPv = storedProp(storageKey('ceval.multipv'), opts.multiPvDefault || 1);
   const infinite = storedProp('ceval.infinite', false);
   let curEval: Tree.ClientEval | null = null;
-  const enableStorage = li.storage.makeBoolean(storageKey('client-eval-enabled'));
   const allowed = prop(true);
-  const enabled = prop(opts.possible && allowed() && enableStorage.get() && !document.hidden);
+  const enabled = prop(false);
   let started: Started | false = false;
   let lastStarted: Started | false = false; // last started object (for going deeper even if stopped)
   const hovering = prop<Hovering | null>(null);
@@ -216,15 +215,6 @@ export default function(opts: CevalOpts): CevalCtrl {
     started = false;
   }
 
-  // ask other tabs if a game is in progress
-  if (enabled()) {
-    li.storage.fire('ceval.fen', 'start');
-    li.storage.make('round.ongoing').listen(_ => {
-      enabled(false);
-      opts.redraw();
-    });
-  }
-
   return {
     technology,
     start,
@@ -250,8 +240,6 @@ export default function(opts: CevalOpts): CevalCtrl {
       if (!opts.possible || !allowed()) return;
       stop();
       enabled(!enabled());
-      if (document.visibilityState !== 'hidden')
-        enableStorage.set(enabled());
     },
     curDepth: () => curEval ? curEval.depth : 0,
     effectiveMaxDepth,

--- a/ui/ceval/src/main.ts
+++ b/ui/ceval/src/main.ts
@@ -9,7 +9,7 @@ export { ctrl, view, winningChances };
 // stop when another tab starts. Listen only once here,
 // as the ctrl can be instanciated several times.
 // gotta do the click on the toggle to have it visually change.
-window.lichess.storage.make('ceval.pool.start').listen(_ => {
+window.lichess.storage.make('ceval.disable').listen(_ => {
   const toggle = document.getElementById('analyse-toggle-ceval');
   if (toggle && (toggle as HTMLInputElement).checked) toggle.click();
 });

--- a/ui/ceval/src/pool.ts
+++ b/ui/ceval/src/pool.ts
@@ -139,7 +139,7 @@ export class Pool {
   }
 
   start(work: Work): void {
-    window.lichess.storage.fire('ceval.pool.start');
+    window.lichess.storage.fire('ceval.disable'); // disable on all other tabs
     this.getWorker().then(function(worker) {
       worker.start(work);
     }).catch(function(error) {

--- a/ui/round/src/cevalSub.ts
+++ b/ui/round/src/cevalSub.ts
@@ -17,15 +17,19 @@ export function subscribe(ctrl: RoundController): void {
   if (!ctrl.data.game.rated && ctrl.opts.userId) return;
   // bots can cheat alright
   if (ctrl.data.player.user && ctrl.data.player.user.title === 'BOT') return;
+
+  // Disable ceval. Unless this game is loaded directly on a position being
+  // analysed, there is plenty of time (7 moves, in most cases) for this to
+  // take effect.
+  li.storage.fire('ceval.disable');
+
   li.storage.make('ceval.fen').listen(e => {
-    if (e.value === 'start') return li.storage.fire('round.ongoing');
     const d = ctrl.data, step = lastStep(ctrl.data);
     if (!found && step.ply > 14 && ctrl.isPlaying() &&
       e.value && truncateFen(step.fen) === truncateFen(e.value)) {
       xhr.text(`/jslog/${d.game.id}${d.player.id}?n=ceval`, { method: 'post' });
       found = true;
     }
-    return;
   });
 }
 


### PR DESCRIPTION
* Fixes #5528
* No more `round.ongoing` event, racing to disable ceval in time
* Previously ceval would only be automatically disabled if it was enabled at page load. Now once disable it no matter what

cc @lakinwecker 