### PR TITLE
mod tweak

### DIFF
--- a/app/views/simul/show.scala
+++ b/app/views/simul/show.scala
@@ -54,7 +54,7 @@ object show {
                     sim.variants.map(_.name).mkString(", "),
                     " • ",
                     trans.casual(),
-                    ctx.userId.has(sim.hostId) && sim.isCreated option frag(
+                    (isGranted(_.ManageSimul) || ctx.userId.has(sim.hostId)) && sim.isCreated option frag(
                       " • ",
                       a(href := routes.Simul.edit(sim.id), title := "Edit simul")(iconTag("%"))
                     )

--- a/modules/forum/src/main/TopicApi.scala
+++ b/modules/forum/src/main/TopicApi.scala
@@ -176,7 +176,7 @@ final private[forum] class TopicApi(
   def toggleSticky(categ: Categ, topic: Topic, mod: User): Funit =
     env.topicRepo.sticky(topic.id, !topic.isSticky) >> {
       MasterGranter(_.ModerateForum)(mod) ??
-        modLog.toggleStickyTopic(mod.id, categ.name, topic.name, topic.isSticky)
+        modLog.toggleStickyTopic(mod.id, categ.name, topic.name, !topic.isSticky)
     }
 
   def denormalize(topic: Topic): Funit =


### PR DESCRIPTION
Fix `sticky` and `unsticky` mod log

 Currently it was swapped: stickying a topic was logged as un-styckying and vice versa