### PR TITLE
hide broken tos wording in lichobile, tweak class name

### DIFF
--- a/app/templating/GameHelper.scala
+++ b/app/templating/GameHelper.scala
@@ -155,7 +155,7 @@ trait GameHelper { self: I18nHelper with UserHelper with AiHelper with StringHel
               frag(" ", showRatingDiff(d))
             },
             engine option span(
-              cls := "engine_mark",
+              cls := "tos_violation",
               title := trans.thisAccountViolatedTos.txt()
             )
           ),

--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -194,12 +194,12 @@ object header {
             div(cls := "profile-side")(
               div(cls := "user-infos")(
                 !ctx.is(u) option frag(
-                  u.marks.engine option div(cls := "warning engine_warning")(
+                  u.marks.engine option div(cls := "warning tos_warning")(
                     span(dataIcon := "j", cls := "is4"),
                     trans.thisAccountViolatedTos()
                   ),
                   (u.marks.boost && (u.count.game > 0 || isGranted(_.Hunter))) option div(
-                    cls := "warning engine_warning"
+                    cls := "warning tos_warning"
                   )(
                     span(dataIcon := "j", cls := "is4"),
                     trans.thisPlayerArtificiallyIncreasesTheirRating(),

--- a/modules/user/src/main/JsonView.scala
+++ b/modules/user/src/main/JsonView.scala
@@ -22,7 +22,7 @@ final class JsonView(isOnline: lila.socket.IsOnline) {
         "createdAt" -> u.createdAt
       )
       .add("disabled" -> u.disabled)
-      .add("engine" -> u.marks.engine)
+      .add("tosViolation" -> u.marks.engine)
       .add("booster" -> u.marks.boost)
       .add("profile" -> u.profile.map(p => profileWrites.writes(p).noNull))
       .add("seenAt" -> u.seenAt)
@@ -41,7 +41,7 @@ final class JsonView(isOnline: lila.socket.IsOnline) {
       )
       .add("title" -> u.title)
       .add("disabled" -> u.disabled)
-      .add("engine" -> u.marks.engine)
+      .add("tosViolation" -> u.marks.engine)
       .add("booster" -> u.marks.boost)
       .add("language" -> u.lang)
       .add("profile" -> u.profile.flatMap(_.country).map { country =>

--- a/ui/site/css/user/_profile.scss
+++ b/ui/site/css/user/_profile.scss
@@ -17,7 +17,7 @@
     }
   }
 
-  .engine_warning {
+  .tos_warning {
     margin: 10px 0;
   }
 


### PR DESCRIPTION
not displaying any mark may be better than displaying the wrong wording. after this, fixed wording and the renaming should land in a future lichobile version