### PR TITLE
Fix sparkline puzzle rating

### DIFF
--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -74,11 +74,12 @@ function ratingChart(ctrl: Controller, hash: string): VNode {
 function drawRatingChart(ctrl: Controller, vnode: VNode): void {
   const $el = $(vnode.elm as HTMLElement);
   const points = ctrl.getData().user!.recent.map(r => r[2] + r[1]);
+  const localPuzzleMin = Math.min(...points); 
   const redraw = () => {
     const $svg = $('<svg class="sparkline" height="80px" stroke-width="3">')
       .attr('width', Math.round($el.outerWidth()) + 'px')
       .prependTo($(vnode.elm).empty());
-    sparkline($svg[0], points, {
+    sparkline($svg[0], points.map(r => r - localPuzzleMin), {
       interactive: true,
     })
   };


### PR DESCRIPTION
Puzzle rating graph was [too flat](https://lichess.org/forum/lichess-feedback/puzzle-solving-graph-is-not-changing-its-linear-always-3) due to this issue: https://github.com/fnando/sparkline/issues/17

before:
![Screen Shot 2020-10-02 at 13 34 17](https://user-images.githubusercontent.com/56031107/94935910-89173500-04c5-11eb-99c6-09b288d502ac.png)
after:
![Screen Shot 2020-10-02 at 15 36 47 copy](https://user-images.githubusercontent.com/56031107/94935918-8a486200-04c5-11eb-8958-3698e5f58695.png)
![Screen Shot 2020-10-02 at 15 36 47](https://user-images.githubusercontent.com/56031107/94935914-89afcb80-04c5-11eb-90cd-6fbf48bfd64e.png)
