### PR TITLE
Adds hourly rotating 960/3+ and horde/rk tournaments.

### DIFF
--- a/modules/tournament/src/main/TournamentScheduler.scala
+++ b/modules/tournament/src/main/TournamentScheduler.scala
@@ -424,7 +424,7 @@ Thank you all, you rock!"""
           }
         ).flatten
       },
-      // hourly variant tournaments!
+      // hourly atomic/antichess variant tournaments!
       (0 to 6).toList.flatMap { hourDelta =>
         val date = rightNow plusHours hourDelta
         val hour = date.getHourOfDay
@@ -435,6 +435,47 @@ Thank you all, you rock!"""
           case _     => Blitz
         }
         val variant = if (hour % 2 == 0) Atomic else Antichess
+        List(
+          at(date, hour) map { date =>
+            Schedule(Hourly, speed, variant, none, date).plan
+          },
+          at(date, hour, 30) collect {
+            case date if speed == Bullet =>
+              Schedule(Hourly, if (hour == 18) HyperBullet else Bullet, variant, none, date).plan
+          }
+        ).flatten
+      },
+      // hourly chess960/three check variant tournaments!
+      (0 to 6).toList.flatMap { hourDelta =>
+        val date = rightNow plusHours hourDelta
+        val hour = date.getHourOfDay
+        val speed = hour % 6 match {
+          case 1 | 4 => Bullet
+          case 2 | 5 => SuperBlitz
+          case 3 |_  => Blitz
+        }
+        val variant = if (hour % 2 == 0) Chess960 else ThreeCheck
+        List(
+          at(date, hour) map { date =>
+            Schedule(Hourly, speed, variant, none, date).plan
+          },
+          at(date, hour, 30) collect {
+            case date if speed == Bullet =>
+              Schedule(Hourly, if (hour == 18) HyperBullet else Bullet, variant, none, date).plan
+          }
+        ).flatten
+      },
+      // hourly horde/racing kings variant tournaments!
+      (0 to 6).toList.flatMap { hourDelta =>
+        val date = rightNow plusHours hourDelta
+        val hour = date.getHourOfDay
+        val speed = hour % 6 match {
+          case 1 | 4 => Bullet
+          case 2 | 5 => SuperBlitz
+          case 3     => HippoBullet
+          case _     => Blitz
+        }
+        val variant = if (hour % 2 == 0) Horde else RacingKings
         List(
           at(date, hour) map { date =>
             Schedule(Hourly, speed, variant, none, date).plan


### PR DESCRIPTION
These variants now have the popularity that crazyhouse, atomic, and antichess had when they got hourly tournaments. This uses a 1+0/3+0/5+0 time control rotation for all variants except racing kings, which has a 1+0/2+0/3+0 rotation as RoyalManiac, the racing kings world champion, suggested that 5+0 is a bit long for racing kings as there aren't as many pieces, and that racing kings players would prefer 2+0 to 5+0. This closes #7884.