### PR TITLE
Fix practice icon

### DIFF
--- a/ui/site/css/practice/_icons.scss
+++ b/ui/site/css/practice/_icons.scss
@@ -51,7 +51,7 @@ i.practice {
   background-image: img-url('practice/catapult.svg');
 }
 
-.\39 6lij7wh {
+.\39 \36 Lij7wH {
   background-image: img-url('practice/musket.svg');
 }
 


### PR DESCRIPTION
It seems prettier tool broke one of tricky css classes in practice page.

![Screenshot from 2021-02-21 19-31-23](https://user-images.githubusercontent.com/4232207/108622343-8a003180-747b-11eb-95ed-7121bab26bf1.png)

See small demo at prettier playground [here](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEA6AOugzATgAQBsAMgJYBWA7AO4ASew6UeeARgIZgDWA5gE4QBXKABMAtCQC2bbnCR5J3UQN4AbABQByAA68OMEmDgB6CQIDOnODFRmAbtw0BKANyMAvo0ZGAVHh1X9OF5xbigIXjg8byNGDGx8YnJqOgYmVg4efiExSWlZeQlFZXVtXTB9QxNzS2s7Bxd3Tyg43DxMLAI8UkpaekZmdi4+QRFxKRk5BSVVTR09A2NTCysbeydXKA8oEAAaEAgtfWgzZFA2Xn4qAAVzhBOUNhUqNgBPE72WMpqAZS0OEig3GQMF4AjgezgEhYcGEwhhRDYgIEeQAYuEpDB9IDkCA2AIYBBdiAABYwCQqADqxJI8DMf0M3zuNJIthpLxxYDM7xAALMQRgV103CkyAAZo8+XsyGYAB4AIS+Vm+bAkcFIUDgYol4JA0pl3wB3BUcAAigIIPAtSpJSA-rw+bwOVyiToATAKSRhDBicgABwABj2OggfIpui0OP8Dtsmr2AEdzfBBQd7rizKINTCYUSIgmSBFBdIRUhxdadXyJCRgaDy4bjWaLZqS9q9jA2CwPV6fUgAEyt3QkFSGgDCEAkxZAcDMAFYieY4AAVdv3Us22xggCSIgQMG+YF4JEOAEERN8YC9jVa+W43EA).

I tested the new selector `.\39 \36 Lij7wH` directly from devtool and it seems to work.