### PR TITLE
Disable move annotation when computer analysis is disabled

### DIFF
--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -101,7 +101,7 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
       }
     });
   }
-  if (ctrl.showMoveAnnotation()) {
+  if (ctrl.showMoveAnnotation() && ctrl.showComputer()) {
     const { uci, glyphs } = ctrl.node;
     if (glyphs && glyphs.length > 0) {
       const glyph = glyphs[0];


### PR DESCRIPTION
Fixes https://github.com/ornicar/lila/issues/8273