### PR TITLE
MultiKeyMap for HookRepo

### DIFF
--- a/modules/common/src/main/MultiKeyMap.scala
+++ b/modules/common/src/main/MultiKeyMap.scala
@@ -15,26 +15,26 @@ final class MultiKeyMap[K1, K2, V](val values: Set[V], index1: Map[K1, V], index
 
   def key1s: Iterable[K1] = index1.keys
 
-  def updated(value: V): MultiKeyMap[K1, K2, V] = {
-    val (k1, k2) = (toK1(value), toK2(value))
+  def updated(toAdd: V): MultiKeyMap[K1, K2, V] = {
+    val (k1, k2) = (toK1(toAdd), toK2(toAdd))
     copy(
-      values = values -- Set(get1(k1), get2(k2)).flatten + value,
-      index1 = index1.removed(k1).updated(k1, value),
-      index2 = index2.removed(k2).updated(k2, value)
+      values = values -- Set(get1(k1), get2(k2)).flatten + toAdd,
+      index1 = index1.removed(k1).updated(k1, toAdd),
+      index2 = index2.removed(k2).updated(k2, toAdd)
     )
   }
 
-  def removed(value: V): MultiKeyMap[K1, K2, V] = {
-    val (k1, k2) = (toK1(value), toK2(value))
+  def removed(toRemove: V): MultiKeyMap[K1, K2, V] = {
+    val (k1, k2) = (toK1(toRemove), toK2(toRemove))
     copy(
-      values = values -- Set(get1(k1), get2(k2)).flatten + value,
+      values = values -- Set(get1(k1), get2(k2)).flatten,
       index1 = index1.removed(k1),
       index2 = index2.removed(k2)
     )
   }
 
-  def removed(values: Set[V]): MultiKeyMap[K1, K2, V] = {
-    val (k1s, k2s) = (values map toK1, values map toK2)
+  def removed(toRemove: Set[V]): MultiKeyMap[K1, K2, V] = {
+    val (k1s, k2s) = (toRemove map toK1, toRemove map toK2)
     copy(
       values = values -- k1s.flatMap(get1) -- k2s.flatMap(get2),
       index1 = index1 -- k1s,
@@ -42,13 +42,11 @@ final class MultiKeyMap[K1, K2, V](val values: Set[V], index1: Map[K1, V], index
     )
   }
 
-  // def filter(f: V => Boolean) = new MultiKeyMap(values filter f)(toK1, toK2)
-
   def size = values.size
 
   def reset(newValues: Set[V]) = if (newValues == values) this else MultiKeyMap(newValues)(toK1, toK2)
 
-  def copy(values: Set[V], index1: Map[K1, V], index2: Map[K2, V]) =
+  private def copy(values: Set[V], index1: Map[K1, V], index2: Map[K2, V]) =
     new MultiKeyMap(values, index1, index2)(toK1, toK2)
 }
 

--- a/modules/common/src/test/MultiKeyMapTest.scala
+++ b/modules/common/src/test/MultiKeyMapTest.scala
@@ -1,0 +1,30 @@
+package lila.common
+
+import org.specs2.mutable.Specification
+
+class MultiKeyMapTest extends Specification {
+
+  case class V(a: Int, b: Int)
+
+  "MultiKeyMap.removed" should {
+    val m = MultiKeyMap(Set(V(1, 100)))(_.a, _.b)
+    "have entries" in {
+      m.values == Set(V(1, 100))
+    }
+    "add a new entry" in {
+      m.updated(V(2, 200)).values must_== Set(V(1, 100), V(2, 200))
+    }
+    "replace an entry" in {
+      m.updated(V(1, 200)).values must_== Set(V(1, 200))
+    }
+    "remove empty entries" in {
+      m.removed(Set.empty[V]).values must_== m.values
+    }
+    "remove entries" in {
+      m.removed(Set(V(1, 100))).values must_== Set.empty
+    }
+    "expose keys" in {
+      m.key1s.toSet must_== Set(1)
+    }
+  }
+}

--- a/modules/lobby/src/main/HookRepo.scala
+++ b/modules/lobby/src/main/HookRepo.scala
@@ -41,7 +41,7 @@ final private class HookRepo {
 
   // O(n)
   // invoked when a hook is added
-  def bySid(sid: String) = hooks.values.find(_.sid == sid.some)
+  def bySid(sid: String) = hooks.values.find(_.sid has sid)
 
   // O(n)
   def notInSris(sris: Set[Sri]): Set[Hook] = hooks.values.filterNot(h => sris(h.sri))

--- a/modules/lobby/src/main/HookRepo.scala
+++ b/modules/lobby/src/main/HookRepo.scala
@@ -18,6 +18,8 @@ final private class HookRepo {
 
   implicit private val creationOrdering = Ordering.by[Hook, Long](_.createdAt.getMillis)
 
+  def size = hooks.size
+
   // O(n)
   def filter(f: Hook => Boolean): View[Hook] = hooks.values.view.filter(f)
 


### PR DESCRIPTION
Hooks (i.e. realtime seeks on lobby) have 2 unique keys:
id, the hook identifier
sri, the websocket identifier

there can't be 2 hooks with the same id or sri.

the previous hook repo did a lot of traversing of a Vector[Hook]
to look them up by id or sri.

This attempts to index the hooks.