### PR TITLE
fix spotlight icons shadow

### DIFF
--- a/ui/lobby/css/_spotlight.scss
+++ b/ui/lobby/css/_spotlight.scss
@@ -43,6 +43,12 @@
     }
   }
 
+  img.img.icon {
+    @if $theme-light {
+      filter: drop-shadow(1px 1px 1px $c-link);
+    }
+  }
+
   .name {
     margin-top: 1px;
     line-height: 13px;


### PR DESCRIPTION
Some icons in the lobby spotlight have a blue shadow, some don't. This fixes the inconsistency. 
![spotlight-shadow](https://user-images.githubusercontent.com/23665894/107126487-90ee4800-68b0-11eb-9e5f-fcd5481afe82.png)
