### PR TITLE
iOS contextual menu fix

### DIFF
--- a/ui/analyse/src/util.ts
+++ b/ui/analyse/src/util.ts
@@ -6,6 +6,12 @@ import { fixCrazySan } from 'chess';
 
 export const emptyRedButton = 'button.button.button-red.button-empty';
 
+const longPressDuration = 610; // used in bindMobileTapHold
+
+export function clearSelection() {
+  window.getSelection()?.removeAllRanges();
+}
+
 export function plyColor(ply: number): Color {
   return ply % 2 === 0 ? 'white' : 'black';
 }
@@ -18,6 +24,29 @@ export function bindMobileMousedown(el: HTMLElement, f: (e: Event) => any, redra
       if (redraw) redraw();
     });
   }
+}
+  
+export function bindMobileTapHold(el: HTMLElement, f: (e: Event) => any, redraw?: () => void) {
+  let longPressCountdown;
+
+  el.addEventListener('touchstart', e => {
+    longPressCountdown = setTimeout(() => {
+      f(e);
+      if (redraw) redraw();
+    }, longPressDuration);
+  });
+
+  el.addEventListener('touchmove', () => {
+    clearTimeout(longPressCountdown);
+  });
+
+  el.addEventListener('touchcancel', () => {
+    clearTimeout(longPressCountdown);
+  });
+
+  el.addEventListener('touchend', () => {
+    clearTimeout(longPressCountdown);
+  });
 }
 
 function listenTo(el: HTMLElement, eventName: string, f: (e: Event) => any, redraw?: () => void) {

--- a/ui/analyse/src/util.ts
+++ b/ui/analyse/src/util.ts
@@ -25,7 +25,7 @@ export function bindMobileMousedown(el: HTMLElement, f: (e: Event) => any, redra
     });
   }
 }
-  
+
 export function bindMobileTapHold(el: HTMLElement, f: (e: Event) => any, redraw?: () => void) {
   let longPressCountdown;
 


### PR DESCRIPTION
Allows to manage variations using touch devices by invoking the contextual menu on tap & hold. Supposedly doesn't break anything.

![animation-small](https://user-images.githubusercontent.com/79122218/108007570-fa83fa00-7006-11eb-9042-20fa41454559.gif)
