### PR TITLE
Add slight gradient to capture indicators

### DIFF
--- a/ui/common/css/vendor/chessground/_chessground.scss
+++ b/ui/common/css/vendor/chessground/_chessground.scss
@@ -32,11 +32,11 @@ square {
   }
 
   &.oc.move-dest {
-    background: radial-gradient(transparent 0%, transparent 80%, rgba(20, 85, 0, 0.3) 80%);
+    background: radial-gradient(transparent 0%, transparent 79%, rgba(20, 85, 0, 0.3) 80%);
   }
 
   &.oc.premove-dest {
-    background: radial-gradient(transparent 0%, transparent 80%, rgba(20, 30, 85, 0.2) 80%);
+    background: radial-gradient(transparent 0%, transparent 79%, rgba(20, 30, 85, 0.2) 80%);
   }
 
   body.green &.last-move,


### PR DESCRIPTION
The move spots currently have a difference of 1% (between 19 and 20) across their gradient, which smooths them a little bit. This PR adds the same to the capture marks. See [before](https://i.imgur.com/2Vuf4Wc.png) vs [after](https://i.imgur.com/bOrXVD3.png).