### PR TITLE
Fixup: update generation of sound asset path

### DIFF
--- a/ui/site/src/component/assets.ts
+++ b/ui/site/src/component/assets.ts
@@ -3,7 +3,7 @@ import * as xhr from 'common/xhr';
 export const assetUrl = (path: string, opts: AssetUrlOpts = {}) => {
   opts = opts || {};
   const baseUrl = opts.sameDomain ? '' : document.body.getAttribute('data-asset-url'),
-    version = opts.version || document.body.getAttribute('data-asset-version');
+    version = document.body.getAttribute('data-asset-version');
   return baseUrl + '/assets' + (opts.noVersion ? '' : '/_' + version) + '/' + path;
 };
 

--- a/ui/site/src/component/sound.ts
+++ b/ui/site/src/component/sound.ts
@@ -11,7 +11,7 @@ const sound = new class {
   soundSet = $('body').data('sound-set');
   speechStorage = storage.makeBoolean('speech.enabled');
   volumeStorage = storage.make('sound-volume');
-  baseUrl = assetUrl('sound', { version: '000004' });
+  baseUrl = assetUrl('sound');
 
   constructor() {
     if (this.soundSet == 'music') setTimeout(this.publish, 500);


### PR DESCRIPTION
This might not be the correct fix here, so please bear with me if not :)

I noticed on the lichess site that the low-time warning sounds didn't seem to be audible, and found an existing report of this in #7379.

Looking at recent commits, 46b5ae586df633e6c7f3448d029af80c221dbf8b seemed like a possible cause, so I was trying to figure out whether the problem could be related to that.

Grepping the codebase, it wasn't clear whether the version number applied to sound assets was used elsewhere.  On lichess.org currently, `data-asset-url="https://lichess1.org" data-asset-version="AYLyxt"`, and the resource `https://lichess1.org/assets/_AYLyxt/sound/sfx/LowTime.ogg` *does* exist, so it seems like the default behaviour of asset-URL + asset-version + 'sound' might work as-is for sound assets, without the `version` option override.

After adjusting that, I couldn't find any remaining usages of the `version` option, so I removed that too.

I haven't yet understood the asset bundling process, so this could all be on the wrong track, but it looked like a small effort so I figured I'd take a go and learn something along the way.

Resolves #7379 