### PR TITLE
Fix ceval 'go deeper' button analyzing a different position than the currently viewed one

### DIFF
--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -163,7 +163,14 @@ export default function(opts: CevalOpts): CevalCtrl {
     const step = steps[steps.length - 1];
 
     const existing = threatMode ? step.threat : step.ceval;
-    if (existing && existing.depth >= maxD) return;
+    if (existing && existing.depth >= maxD) {
+      lastStarted = {
+        path,
+        steps,
+        threatMode
+      };
+      return;
+    }
 
     const work: Work = {
       initialFen: steps[0].fen,


### PR DESCRIPTION
Hi,
I found this small issue while playing on lichess.org, and being a software developer myself, I decided to dig into the code and try to offer a fix.

The thing is, I found the "go deeper" button on the analysis board page sometimes starting analysis on some other previously viewed position of the game instead of the current one. Specifically that occurs when the analysis of a position (calling it p1) was already finished, then one selects a position where analysis still needs to run (p2), and then going back to p1 and clicking "go deeper" there. Then it analyzes p2 instead of p1.

I think this happens because the goDeeper routine in CevalCtrl uses the stored position "lastStarted", but that variable is not updated to reflect selection of a different position when there is no need to start the analysis on that position.

So with this change, I added updating the lastStarted variable in the case when the start function returns early because analysis was already finished.
I could verify locally that this change fixes the issue. However, since I have only looked in that particular place and I have no experience with the whole system, I may have overlooked some consequences. Please feel free to point me in the right direction in that case.