### PR TITLE
Fix chessground css in ui/learn

### DIFF
--- a/ui/common/css/vendor/chessground/_chessground.scss
+++ b/ui/common/css/vendor/chessground/_chessground.scss
@@ -170,3 +170,21 @@ cg-container .cg-shapes {
 cg-container .cg-custom-svgs {
   z-index: z('cg__svg.cg-custom-svgs');
 }
+
+// Workaround for chessground 4.4 used in `ui/learn` page.
+// This selector has no effect for chessground 7.11.0 used in other pages.
+cg-container > cg-board > svg {
+  overflow: hidden;
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: z('cg__svg.cg-shapes');
+  opacity: 0.6;
+
+  image {
+    opacity: 0.5;
+  }
+}


### PR DESCRIPTION
Closes https://github.com/ornicar/lila/issues/8285.
I added a workaround for older version (4.4) of chessground dom hierarchy used in ui/learn page.