### PR TITLE
update gitignore to ignore bloop build files, metals build files, and vscode files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .sbtopts
 .bsp
+.bloop/
+.metals/
+project/.bloop/
 conf/application.conf
 conf/version.conf
 
@@ -38,3 +41,6 @@ RUNNING_PID
 /modules/*/.classpath
 /modules/*/.project
 /modules/*/.settings/
+
+# VSCode auto-generated files
+.vscode/


### PR DESCRIPTION
After a clean install of lila, and setting up the bloop server, I was left with these changes already
![20210211_18h47m13s_grim](https://user-images.githubusercontent.com/1687121/107616350-9aedbd80-6c99-11eb-9e83-721f0d437737.png)
and I hadn't even contributed anything yet. I believe these files should be added to the .gitignore as to avoid pushing them to git.