### PR TITLE
fix normalized emails in database (fixes #7848)

### DIFF
--- a/bin/mongodb/fix-normalized-emails.js
+++ b/bin/mongodb/fix-normalized-emails.js
@@ -1,0 +1,20 @@
+function gmailNormalize(email) {
+  let [name, domain] = email.toLowerCase().split('@');
+  [name, ] = name.replace('.', '').split('+');
+  return name + '@' + domain;
+}
+
+db.user4.find({email: {$regex:/.*[+.].*@(protonmail\.com|protonmail\.ch|pm\.me|gmail\.com|googlemail\.com)$/}}).forEach(user => {
+  const normalized = gmailNormalize(user.email);
+  const verbatim = user.verbatimEmail || user.email;
+  print(verbatim, '->', normalized);
+
+  db.user4.update({
+    _id: user._id
+  }, {
+    $set: {
+      email: normalized,
+      verbatimEmail: verbatim
+    }
+  });
+});

--- a/modules/common/src/main/model.scala
+++ b/modules/common/src/main/model.scala
@@ -44,8 +44,10 @@ case class EmailAddress(value: String) extends AnyVal with StringValue {
       case Array(user, domain) => s"${user take 3}*****@$domain"
       case _                   => value
     }
+
   def normalize =
     NormalizedEmailAddress {
+      // changing normalization requires database migration!
       val lower = value.toLowerCase
       lower.split('@') match {
         case Array(name, domain) if EmailAddress.gmailLikeNormalizedDomains(domain) =>
@@ -56,6 +58,7 @@ case class EmailAddress(value: String) extends AnyVal with StringValue {
         case _ => lower
       }
     }
+
   def domain: Option[Domain] =
     value split '@' match {
       case Array(_, domain) => Domain from domain.toLowerCase
@@ -76,6 +79,7 @@ object EmailAddress {
   private val regex =
     """^[a-zA-Z0-9\.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$""".r
 
+  // adding normalized domains requires database migration!
   private val gmailLikeNormalizedDomains =
     Set("gmail.com", "googlemail.com", "protonmail.com", "protonmail.ch", "pm.me")
 


### PR DESCRIPTION
Getting users by email assumes that the email is stored normalized, but it isn't, for some users. Maybe we just forgot to run a database migration at the time.

The regex query matches 4409 users in prod, as of now. If this number grows, there is a bug somewhere. The normalization function is tested. The update part of the query is **not** tested. Please review and run :)