### PR TITLE
Add lichess.org/thanks link back to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Feel free to use the [Lichess API](https://lichess.org/api) in your applications
 Credits
 -------
 
-See the [contributors](https://github.com/ornicar/lila/graphs/contributors) on this repository.
+See the [contributors](https://github.com/ornicar/lila/graphs/contributors) on this repository and [lichess.org/thanks](https://lichess.org/thanks).
 
 Supported browsers
 ------------------


### PR DESCRIPTION
Since the `thanks` page has been restored, this reverts changes done to close #7396 in commit https://github.com/ornicar/lila/commit/a74cf1cacd7b9a4a3093b24522cfce52d051b5cc.