### PR TITLE
bump fishnet min version to 2.1.3

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -428,7 +428,7 @@ fishnet {
   actor.name = fishnet
   analysis.nodes = 2250000 # nnue
   move.plies = 300
-  client_min_version = "1.15.10"
+  client_min_version = "2.1.3"
 }
 insight {
   mongodb {


### PR DESCRIPTION
2.1.3 is the oldest 2.x release that does not have the variant analysis bug
(https://github.com/niklasf/fishnet/issues/147).

I also wrote emails to the last remaining contributors on 1.x.