### PR TITLE
stop supporting safari 10

### DIFF
--- a/bin/gen/timeago-to-scala.py
+++ b/bin/gen/timeago-to-scala.py
@@ -71,7 +71,7 @@ def main(args):
 
 
 def terser(js):
-    p = subprocess.Popen(["yarn", "run", "--silent", "terser", "--mangle", "--compress", "--safari10"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=sys.stderr)
+    p = subprocess.Popen(["yarn", "run", "--silent", "terser", "--mangle", "--compress"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=sys.stderr)
     stdout, stderr = p.communicate(js.encode("utf-8"))
     if p.returncode != 0:
         sys.exit(p.returncode)

--- a/ui/@build/rollupProject/index.js
+++ b/ui/@build/rollupProject/index.js
@@ -16,7 +16,6 @@ exports.rollupProject = (targets) => {
           name: target.name,
           plugins: [
             terser({
-              safari10: true,
               output: {
                 comments: false,
               },

--- a/ui/analyse/css/_tools.scss
+++ b/ui/analyse/css/_tools.scss
@@ -4,9 +4,6 @@
 
     max-height: 100vh;
 
-    /* magically fixes fit-content on safari 10 */
-    background: $c-bg-box;
-
     .ceval {
       flex: 0 0 38px;
     }

--- a/ui/puzzle/css/_tools.scss
+++ b/ui/puzzle/css/_tools.scss
@@ -3,9 +3,6 @@
 
   max-height: 90vh;
 
-  /* hack to mitigate safari 10 disaster */
-  background: $c-bg-box;
-
   .ceval-wrap {
     flex: 0 0 38px;
   }

--- a/ui/tsconfig.base.json
+++ b/ui/tsconfig.base.json
@@ -8,7 +8,7 @@
     "noImplicitThis": true,
     "noUnusedParameters": true,
     "moduleResolution": "node",
-    "target": "ES2016",
+    "target": "ES2017",
     "module": "commonjs",
     "lib": ["DOM", "ES2017", "DOM.iterable"],
     "types": ["lichess", "cash"]


### PR DESCRIPTION
Safari 10 appears to be the only browser preventing us from targeting ES2017 (matching recently bumped lib ES2017), and it's not supported anyway according to our list (https://github.com/ornicar/lila#supported-browsers).