### PR TITLE
remember ceval state in session storage

### DIFF
--- a/ui/ceval/src/main.ts
+++ b/ui/ceval/src/main.ts
@@ -9,7 +9,7 @@ export { ctrl, view, winningChances };
 // stop when another tab starts. Listen only once here,
 // as the ctrl can be instantiated several times.
 // gotta do the click on the toggle to have it visually change.
-lichess.storage.make('ceval.disable').listen(_ => {
+lichess.storage.make('ceval.disable').listen(() => {
   const toggle = document.getElementById('analyse-toggle-ceval') as HTMLInputElement | undefined;
   if (toggle?.checked) toggle.click();
 });

--- a/ui/ceval/src/pool.ts
+++ b/ui/ceval/src/pool.ts
@@ -144,7 +144,6 @@ export class Pool {
   }
 
   start(work: Work): void {
-    lichess.storage.fire('ceval.disable'); // disable on all other tabs
     this.getWorker().then(function(worker) {
       worker.start(work);
     }).catch(function(error) {

--- a/ui/round/src/cevalSub.ts
+++ b/ui/round/src/cevalSub.ts
@@ -17,9 +17,9 @@ export function subscribe(ctrl: RoundController): void {
   // bots can cheat alright
   if (ctrl.data.player.user && ctrl.data.player.user.title === 'BOT') return;
 
-  // Disable ceval. Unless this game is loaded directly on a position being
-  // analysed, there is plenty of time (7 moves, in most cases) for this to
-  // take effect.
+  // Notify tabs to disable ceval. Unless this game is loaded directly on a
+  // position being analysed, there is plenty of time (7 moves, in most cases)
+  // for this to take effect.
   lichess.storage.fire('ceval.disable');
 
   lichess.storage.make('ceval.fen').listen(e => {


### PR DESCRIPTION
off by default via c7bb57a621043bbc5bc75bae0ed06bacce11541a (fixing #5528), but a small paper cut remains, especially because actions on the same page can cause ceval to be reinstanciated.

the idea is to have a shared local storage `ceval.disable` that gets set to a random value if ceval is automatically disabled.

then each tab has a local storage `ceval.enabled-after`, that stores an acknowlegement of the previous disable. it is set only if the user explicitly toggles analysis on.

when (re)opening analysis or reinstanciating ceval, analysis is only enabled if the latest disable has been acknowledged. to avoid a mostly theoretical race condition in self-reporting, self reports are only emitted if the current disable has been acknowleged.