### PR TITLE
simplify monitoring after fishnet 2

### DIFF
--- a/modules/common/src/main/mon.scala
+++ b/modules/common/src/main/mon.scala
@@ -515,8 +515,6 @@ object mon {
       }
       def status(enabled: Boolean) = gauge("fishnet.client.status").withTag("enabled", enabled)
       def version(v: String)       = gauge("fishnet.client.version").withTag("version", v)
-      def stockfish(v: String)     = gauge("fishnet.client.engine.stockfish").withTag("version", v)
-      def python(v: String)        = gauge("fishnet.client.python").withTag("version", v)
     }
     def queueTime(sender: String)     = timer("fishnet.queue.db").withTag("sender", sender)
     val acquire                       = future("fishnet.acquire")
@@ -524,8 +522,6 @@ object mon {
     def oldest(as: String)            = gauge("fishnet.oldest").withTag("for", as)
     object analysis {
       object by {
-        def hash(client: String)     = gauge("fishnet.analysis.hash").withTag("client", client)
-        def threads(client: String)  = gauge("fishnet.analysis.threads").withTag("client", client)
         def movetime(client: String) = histogram("fishnet.analysis.movetime").withTag("client", client)
         def node(client: String)     = histogram("fishnet.analysis.node").withTag("client", client)
         def nps(client: String)      = histogram("fishnet.analysis.nps").withTag("client", client)

--- a/modules/fishnet/src/main/BSONHandlers.scala
+++ b/modules/fishnet/src/main/BSONHandlers.scala
@@ -17,10 +17,6 @@ private object BSONHandlers {
     x => BSONString(x.key)
   )
 
-  import Client.{ Engine, Engines }
-  implicit val EngineBSONHandler  = Macros.handler[Engine]
-  implicit val EnginesBSONHandler = Macros.handler[Engines]
-
   import Client.Instance
   implicit val InstanceBSONHandler = Macros.handler[Instance]
 

--- a/modules/fishnet/src/main/Client.scala
+++ b/modules/fishnet/src/main/Client.scala
@@ -49,19 +49,15 @@ object Client {
   case class Version(value: String) extends AnyVal with StringValue
   case class Python(value: String)  extends AnyVal with StringValue
   case class UserId(value: String)  extends AnyVal with StringValue
-  case class Engine(name: String)
-  case class Engines(stockfish: Engine)
 
   case class Instance(
       version: Version,
-      engines: Engines,
       ip: IpAddress,
       seenAt: DateTime
   ) {
 
     def update(i: Instance): Option[Instance] =
       if (i.version != version) i.some
-      else if (i.engines != engines) i.some
       else if (i.ip != ip) i.some
       else if (i.seenAt isAfter seenAt.plusMinutes(5)) i.some
       else none

--- a/modules/fishnet/src/main/Monitor.scala
+++ b/modules/fishnet/src/main/Monitor.scala
@@ -31,13 +31,9 @@ final private class Monitor(
   ) = {
     Monitor.success(work, client)
 
-    val threads = result.stockfish.options.threadsInt
-    val userId  = client.userId.value
+    val userId = client.userId.value
 
-    result.stockfish.options.hashInt foreach { monBy.hash(userId).update(_) }
-    result.stockfish.options.threadsInt foreach { monBy.threads(userId).update(_) }
-
-    monBy.totalSecond(userId).increment(sumOf(result.evaluations)(_.time) * threads.|(1) / 1000)
+    monBy.totalSecond(userId).increment(sumOf(result.evaluations)(_.time) / 1000)
 
     if (result.stockfish.isNnue)
       monBy
@@ -84,9 +80,6 @@ final private class Monitor(
 
       instances.groupMapReduce(_.version.value)(_ => 1)(_ + _) foreach { case (v, nb) =>
         version(v).update(nb)
-      }
-      instances.groupMapReduce(_.engines.stockfish.name)(_ => 1)(_ + _) foreach { case (s, nb) =>
-        stockfish(s).update(nb)
       }
     }
 


### PR DESCRIPTION
some monitoring is obsolete with fishnet 2:
* python version (ce5de77d90c0f1ff03beb324d74b1ed3899e1f6f)
* engine version (implied by fishnet version)
* hash (not configurable, implied by fishnet version)
* threads (always 1)