### PR TITLE
Minor css fix: Vertically center learn screen overlay

### DIFF
--- a/ui/learn/css/_screen.scss
+++ b/ui/learn/css/_screen.scss
@@ -15,6 +15,8 @@
   overflow: hidden;
   text-align: center;
   padding-top: 36px;
+  max-height: 100%;
+  overflow: auto;
 
   > :nth-child(1) {
     animation: slideIn 1s cubic-bezier(0.37, 0.82, 0.2, 1);

--- a/ui/learn/css/_screen.scss
+++ b/ui/learn/css/_screen.scss
@@ -3,12 +3,13 @@
 
   background: rgba(79, 195, 247, 0.9);
   cursor: pointer;
+  display: grid;
 }
 
 .learn__screen {
   @extend %popup-shadow, %box-radius;
 
-  margin: 150px auto;
+  margin: auto;
   background-color: #fff;
   width: 350px;
   overflow: hidden;


### PR DESCRIPTION
Vertically (as well as horizontally) center learn screen overlay. The "Let's go" button is barely visible in some levels, as shown in
https://lichess.org/learn#/16
Before
![image](https://user-images.githubusercontent.com/13644295/109389387-3d1ece00-7947-11eb-9581-7df5b0b5f6df.png)

After
![image](https://user-images.githubusercontent.com/13644295/109389290-efa26100-7946-11eb-8f8e-b1b8298a32f3.png)
Also if height is too small, it will become scrollable.
![image](https://user-images.githubusercontent.com/13644295/109389658-380e4e80-7948-11eb-9345-4ccfee5c8f5a.png)
