### PR TITLE
Include player POV ID for owner analysis

### DIFF
--- a/modules/round/src/main/JsonView.scala
+++ b/modules/round/src/main/JsonView.scala
@@ -167,7 +167,8 @@ final class JsonView(
             "player" -> {
               commonWatcherJson(game, player, playerUser, withFlags) ++ Json.obj(
                 "version"   -> socket.version.value,
-                "spectator" -> true
+                "spectator" -> true,
+                "id" -> me.flatMap(game.player).map(_.id)
               )
             }.add("onGame" -> (player.isAi || socket.onGame(player.color))),
             "opponent" -> commonWatcherJson(game, opponent, opponentUser, withFlags).add(


### PR DESCRIPTION
Another tweak to unblock https://github.com/veloce/lichobile/issues/374 : the mobile client needs to know the POV player ID, not just the user ID, in order to construct the URL to save forecasts.