### PR TITLE
Use standard analysis from normal looking positions

### DIFF
--- a/app/controllers/UserAnalysis.scala
+++ b/app/controllers/UserAnalysis.scala
@@ -29,7 +29,7 @@ final class UserAnalysis(
       case Array(key, fen) =>
         Variant.byKey get key match {
           case Some(variant)                              => load(fen, variant)
-          case _ if FEN.clean(fen) == Standard.initialFen => load(arg, Standard)
+          case _ if FEN.clean(arg) == Standard.initialFen => load(arg, Standard)
           case _                                          => load(arg, FromPosition)
         }
       case _ => load("", Standard)

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -134,26 +134,10 @@ export default class EditorCtrl {
   }
 
   private isLikelyStandard(legalFen: string): boolean {
-    const setup = parseFen(legalFen).unwrap();
-    const board = setup.board;
-
-    if (
-      setup.unmovedRooks
-        .without(0)
-        .without(7)
-        .without(7 * 8)
-        .without(7 * 8 + 7)
-        .nonEmpty()
-    )
-      return false;
+    const board = parseFen(legalFen).unwrap().board;
 
     for (const color of COLORS) {
       const pieces = board[color];
-      const canCastle = setup.unmovedRooks.intersect(SquareSet.backrank(color)).nonEmpty();
-      const expectedKingSquare = color === 'white' ? 4 : 7 * 8 + 4;
-
-      if (canCastle && board.king.intersect(pieces).singleSquare() !== expectedKingSquare) return false;
-
       const promotedPieces =
         Math.max(board.queen.intersect(pieces).size() - 1, 0) +
         Math.max(board.rook.intersect(pieces).size() - 2, 0) +

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -155,7 +155,7 @@ export default class EditorCtrl {
       if (canCastle && board.king.intersect(pieces).singleSquare() !== expectedKingSquare) return false;
 
       const promotedPieces =
-        Math.max(board.queen.intersect(pieces).size() - 2, 0) +
+        Math.max(board.queen.intersect(pieces).size() - 1, 0) +
         Math.max(board.rook.intersect(pieces).size() - 2, 0) +
         Math.max(board.knight.intersect(pieces).size() - 2, 0) +
         Math.max(board.bishop.intersect(pieces).intersect(SquareSet.lightSquares()).size() - 1, 0) +


### PR DESCRIPTION
Closes #8296

This implements a fairly simple heuristic to detect if a "From Position" board in the editor is likely a normal game and if so, it adjusts the analysis board link to use standard analysis which allows it to use NNUE Stockfish.

The heuristic simply checks if any non-standard castling is possible and if the total number of pieces that must have come from pawn-promotions + the number of actual pawns is at mots 8. From my understanding, this should rule out pretty much all of the positions that are very problematic for NNUE.

This also fixes a small bug with the already existing server-side check to use the standard analysis for the starting position setup.

My new check is currently performed client-side in the editor. This seemed the most sensible to me since it still allows using HCE Stockfish with any position if desired by changing the URL but I guess there are also good reasons to do this server-side. If you think that's a better idea, I'd be happy to change it.

An alternative would be to instead expose the "From Position" variant in the editor (it already shows up there in the analysis board), maybe with a different name (i.e. "Custom Position"), to give users the explicit choice but I'm not sure if this is really necessary.