### PR TITLE
Added color to BOT title in search.

### DIFF
--- a/ui/site/src/userComplete.ts
+++ b/ui/site/src/userComplete.ts
@@ -35,13 +35,13 @@ export default function(opts: Opts): void {
 
   complete<Result>({
     input: opts.input,
-    fetch: t => debounced(t).then(({term, result}) => 
+    fetch: t => debounced(t).then(({term, result}) =>
       t == term ? result : Promise.reject('Debounced ' + t)
     ),
     render(o: Result) {
       const tag = opts.tag || 'a';
       return '<' + tag + ' class="complete-result ulpt user-link' + (o.online ? ' online' : '') + '" ' + (tag === 'a' ? '' : 'data-') + 'href="/@/' + o.name + '">' +
-        '<i class="line' + (o.patron ? ' patron' : '') + '"></i>' + (o.title ? '<span class="utitle">' + o.title + '</span>&nbsp;' : '') + o.name +
+        '<i class="line' + (o.patron ? ' patron' : '') + '"></i>' + (o.title ? '<span class="utitle"' + (o.title == 'BOT' ? ' data-bot="data-bot" ': '') + '>' + o.title + '</span>&nbsp;' : '') + o.name +
         '</' + tag + '>';
     },
     populate: opts.populate || (r => r.name),


### PR DESCRIPTION
Currently when you search for a bot, it shows the old orange color that's used for titles.

This changes it to the purple that's used for the bot titles.