### PR TITLE
Modify lila.common.form error message

### DIFF
--- a/modules/common/src/main/Form.scala
+++ b/modules/common/src/main/Form.scala
@@ -68,7 +68,7 @@ object Form {
       Constraints maxLength maxLength,
       Constraints.pattern(
         regex = """[\p{L}\p{N}-\s:.,;'\+]+""".r,
-        error = "Invalid characters contained; only letters, numbers and the following characters are supported: ":", ",", "+", "'", ".", ";" "
+        error = "Invalid characters contained; only letters, numbers and the following characters are supported: ':', ',', '+', ''', '.', ';' "
       )
     )
 

--- a/modules/common/src/main/Form.scala
+++ b/modules/common/src/main/Form.scala
@@ -68,7 +68,7 @@ object Form {
       Constraints maxLength maxLength,
       Constraints.pattern(
         regex = """[\p{L}\p{N}-\s:.,;'\+]+""".r,
-        error = "Invalid characters"
+        error = "Invalid characters contained; only letters, numbers and the following characters are supported: ":", ",", "+", "'", ".", ";" "
       )
     )
 


### PR DESCRIPTION
The "invalid characters" error message is sometimes confusing for the users, and sometimes people have trouble finding out which of all characters contained is invalid. This message (or an improved version of it) would be more clear and user-friendly.