### PR TITLE
Move Fishnet key to end of message

### DIFF
--- a/modules/security/src/main/AutomaticEmail.scala
+++ b/modules/security/src/main/AutomaticEmail.scala
@@ -103,14 +103,13 @@ ${Mailgun.txt.serviceNote}
         implicit val lang = userLang(user)
         val body          = s"""Hello,
 
-Here is your private fishnet key:
-
-$key
-
-
-Please treat it like a password. You can use the same key on multiple machines (even at the same time), but you should not share it with anyone.
+This message contains your private fishnet key. Please treat it like a password. You can use the same key on multiple machines (even at the same time), but you should not share it with anyone.
 
 Thank you very much for your help! Thanks to you, chess lovers all around the world will enjoy swift and powerful analysis for their games.
+
+Your key is:
+
+$key
 
 $regards
 """


### PR DESCRIPTION
At the moment, the Fishnet API keys are visible in the inbox message preview (at least on my browser): see [image](https://i.imgur.com/kzhW8cE.png). This seems like a (fairly minor) security issue, because it’s easier for somebody else to see it. The most straightforward way to get around this is probably just to change the message so the key is at the bottom. I’ve done that here.

It probably needs a bit more rewording, because it reads slightly awkwardly now. I was reluctant to adjust it much myself because it’s from ‘The Lichess team’, which I’m not sure I’m entitled to speak on behalf of!