### PR TITLE
chore: add ambient declaration for ab stub  module

### DIFF
--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -1,3 +1,5 @@
+/// <reference types="../types/ab" />
+
 import * as ab from 'ab';
 import * as round from './round';
 import * as game from 'game';

--- a/ui/round/tsconfig.json
+++ b/ui/round/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../tsconfig.base.json",
   "include": ["src/**/*.ts"],
-  "compilerOptions": {
-    "noImplicitAny": false
-  }
+  "compilerOptions": {}
 }

--- a/ui/round/types/ab.d.ts
+++ b/ui/round/types/ab.d.ts
@@ -1,0 +1,5 @@
+declare module 'ab' {
+  import { MoveMetadata } from 'chessground/types';
+  function init (round: unknown): unknown
+  function move (round: unknown, meta: MoveMetadata): unknown
+}


### PR DESCRIPTION
Type declaration unfortunately contains unknown types because an ambient type declaration cannot reference
a module with a relative path (RoundController)

Checks out ui/round for #6939 