### PR TITLE
Include full game id in notification

### DIFF
--- a/modules/round/src/main/RoundNotifier.scala
+++ b/modules/round/src/main/RoundNotifier.scala
@@ -30,7 +30,7 @@ final private class RoundNotifier(
             Notification.make(
               Notification.Notifies(userId),
               GameEnd(
-                GameEnd.GameId(game.id),
+                GameEnd.GameId(game fullIdOf color),
                 game.opponent(color).userId map GameEnd.OpponentId.apply,
                 game.wonBy(color) map GameEnd.Win.apply
               )


### PR DESCRIPTION
When a correspondence game I play in ends (for example my opponent checkmates me),
and I am not present at the game (I have some other page open),
a notification is sent to me.

The game id is a short id,
so when clicking on the notification - I'm directed to a "spectator" view of the game.

This commit updates the notification from short game id to full game id.
Clicking the link will now go to "first person" view of the game,
so I can say "Thanks for the game" in the chat, for instance.