### PR TITLE
remove captcha on team join request

### DIFF
--- a/app/controllers/Team.scala
+++ b/app/controllers/Team.scala
@@ -308,7 +308,7 @@ final class Team(
   def requestForm(id: String) =
     Auth { implicit ctx => me =>
       OptionFuOk(api.requestable(id, me)) { team =>
-        forms.anyCaptcha map { html.team.request.requestForm(team, forms.request, _) }
+        fuccess(html.team.request.requestForm(team, forms.request))
       }
     }
 
@@ -319,10 +319,7 @@ final class Team(
         forms.request
           .bindFromRequest()
           .fold(
-            err =>
-              forms.anyCaptcha map { captcha =>
-                BadRequest(html.team.request.requestForm(team, err, captcha))
-              },
+            err => BadRequest(html.team.request.requestForm(team, err)).fuccess,
             setup =>
               api.createRequest(team, me, setup.message) inject Redirect(
                 routes.Team.show(team.id)

--- a/app/views/team/request.scala
+++ b/app/views/team/request.scala
@@ -13,14 +13,13 @@ object request {
 
   import trans.team._
 
-  def requestForm(t: lila.team.Team, form: Form[_], captcha: lila.common.Captcha)(implicit ctx: Context) = {
+  def requestForm(t: lila.team.Team, form: Form[_])(implicit ctx: Context) = {
 
     val title = s"${joinTeam.txt()} ${t.name}"
 
     views.html.base.layout(
       title = title,
-      moreCss = cssTag("team"),
-      moreJs = captchaTag
+      moreCss = cssTag("team")
     ) {
       main(cls := "page-menu page-small")(
         bits.menu("requests".some),
@@ -30,7 +29,6 @@ object request {
           postForm(cls := "form3", action := routes.Team.requestCreate(t.id))(
             form3.group(form("message"), trans.message())(form3.textarea(_)()),
             p(willBeReviewed()),
-            views.html.base.captcha(form, captcha),
             form3.actions(
               a(href := routes.Team.show(t.slug))(trans.cancel()),
               form3.submit(joinTeam())

--- a/modules/team/src/main/TeamForm.scala
+++ b/modules/team/src/main/TeamForm.scala
@@ -54,15 +54,10 @@ final private[team] class TeamForm(
 
   val request = Form(
     mapping(
-      "message" -> clean(text(minLength = 30, maxLength = 2000)),
-      Fields.gameId,
-      Fields.move
+      "message" -> clean(text(minLength = 30, maxLength = 2000))
     )(RequestSetup.apply)(RequestSetup.unapply)
-      .verifying(captchaFailMessage, validateCaptcha _)
   ) fill RequestSetup(
-    message = "Hello, I would like to join the team!",
-    gameId = "",
-    move = ""
+    message = "Hello, I would like to join the team!"
   )
 
   val apiRequest = Form(single("message" -> optional(clean(text(minLength = 30, maxLength = 2000)))))
@@ -132,7 +127,5 @@ private[team] case class TeamEdit(
 }
 
 private[team] case class RequestSetup(
-    message: String,
-    gameId: String,
-    move: String
+    message: String
 )


### PR DESCRIPTION
Hi,

Note about this PR for issue #7706 

I'm not 100% sure how the bindrequest error should be handled (although I think it should never be called for the time being)

`err => BadRequest(html.team.request.requestForm(team, err)).fuccess`

I'm having a look issue #7524 where handling this error will be necessary