### PR TITLE
use different field names for passwords

### DIFF
--- a/app/views/swiss/form.scala
+++ b/app/views/swiss/form.scala
@@ -204,7 +204,7 @@ final private class SwissFields(form: Form[_])(implicit ctx: Context) {
 
   def password =
     form3.group(
-      form("password"),
+      form("swiss_password"),
       trans.password(),
       help = trans.makePrivateTournament().some,
       half = true

--- a/app/views/team/form.scala
+++ b/app/views/team/form.scala
@@ -103,7 +103,7 @@ object form {
 
   private def passwordField(form: Form[_])(implicit ctx: Context) =
     form3.group(
-      form("password"),
+      form("team_password"),
       trans.team.teamPassword(),
       help = trans.team.teamPasswordDescriptionForLeader().some
     )(

--- a/app/views/team/request.scala
+++ b/app/views/team/request.scala
@@ -30,7 +30,7 @@ object request {
               form3.group(form("message"), trans.message())(form3.textarea(_)()),
               p(willBeReviewed())
             ),
-            t.password.nonEmpty ?? form3.passwordModified(form("password"), teamPassword())(
+            t.password.nonEmpty ?? form3.passwordModified(form("team_password"), teamPassword())(
               autocomplete := "new-password"
             ),
             form3.globalError(form),

--- a/app/views/tournament/form.scala
+++ b/app/views/tournament/form.scala
@@ -279,7 +279,7 @@ final private class TourFields(form: Form[_], tour: Option[Tournament])(implicit
   def password =
     !isTeamBattle option
       form3.group(
-        form("password"),
+        form("tournament_password"),
         trans.password(),
         help = trans.makePrivateTournament().some,
         half = true


### PR DESCRIPTION
I was able to reproduce issue #8255 

Although I agree this is LastPass' problem, we could help Password Managers by giving password's fields different names (at least, different from the signup/login password which is usually saved by Password Manager's users)