### PR TITLE
"display: table" for .cg-wrap (maybe fixes #7435)

### DIFF
--- a/ui/common/css/component/_board.scss
+++ b/ui/common/css/component/_board.scss
@@ -10,6 +10,11 @@
   }
 }
 
+.cg-wrap {
+  display: table; // part of hack to round to full pixel size in chrome
+}
+
 .mini-board, .mini-game .cg-wrap {
   @extend %square;
+  display: table;
 }

--- a/ui/common/css/vendor/chessground/_chessground.scss
+++ b/ui/common/css/vendor/chessground/_chessground.scss
@@ -108,9 +108,7 @@ cg-helper {
   position: absolute;
   width: 12.5%;
   padding-bottom: 12.5%;
-  display: table;
-
-  /* hack: round to full pixel size in chrome */
+  display: table; // hack to round to full pixel size in chrome
   bottom: 0;
 }
 


### PR DESCRIPTION
appears to be a fix, but could use some more cross-browser testing. it's on stage