### PR TITLE
Fix #7389: minor (sass) - making the horizontal padding smaller for TDs

### DIFF
--- a/ui/tournament/css/_team-battle.scss
+++ b/ui/tournament/css/_team-battle.scss
@@ -83,6 +83,10 @@ team {
   tr:hover {
     background: mix($c-primary, $c-bg-box, 30%) !important;
   }
+
+  td {
+    padding: 1rem 0.5rem;
+  }
 }
 
 .team-battle {


### PR DESCRIPTION
It's inside the `.tour__team-standing` block, so the CSS rule shouldn't "leak" somewhere else.

before:
![Screenshot from 2020-10-01 14-41-41](https://user-images.githubusercontent.com/535866/94810428-476a8980-03f4-11eb-9d70-13a35c302986.png)




![Screenshot from 2020-10-01 14-39-12](https://user-images.githubusercontent.com/535866/94810165-f22e7800-03f3-11eb-8da0-8635b96dd72e.png)



after:

![Screenshot from 2020-10-01 14-31-41](https://user-images.githubusercontent.com/535866/94810468-53eee200-03f4-11eb-9119-a3710284e305.png)


![Screenshot from 2020-10-01 14-43-14](https://user-images.githubusercontent.com/535866/94810548-75e86480-03f4-11eb-8b5e-b36f4f0523f7.png)
