### PR TITLE
server side analysis now using sf 12 nnue

### DIFF
--- a/app/views/plan/features.scala
+++ b/app/views/plan/features.scala
@@ -43,10 +43,10 @@ object features {
               a(href := routes.Page.variantHome())("8 chess variants (Crazyhouse, Chess960, Horde, ...)")
             ),
             tr(custom("30 per day"))(
-              s"Deep $engineName server analysis"
+              "Deep Stockfish 12+ server analysis"
             ),
             tr(unlimited)(
-              s"Instant local $engineName analysis"
+              "Instant local Stockfish 11+ analysis"
             ),
             tr(unlimited)(
               a(href := "https://lichess.org/blog/WN-gLzAAAKlI89Xn/thousands-of-stockfish-analysers")(
@@ -125,7 +125,7 @@ object features {
               a(href := routes.Tournament.home())("Arena tournaments")
             ),
             tr(check)(
-              s"Board editor and analysis board with $engineName"
+              "Board editor and analysis board with Stockfish 11+"
             ),
             tr(unlimited)(
               a(href := routes.Puzzle.home())("Tactics puzzles")
@@ -196,6 +196,4 @@ object features {
   private def tr(value: Frag)(text: Frag*) = st.tr(th(text), all(value))
 
   private val title = "Lichess features"
-
-  private val engineName = "Stockfish 11+"
 }

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -441,7 +441,7 @@ fishnet {
   }
   offline_mode = true # any client can provide moves and analysis
   actor.name = fishnet
-  analysis.nodes = 4000000
+  analysis.nodes = 2250000 # nnue
   move.plies = 300
   client_min_version = "1.15.10"
 }

--- a/ui/analyse/src/serverSideUnderboard.ts
+++ b/ui/analyse/src/serverSideUnderboard.ts
@@ -75,7 +75,7 @@ export default function(element: HTMLElement, ctrl: AnalyseCtrl) {
   }
 
   function chartLoader() {
-    return `<div id="acpl-chart-loader"><span>Stockfish 11+<br>server analysis</span>${lichess.spinnerHtml}</div>`;
+    return `<div id="acpl-chart-loader"><span>Stockfish 12+<br>server analysis</span>${lichess.spinnerHtml}</div>`;
   }
   function startAdvantageChart() {
     if (lichess.advantageChart || lichess.AnalyseNVUI) return;


### PR DESCRIPTION
* Stockfish 11 -> Stockfish 12 for server analysis
* Lower node target for NNUE, based on same time taken on x86-64-sse41-popcnt. Still wins Elo. More efficient on newer hardware. Before this is deployed, fishnet 2 will lie about nodes (factor 1.8x) in order to avoid being flagged as weak.
* Remaining todo: Monitor only NNUE nodes/nps