### PR TITLE
Update bin/diagnostic

### DIFF
--- a/bin/diagnostic
+++ b/bin/diagnostic
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 MONGO_PORT=27017
 REDIS_PORT=6379
@@ -9,7 +9,7 @@ LILA_FISHNET_PORT=9665
 SEPARATOR="\n\n=========================================\n\n"
 
 echo -e "Java version: $(java --version)\n"
-echo -e "SBT  version: $(sbt --version)\n"
+echo -e "SBT  version: $(sbt sbtVersion)\n"
 echo -e "Node version: $(node --version)\n"
 echo -e "Yarn version: $(yarn --version)\n"
 


### PR DESCRIPTION
In [`#!/bin/sh` the echo command]( https://www.unix.com/man-page/posix/1posix/echo/) does not accept any options. It will just print "-e" on the screen. 
With bash there would be no problem and is probably also installed by all contributors. 

sbt is weird. sbt doesn't use the commonly used version option, but an sbt command. 
Maybe checking that sbt is installed with `which sbt` would even be sufficient, as sbt downloads the appropriate version for the project anyway.