### PR TITLE
Update stockfish-nnue.wasm 0.0.2

### DIFF
--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -231,7 +231,7 @@ export default function (opts: CevalOpts): CevalCtrl {
             downloadProgress(mb);
             opts.redraw();
           }),
-          version: '2732f2',
+          version: '85a969',
           wasmMemory: sharedWasmMemory(2048, growableSharedMem ? 32768 : 2048),
         });
       else if (technology == 'hce')

--- a/ui/site/package.json
+++ b/ui/site/package.json
@@ -21,7 +21,7 @@
     "hopscotch": "^0.3.1",
     "jquery-bar-rating": "^1.2.2",
     "stockfish-mv.wasm": "^0.6.1",
-    "stockfish-nnue.wasm": "0.0.1",
+    "stockfish-nnue.wasm": "0.0.2",
     "stockfish.js": "^10.0.2",
     "stockfish.wasm": "^0.10.0",
     "tablesort": "^5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4144,10 +4144,10 @@ stockfish-mv.wasm@^0.6.1:
   resolved "https://registry.yarnpkg.com/stockfish-mv.wasm/-/stockfish-mv.wasm-0.6.1.tgz#cd160b01b25ff64794cb44fe55b6791c3fb297f8"
   integrity sha512-6QE1LeWbv9NNMABHCjDGyjgob+1CfMpIszxUKCUcCH0znreWPXz48G09rhKTUpRzC8YsOTHPQL/s74gDcqXJGw==
 
-stockfish-nnue.wasm@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/stockfish-nnue.wasm/-/stockfish-nnue.wasm-0.0.1.tgz#945a9904c5a1152bab98b9fdde7c517b1342e83f"
-  integrity sha512-ePulPKbGimjJEtTUYECh4986JnZv1rYVDsSlBOXu+1tvjWKjJSzoHhKpmtdGDG59iVtIBRamix593rfYqMqK2Q==
+stockfish-nnue.wasm@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stockfish-nnue.wasm/-/stockfish-nnue.wasm-0.0.2.tgz#388128b17a22215222ad87cf3f29e71822e7ff5f"
+  integrity sha512-PPbYo0hbPihPVj7j1DWsJq4idifKXf0jfsavXIIuoHE/XG+7nfbrah91DnliDo7s3PsXM0y+ZgOC++Xszv3JyQ==
 
 stockfish.js@^10.0.2:
   version "10.0.2"


### PR DESCRIPTION
Closes https://github.com/ornicar/lila/issues/8284 and https://github.com/ornicar/lila/issues/8309.
The new version fixes spontaneous engine crash, which was investigated here https://github.com/hi-ogawa/Stockfish/issues/2.