### PR TITLE
Fix board flip in interactive study

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -275,7 +275,9 @@ export default class AnalyseCtrl {
       color = this.turnColor(),
       dests = chessUtil.readDests(this.node.dests),
       drops = chessUtil.readDrops(this.node.drops),
-      movableColor = (this.practice || this.gamebookPlay()) ? this.bottomColor() : (
+      movableColor =
+        this.gamebookPlay() ? color :
+        this.practice ? this.bottomColor() : (
         !this.embed && (
           (dests && dests.size > 0) ||
           drops === null || drops.length


### PR DESCRIPTION
This fixes https://github.com/ornicar/lila/issues/8098

My analysis of this issue is that when the user is in interactive study mode (aka. `gamebookPlay`), chessground's `movable` configuration is always fixed to `bottomColor`, which becomes opposite of `turnColor` when board is flipped.
In this PR, I changed it so that it always choose `turnColor` to be the `movable`.

So far, I only manually tested some small example locally and it seems to be working as I expected,
but, of course, I might be missing some other cases (for example, I really haven't followed what `embed`, `dests`, etc.. does, or what happens when in chess variant), so I greatly appreciate code review. Thanks a lot!