### PR TITLE
Add "Enable NNUE" bool setting

### DIFF
--- a/ui/analyse/src/actionMenu.ts
+++ b/ui/analyse/src/actionMenu.ts
@@ -268,6 +268,16 @@ export function view(ctrl: AnalyseCtrl): VNode {
                     },
                     ctrl
                   ),
+                  ctrlBoolSetting(
+                    {
+                      name: 'Enable NNUE',
+                      title: 'Enable NNUE (page reload required after change)',
+                      id: 'enable-nnue',
+                      checked: ceval.enableNNUE(),
+                      change: ctrl.cevalEnableNNUE,
+                    },
+                    ctrl
+                  ),
                   (id => {
                     const max = 5;
                     return h('div.setting', [

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -714,6 +714,12 @@ export default class AnalyseCtrl {
     this.cevalReset();
   };
 
+  cevalEnableNNUE = (v: boolean): void => {
+    // TODO: Actually page reload is required to apply change
+    this.ceval.enableNNUE(v);
+    this.cevalReset();
+  };
+
   showEvalGauge(): boolean {
     return this.hasAnyComputerAnalysis() && this.showGauge() && !this.outcome() && this.showComputer();
   }

--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -48,6 +48,7 @@ export default function (opts: CevalOpts): CevalCtrl {
   const storageKey = (k: string) => {
     return opts.storageKeyPrefix ? `${opts.storageKeyPrefix}.${k}` : k;
   };
+  const enableNNUE = storedProp(storageKey('ceval.enable-nnue'), true);
 
   // select nnue > hce > wasm > asmjs
   let technology: CevalTechnology = 'asmjs';
@@ -62,6 +63,7 @@ export default function (opts: CevalOpts): CevalCtrl {
       // i32x4.dot_i16x8_s
       const sourceWithSimd = Uint8Array.from([0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 96, 0, 1, 123, 3, 2, 1, 0, 7, 8, 1, 4, 116, 101, 115, 116, 0, 0, 10, 15, 1, 13, 0, 65, 0, 253, 17, 65, 0, 253, 17, 253, 186, 1, 11]); // prettier-ignore
       if (
+        enableNNUE() &&
         !(navigator as any).connection?.saveData &&
         officialStockfish(opts.variant.key) &&
         WebAssembly.validate(sourceWithSimd)
@@ -282,6 +284,7 @@ export default function (opts: CevalOpts): CevalCtrl {
     maxThreads,
     maxHashSize,
     infinite,
+    enableNNUE,
     hovering,
     setHovering(fen: Fen, uci?: Uci) {
       hovering(

--- a/ui/ceval/src/types.ts
+++ b/ui/ceval/src/types.ts
@@ -71,6 +71,7 @@ export interface CevalCtrl {
   maxThreads: number;
   maxHashSize: number;
   infinite: StoredBooleanProp;
+  enableNNUE: StoredBooleanProp;
   hovering: Prop<Hovering | null>;
   toggle(): void;
   curDepth(): number;


### PR DESCRIPTION
This PR adds option to disable nnue ceval, reflecting some report where engine failed to start on some device and also for some mobile users who want to avoid downloading 10mb https://github.com/ornicar/lila/issues/8284, https://github.com/ornicar/lila/issues/8309.
I know It's better to fix the engine bug on my end https://github.com/hi-ogawa/Stockfish/issues/2, but I need more time on it.

This bool switch actually requires reloading page to apply change so it's a bit mis-leading, but I think user will be fine doing it for this case.