### PR TITLE
clarify anon/public donation (hopefully closes lichess-org/talk#73)

### DIFF
--- a/app/views/plan/index.scala
+++ b/app/views/plan/index.scala
@@ -133,8 +133,19 @@ object index {
   <input type="hidden" name="lc" value="US">
   <input type="hidden" name="currency_code" value="USD">
 </form>"""),
-                  patron.exists(_.isLifetime) option
-                    p(style := "text-align:center;margin-bottom:1em")(makeExtraDonation()),
+                  ctx.me map { me =>
+                    p(style := "text-align:center;margin-bottom:1em")(
+                      if (patron.exists(_.isLifetime))
+                        makeExtraDonation()
+                      else
+                        frag(
+                          "Donating ",
+                          strong("publicly"),
+                          " as ",
+                          userSpan(me)
+                        )
+                    )
+                  },
                   st.group(cls := "radio buttons freq")(
                     div(
                       st.title := payLifetimeOnce.txt(lila.plan.Cents.lifetime.usd),


### PR DESCRIPTION
Would something like this maybe be sufficient for the final point of lichess-org/talk#73?

![image](https://user-images.githubusercontent.com/402777/108203283-8f2f4a80-7122-11eb-92e8-857d16e3dea0.png)

On the flipside, it might also prevent the occasional unintended anon donation.

![image](https://user-images.githubusercontent.com/402777/108203329-a79f6500-7122-11eb-9b6f-3a561b51fe6d.png)
