### PR TITLE
Removing the illusion that the range selector does not reach the max selection

### DIFF
--- a/ui/analyse/css/_action-menu.scss
+++ b/ui/analyse/css/_action-menu.scss
@@ -105,7 +105,7 @@
 
     input[type=range] {
       flex: 1 4 auto;
-      padding: 0 1em;
+      padding: 0 0 0 1em;
       height: 1.6em;
       width: 100%;
     }


### PR DESCRIPTION
Changed the padding from the local analysis range input selectors so that it stops giving the illusion that you can select more than it's allowed.

Before
![image](https://user-images.githubusercontent.com/27678178/104122903-c2223980-533f-11eb-83d9-39906b5baa16.png)

After
![image](https://user-images.githubusercontent.com/27678178/104122912-d23a1900-533f-11eb-8ba1-da3f44a76369.png)

This change makes the selectors feel right to me. I don't know if it's intentional that they have padding on the right side. Feel free to decline if reasonable.