### PR TITLE
Add color-scheme property, fixes #7465

### DIFF
--- a/ui/common/css/base/_elements.scss
+++ b/ui/common/css/base/_elements.scss
@@ -1,6 +1,7 @@
 html {
   box-sizing: border-box;
   min-height: 100%;
+  color-scheme: unquote($theme);
 }
 
 *,


### PR DESCRIPTION
This Pull Request fixes #7465 by indicating the browser what theme is currently using the webpage, with the `color-scheme` property. In Chrome/Chromium, this makes the browser use dark scrollbars when using lichess' dark theme.