### PR TITLE
Allow more promotion move inputs (#7326)

### DIFF
--- a/ui/round/src/plugins/keyboardMove.ts
+++ b/ui/round/src/plugins/keyboardMove.ts
@@ -6,7 +6,7 @@ const keyRegex = /^[a-h][1-8]$/;
 const fileRegex = /^[a-h]$/;
 const crazyhouseRegex = /^\w?@[a-h][1-8]$/;
 const ambiguousPromotionCaptureRegex = /^([a-h]x?)?[a-h](1|8)$/;
-const promotionRegex = /^([a-h]x?)?[a-h](1|8)=?[nbrq]$/;
+const promotionRegex = /^([a-h]x?)?[a-h](1|8)=?[nbrqNBRQ]$/;
 
 interface Opts {
   input: HTMLInputElement;
@@ -128,7 +128,8 @@ function sanToUci(san: string, legalSans: SanToUci): Uci | undefined {
 }
 
 function sanCandidates(san: string, legalSans: SanToUci): San[] {
-  const lowered = san.toLowerCase();
+  // replace '=' in promotion moves (#7326)
+  const lowered = san.replace('=', '').toLowerCase();
   return Object.keys(legalSans).filter(function(s) {
     return s.toLowerCase().startsWith(lowered);
   });


### PR DESCRIPTION
Keyboard input promoting pawn, h8=q should be the same as h8=Q
- allow upper case as promotion moves as well
- do not consider inputs containing a '=' as wrong