### PR TITLE
Ceval with Stockfish NNUE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ public/vendor/highcharts-4.2.5
 public/vendor/hopscotch
 public/vendor/tagify
 public/vendor/stockfish.wasm
+public/vendor/stockfish-nnue.wasm
 public/vendor/stockfish-mv.wasm
 public/vendor/stockfish.js
 public/css/

--- a/ui/ceval/src/pool.ts
+++ b/ui/ceval/src/pool.ts
@@ -131,9 +131,11 @@ export class Pool {
   warmup(): void {
     if (this.workers.length) return;
 
-    if (this.poolOpts.technology == 'wasmx')
+    if (this.poolOpts.technology == 'nnue') {
+      this.workers.push(new ThreadedWasmWorker(this.poolOpts.nnue, this.poolOpts, this.protocolOpts));
+    } else if (this.poolOpts.technology == 'wasmx') {
       this.workers.push(new ThreadedWasmWorker(this.poolOpts.wasmx, this.poolOpts, this.protocolOpts));
-    else {
+    } else {
       for (let i = 1; i <= 2; i++)
         this.workers.push(
           new WebWorker(

--- a/ui/ceval/src/types.ts
+++ b/ui/ceval/src/types.ts
@@ -2,7 +2,7 @@ import { Outcome } from 'chessops/types';
 import { Prop } from 'common';
 import { StoredProp, StoredBooleanProp } from 'common/storage';
 
-export type CevalTechnology = 'asmjs' | 'wasm' | 'wasmx';
+export type CevalTechnology = 'asmjs' | 'wasm' | 'wasmx' | 'nnue';
 
 export interface Eval {
   cp?: number;
@@ -33,6 +33,7 @@ export interface PoolOpts {
   wasm: string;
   wasmx: string;
   asmjs: string;
+  nnue: string;
 }
 
 export interface CevalOpts {

--- a/ui/ceval/src/view.ts
+++ b/ui/ceval/src/view.ts
@@ -77,9 +77,11 @@ function engineName(ctrl: CevalCtrl): VNode[] {
     h(
       'span',
       version ? { attrs: { title: `${version} (classical eval)` } } : {},
-      ctrl.technology == 'wasmx' ? 'Stockfish 12+' : 'Stockfish 10+'
+      ctrl.technology == 'wasmx' || ctrl.technology == 'nnue' ? 'Stockfish 12+' : 'Stockfish 10+'
     ),
-    ctrl.technology == 'wasmx'
+    ctrl.technology == 'nnue'
+      ? h('span.wasmx', { attrs: { title: 'Multi-threaded WebAssembly NNUE (strongest)' } }, 'nnue')
+      : ctrl.technology == 'wasmx'
       ? h('span.wasmx', { attrs: { title: 'Multi-threaded WebAssembly (fastest)' } }, 'wasmx')
       : ctrl.technology == 'wasm'
       ? h('span.wasm', { attrs: { title: 'Single-threaded WebAssembly fallback (second fastest)' } }, 'wasm')

--- a/ui/site/package.json
+++ b/ui/site/package.json
@@ -21,6 +21,7 @@
     "hopscotch": "^0.3.1",
     "jquery-bar-rating": "^1.2.2",
     "stockfish-mv.wasm": "^0.5.2",
+    "stockfish-nnue.wasm": "0.0.1",
     "stockfish.js": "^10.0.2",
     "stockfish.wasm": "^0.9.1",
     "tablesort": "^5.1",

--- a/ui/site/rollup.config.js
+++ b/ui/site/rollup.config.js
@@ -61,6 +61,15 @@ export default rollupProject({
             ].map(require.resolve),
             dest: '../../public/vendor/stockfish-mv.wasm',
           },
+          // stockfish-nnue.wasm
+          {
+            src: [
+              'stockfish-nnue.wasm/stockfish.js',
+              'stockfish-nnue.wasm/stockfish.wasm',
+              'stockfish-nnue.wasm/stockfish.worker.js',
+            ].map(require.resolve),
+            dest: '../../public/vendor/stockfish-nnue.wasm',
+          },
         ],
       }),
       replace({

--- a/yarn.lock
+++ b/yarn.lock
@@ -4137,6 +4137,11 @@ stockfish-mv.wasm@^0.5.2:
   resolved "https://registry.yarnpkg.com/stockfish-mv.wasm/-/stockfish-mv.wasm-0.5.2.tgz#08faca73ae2f5b69fb28bd04c20074e443cdaa7e"
   integrity sha512-MujfrAVAzDkRoVEiYMkGaiAw9wei2hRR8sxD5l7emHDyCbmc0KdlqoIZtS+coQ9CVNaZa1o5JokTKJVv8wJhUQ==
 
+stockfish-nnue.wasm@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/stockfish-nnue.wasm/-/stockfish-nnue.wasm-0.0.1.tgz#945a9904c5a1152bab98b9fdde7c517b1342e83f"
+  integrity sha512-ePulPKbGimjJEtTUYECh4986JnZv1rYVDsSlBOXu+1tvjWKjJSzoHhKpmtdGDG59iVtIBRamix593rfYqMqK2Q==
+
 stockfish.js@^10.0.2:
   version "10.0.2"
   resolved "https://registry.yarnpkg.com/stockfish.js/-/stockfish.js-10.0.2.tgz#c8206aa3b0290171ace52b463a74112ea1f83989"


### PR DESCRIPTION
EDIT:
As par the discussion at https://github.com/niklasf/stockfish.wasm/pull/30#issuecomment-782651525, now `stockfish-nnue.wasm` points to an npm package from this repository https://github.com/hi-ogawa/Stockfish.

Hi guys.
I've made an experimental integration of Stockfish NNUE.
On niklasf's stockfish.wasm repo, there is a corresponding on-going PR https://github.com/niklasf/stockfish.wasm/pull/30, but I thought I would integrate it into lichess for easier testing.
For now, npm package `stockfish-nnue.wasm` directly points to my fork https://github.com/hi-ogawa/stockfish.wasm/tree/nnue-wasm-simd--publish (EDIT: now it changed to https://github.com/hi-ogawa/stockfish.wasm/tree/demo) where I just pushed build artifacts directly.
Since WASM SIMD feature itself is not stable stage, I would appreciate any feedback. Thanks!

EDIT:

These are conditions I tested so far:

- Chromium 88.0.4324.150 (V8 8.8.278.15) with `chrome://flags/#enable-webassembly-simd` enabled
- Firefox 85.0.1 with `javascript.options.wasm_simd` enabled under `about:config` page

and also I use Archlinux if that matters.
