### PR TITLE
Allow different increments for simul hosts and participants

### DIFF
--- a/app/views/simul/bits.scala
+++ b/app/views/simul/bits.scala
@@ -45,7 +45,8 @@ object bits {
         tr(
           td(cls := "name")(a(href := routes.Simul.show(simul.id))(simul.fullName)),
           td(userIdLink(simul.hostId.some)),
-          td(cls := "text", dataIcon := "p")(simul.clock.config.show),
+          td(cls := "text", dataIcon := "p")(simul.clock.participantConfig.show),
+          td(cls := "text", dataIcon := "p")(simul.clock.hostConfig.show),
           td(cls := "text", dataIcon := "r")(simul.applicants.size)
         )
       }
@@ -53,7 +54,8 @@ object bits {
 
   private[simul] def setup(sim: lila.simul.Simul) =
     span(cls := List("setup" -> true, "rich" -> sim.variantRich))(
-      sim.clock.config.show,
+      sim.clock.participantConfig.show,
+      sim.clock.hostConfig.show,
       " • ",
       sim.variants.map(_.name).mkString(", ")
     )

--- a/app/views/simul/form.scala
+++ b/app/views/simul/form.scala
@@ -87,22 +87,21 @@ object form {
       form3.split(
         form3.group(
           form("clockTime"),
-          raw("Clock initial time"),
-          help = trans.simulClockHint().some,
+          trans.simulClockInitialParticipants(),
           half = true
         )(form3.select(_, clockTimeChoices)),
-        form3.group(form("clockIncrement"), raw("Clock increment"), half = true)(
+        form3.group(form("clockIncrement"), trans.simulClockIncrementParticipants(), half = true)(
           form3.select(_, clockIncrementChoices)
         )
       ),
       form3.split(
         form3.group(
           form("clockTimeHost"),
-          raw("Clock initial time for host"),
+          trans.simulClockInitialHost(),
           help = trans.simulClockHint().some,
           half = true
         )(form3.select(_, clockTimeChoices)),
-        form3.group(form("clockIncrementHost"), raw("Clock increment for host"), half = true)(
+        form3.group(form("clockIncrementHost"), trans.simulClockIncrementHost(), half = true)(
           form3.select(_, clockIncrementChoices)
         )
       ),

--- a/app/views/simul/form.scala
+++ b/app/views/simul/form.scala
@@ -97,13 +97,16 @@ object form {
       ),
       form3.split(
         form3.group(
-          form("clockExtra"),
-          trans.simulHostExtraTime(),
-          help = trans.simulAddExtraTime().some,
+          form("clockTimeHost"),
+          raw("Clock initial time for host"),
+          help = trans.simulClockHint().some,
           half = true
-        )(
-          form3.select(_, clockExtraChoices)
-        ),
+        )(form3.select(_, clockTimeChoices)),
+        form3.group(form("clockIncrementHost"), raw("Clock increment for host"), half = true)(
+          form3.select(_, clockIncrementChoices)
+        )
+      ),
+      form3.split(
         form3.group(form("color"), raw("Host color for each game"), half = true)(
           form3.select(_, colorChoices)
         )

--- a/app/views/simul/show.scala
+++ b/app/views/simul/show.scala
@@ -49,7 +49,8 @@ object show {
               div(cls := "header")(
                 iconTag("f"),
                 div(
-                  span(cls := "clock")(sim.clock.config.show),
+                  span(cls := "clock")(sim.clock.participantConfig.show),
+                  span(cls := "clock")(sim.clock.hostConfig.show),
                   div(cls := "setup")(
                     sim.variants.map(_.name).mkString(", "),
                     " • ",
@@ -61,10 +62,6 @@ object show {
                   )
                 )
               ),
-              trans.simulHostExtraTime(),
-              ": ",
-              pluralize("minute", sim.clock.hostExtraMinutes),
-              br,
               trans.hostColorX(sim.color match {
                 case Some("white") => trans.white()
                 case Some("black") => trans.black()

--- a/modules/db/src/main/ByteArray.scala
+++ b/modules/db/src/main/ByteArray.scala
@@ -16,6 +16,8 @@ case class ByteArray(value: Array[Byte]) {
     } mkString ","
 
   override def toString = toHexStr
+
+  def ++(that: ByteArray) = ByteArray(this.value ++ that.value)
 }
 
 object ByteArray {

--- a/modules/game/src/test/BinaryClockTest.scala
+++ b/modules/game/src/test/BinaryClockTest.scala
@@ -19,8 +19,20 @@ class BinaryClockTest extends Specification {
   def read(bytes: List[String])     = readBytes(ByteArray.parseBytes(bytes))
 
   "binary Clock" should {
-    val clock  = Clock(120, 2)
-    val bits22 = List("00000010", "00000010")
+    val clock = Clock(120, 2)
+    val bits22 = List(
+      "11111111",
+      "11111111",
+      "00000000",
+      "00000001",
+      "00000010",
+      "00000010",
+      "00000010",
+      "00000010",
+      "00000010",
+      "00000010"
+    )
+    val bitsLegacy = List("00000010", "00000010")
     "write" in {
       write(clock) must_== {
         bits22 ::: List.fill(6)(_0_)
@@ -32,7 +44,24 @@ class BinaryClockTest extends Specification {
         bits22 ::: List("00000000", "00000000", "00000011") ::: List.fill(3)(_0_)
       }
       write(Clock(0, 3)) must_== {
-        List("00000000", "00000011", "10000000", "00000001", "00101100", "10000000", "00000001", "00101100")
+        List(
+          "11111111",
+          "11111111",
+          "00000000",
+          "00000001",
+          "00000000",
+          "00000011",
+          "00000000",
+          "00000011",
+          "00000000",
+          "00000011",
+          "10000000",
+          "00000001",
+          "00101100",
+          "10000000",
+          "00000001",
+          "00101100"
+        )
       }
     }
     "read" in {
@@ -47,6 +76,17 @@ class BinaryClockTest extends Specification {
           clock.giveTime(White, Centis(-3))
         }
       }
+      "with timer legacy" in {
+        read(bitsLegacy ::: List.fill(11)(_0_)) must_== {
+          clock
+        }
+        read(bitsLegacy ::: List("10000000", "00000000", "00000011") ::: List.fill(8)(_0_)) must_== {
+          clock.giveTime(White, Centis(3))
+        }
+        read(bitsLegacy ::: List("00000000", "00000000", "00000011") ::: List.fill(8)(_0_)) must_== {
+          clock.giveTime(White, Centis(-3))
+        }
+      }
       "without timer bytes" in {
         read(bits22 ::: List.fill(7)(_0_)) must_== {
           clock
@@ -55,6 +95,18 @@ class BinaryClockTest extends Specification {
           clock.giveTime(White, Centis(3))
         }
         read(bits22 ::: List("00000000", "00000000", "00000011") ::: List.fill(4)(_0_)) must_== {
+          clock.giveTime(White, Centis(-3))
+        }
+      }
+
+      "without timer bytes legacy" in {
+        read(bitsLegacy ::: List.fill(7)(_0_)) must_== {
+          clock
+        }
+        read(bitsLegacy ::: List("10000000", "00000000", "00000011") ::: List.fill(4)(_0_)) must_== {
+          clock.giveTime(White, Centis(3))
+        }
+        read(bitsLegacy ::: List("00000000", "00000000", "00000011") ::: List.fill(4)(_0_)) must_== {
           clock.giveTime(White, Centis(-3))
         }
       }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -515,6 +515,12 @@ val `create` = new I18nKey("create")
 val `whenCreateSimul` = new I18nKey("whenCreateSimul")
 val `simulVariantsHint` = new I18nKey("simulVariantsHint")
 val `simulClockHint` = new I18nKey("simulClockHint")
+val `simulClockInitialParticipants` = new I18nKey("simulClockInitialParticipants")
+val `simulClockIncrementParticipants` = new I18nKey("simulClockIncrementParticipants")
+val `simulClockInitialHost` = new I18nKey("simulClockInitialHost")
+val `simulClockIncrementHost` = new I18nKey("simulClockIncrementHost")
+
+
 val `simulAddExtraTime` = new I18nKey("simulAddExtraTime")
 val `simulHostExtraTime` = new I18nKey("simulHostExtraTime")
 val `lichessTournaments` = new I18nKey("lichessTournaments")

--- a/modules/simul/src/main/JsonView.scala
+++ b/modules/simul/src/main/JsonView.scala
@@ -86,7 +86,7 @@ final class JsonView(
       },
       "name"       -> simul.name,
       "fullName"   -> simul.fullName,
-      "variants"   -> simul.variants.map(variantJson(chess.Speed(simul.clock.config.some))),
+      "variants"   -> simul.variants.map(variantJson(chess.Speed(simul.clock.participantConfig.some))),
       "isCreated"  -> simul.isCreated,
       "isRunning"  -> simul.isRunning,
       "isFinished" -> simul.isFinished,

--- a/modules/simul/src/main/Simul.scala
+++ b/modules/simul/src/main/Simul.scala
@@ -110,7 +110,7 @@ case class Simul(
   def perfTypes: List[lila.rating.PerfType] =
     variants.flatMap { variant =>
       lila.game.PerfPicker.perfType(
-        speed = Speed(clock.config.some),
+        speed = Speed(clock.participantConfig.some),
         variant = variant,
         daysPerTurn = none
       )
@@ -163,7 +163,7 @@ object Simul {
       hostRating = host.perfs.bestRatingIn {
         variants.flatMap { variant =>
           lila.game.PerfPicker.perfType(
-            speed = Speed(clock.config.some),
+            speed = Speed(clock.participantConfig.some),
             variant = variant,
             daysPerTurn = none
           )

--- a/modules/simul/src/main/SimulApi.scala
+++ b/modules/simul/src/main/SimulApi.scala
@@ -89,7 +89,7 @@ final class SimulApi(
               user,
               variant,
               PerfPicker.mainOrDefault(
-                speed = chess.Speed(simul.clock.config.some),
+                speed = chess.Speed(simul.clock.participantConfig.some),
                 variant = variant,
                 daysPerTurn = none
               )(user.perfs)

--- a/modules/simul/src/main/SimulClock.scala
+++ b/modules/simul/src/main/SimulClock.scala
@@ -1,15 +1,25 @@
 package lila.simul
 
-import chess.{ Centis, Clock, Color }
+import chess.Clock.Config
+import chess.{ Black, Centis, Clock, ClockPlayer, Color, White }
 
 // All durations are expressed in seconds
+
 case class SimulClock(
-    config: Clock.Config,
-    hostExtraTime: Int
+    hostConfig: Clock.Config,
+    participantConfig: Clock.Config
 ) {
 
-  def chessClockOf(hostColor: Color) =
-    config.toClock.giveTime(hostColor, Centis.ofSeconds(hostExtraTime))
+  def chessClockOf(hostColor: Color) = {
 
-  def hostExtraMinutes = hostExtraTime / 60
+    val whitePlayer = ClockPlayer.withConfig(if (hostColor == White) hostConfig else participantConfig)
+    val blackPlayer = ClockPlayer.withConfig(if (hostColor == Black) hostConfig else participantConfig)
+    Clock(
+      config = hostConfig,
+      color = White,
+      players = Color.Map(whitePlayer, blackPlayer),
+      timer = None
+    )
+  }
+  //def hostExtraMinutes = hostExtraTime / 60
 }

--- a/modules/simul/src/main/SimulForm.scala
+++ b/modules/simul/src/main/SimulForm.scala
@@ -21,10 +21,6 @@ object SimulForm {
   val clockIncrementDefault = 60
   val clockIncrementChoices = options(clockIncrements, "%d second{s}")
 
-  val clockExtras       = (0 to 15 by 5) ++ (20 to 60 by 10) ++ (90 to 120 by 30)
-  val clockExtraChoices = options(clockExtras, "%d minute{s}")
-  val clockExtraDefault = 0
-
   val colors = List("white", "random", "black")
   val colorChoices = List(
     "white"  -> "White",
@@ -60,7 +56,8 @@ object SimulForm {
       name = host.titleUsername,
       clockTime = clockTimeDefault,
       clockIncrement = clockIncrementDefault,
-      clockExtra = clockExtraDefault,
+      clockTimeHost = clockTimeDefault,
+      clockIncrementHost = clockIncrementDefault,
       variants = List(chess.variant.Standard.id),
       position = none,
       color = colorDefault,
@@ -72,9 +69,10 @@ object SimulForm {
   def edit(host: User, teams: List[LeaderTeam], simul: Simul) =
     baseForm(host, teams) fill Setup(
       name = simul.name,
-      clockTime = simul.clock.config.limitInMinutes.toInt,
-      clockIncrement = simul.clock.config.increment.roundSeconds,
-      clockExtra = simul.clock.hostExtraMinutes,
+      clockTime = simul.clock.participantConfig.limitInMinutes.toInt,
+      clockIncrement = simul.clock.participantConfig.increment.roundSeconds,
+      clockTimeHost = simul.clock.hostConfig.limitInMinutes.toInt,
+      clockIncrementHost = simul.clock.hostConfig.increment.roundSeconds,
       variants = simul.variants.map(_.id),
       position = simul.position,
       color = simul.color | "random",
@@ -86,10 +84,11 @@ object SimulForm {
   private def baseForm(host: User, teams: List[LeaderTeam]) =
     Form(
       mapping(
-        "name"           -> nameType(host),
-        "clockTime"      -> numberIn(clockTimeChoices),
-        "clockIncrement" -> numberIn(clockIncrementChoices),
-        "clockExtra"     -> numberIn(clockExtraChoices),
+        "name"               -> nameType(host),
+        "clockTime"          -> numberIn(clockTimeChoices),
+        "clockIncrement"     -> numberIn(clockIncrementChoices),
+        "clockTimeHost"      -> numberIn(clockTimeChoices),
+        "clockIncrementHost" -> numberIn(clockIncrementChoices),
         "variants" -> list {
           number.verifying(
             Set(
@@ -125,7 +124,8 @@ object SimulForm {
       name: String,
       clockTime: Int,
       clockIncrement: Int,
-      clockExtra: Int,
+      clockTimeHost: Int,
+      clockIncrementHost: Int,
       variants: List[Int],
       position: Option[FEN],
       color: String,
@@ -135,8 +135,8 @@ object SimulForm {
   ) {
     def clock =
       SimulClock(
-        config = chess.Clock.Config(clockTime * 60, clockIncrement),
-        hostExtraTime = clockExtra * 60
+        participantConfig = chess.Clock.Config(clockTime * 60, clockIncrement),
+        hostConfig = chess.Clock.Config(clockTimeHost * 60, clockIncrementHost)
       )
 
     def actualVariants = variants.flatMap { chess.variant.Variant(_) }

--- a/translation/dest/site/de-DE.xml
+++ b/translation/dest/site/de-DE.xml
@@ -645,6 +645,10 @@
   <string name="simulClockHint">Fischer Bedenkzeit. Je mehr Gegner du hast, desto mehr Zeit wirst du benötigen.</string>
   <string name="simulAddExtraTime">Du kannst dir selbst zusätzliche Zeit hinzufügen, um mit dem Simultan zurechtzukommen.</string>
   <string name="simulHostExtraTime">Extra Bedenkzeit des Ausrichters</string>
+  <string name="simulClockInitialParticipants">Bedenkzeit der Teilnehmenden</string>
+  <string name="simulClockIncrementParticipants">Inkrement der Teilnehmenden</string>
+  <string name="simulClockInitialHost">Bedenkzeit des Ausrichters</string>
+  <string name="simulClockIncrementHost">Inkrement des Ausrichters</string>
   <string name="lichessTournaments">Lichess Turniere</string>
   <string name="tournamentFAQ">Arena FAQ</string>
   <string name="tournamentOfficial">Offiziell</string>

--- a/translation/dest/site/en-US.xml
+++ b/translation/dest/site/en-US.xml
@@ -644,6 +644,10 @@ computer analysis, game chat and shareable URL.</string>
   <string name="whenCreateSimul">When you create a Simul, you get to play several players at once.</string>
   <string name="simulVariantsHint">If you select several variants, each player gets to choose which one to play.</string>
   <string name="simulClockHint">Fischer Clock setup. The more players you take on, the more time you may need.</string>
+  <string name="simulClockInitialParticipants">Clock initial time for participants</string>
+  <string name="simulClockIncrementParticipants">Clock increment for participants</string>
+  <string name="simulClockInitialHost">Clock initial time for host</string>
+  <string name="simulClockIncrementHost">Clock increment for host</string>
   <string name="simulAddExtraTime">You may add extra time to your clock to help cope with the simul.</string>
   <string name="simulHostExtraTime">Host extra clock time</string>
   <string name="lichessTournaments">Lichess tournaments</string>


### PR DESCRIPTION
Adresses #7540 

@ornicar I would like some early feedback, this is my first few lines in Scala, so please forgive an unidiomatic nonsense etc.
* This is especially useful for large Simuls (100+ participants)
* The chess.Clock class already supports different configurations
  for black and white, add consistent serialization for them and make the `BinaryFormat` module deal with the old and new
  format correctly
* Unit tests for the `BinaryFormat` serialization of clocks have been adapted and extended for the new format
* Include the flexible formats in the simul UI
* Translation keys for the new options are there

* TODO: What to do about the missing languages.
