### PR TITLE
Fix disabled rematch button

### DIFF
--- a/ui/round/src/view/button.ts
+++ b/ui/round/src/view/button.ts
@@ -77,7 +77,7 @@ function rematchButtons(ctrl: RoundController): MaybeVNodes {
             } else if (d.opponent.onGame) {
               d.player.offeringRematch = true;
               ctrl.socket.send('rematch-yes');
-            } else if (!(e.target as HTMLElement).classList.contains('disabled')) ctrl.challengeRematch();
+            } else if (!(e.currentTarget as HTMLElement).classList.contains('disabled')) ctrl.challengeRematch();
           },
           ctrl.redraw
         ),


### PR DESCRIPTION
Closes https://github.com/ornicar/lila/issues/7866.
This bug seems due to a typical error of `Event.target` and `Event.currentTarget`. I actually couldn't reproduce "disabled" state locally, but I saw `event.target` being `<span>Rematch</span>`, which doesn't have any classes.