### PR TITLE
Add a footer to the homepage layout containing a logout button

### DIFF
--- a/app/views/base/layout.scala
+++ b/app/views/base/layout.scala
@@ -282,7 +282,8 @@ object layout {
           ),
           a(id := "reconnecting", cls := "link text", dataIcon := "B")(trans.reconnecting()),
           loadScripts(moreJs, chessground)
-        )
+        ),
+        siteFooter()
       )
     )
 
@@ -345,6 +346,16 @@ object layout {
           ctx.me map { me =>
             frag(allNotifications, dasher(me))
           } getOrElse { !ctx.pageData.error option anonDasher(playing) }
+        )
+      )
+  }
+
+  object siteFooter {
+
+    def apply()(implicit ctx: Context) =
+      footer(id := "bottom")(
+        ctx.isAuth option form(action := routes.Auth.logout(), method := "post")(
+            button(cls := "button button-red", tpe := "submit")(trans.logOut.txt())
         )
       )
   }


### PR DESCRIPTION
Reference implementation that places a logout button in the footer of the `layout` template.  This might not be an ideal placement; I'd be happy to move this around, or an alternate approach might be preferable.

Aims to resolve #7899 