### PR TITLE
Fix study comment form

### DIFF
--- a/ui/analyse/src/study/commentForm.ts
+++ b/ui/analyse/src/study/commentForm.ts
@@ -64,7 +64,11 @@ export function ctrl(root: AnalyseCtrl): CommentForm {
     onSetPath(chapterId: string, path: Tree.Path, node: Tree.Node, playedMyself: boolean): void {
       setTimeout(() => {
         const cur = current();
-        if (cur && (path !== cur.path || chapterId !== cur.chapterId) && (!focus() || playedMyself)) {
+        if (
+          cur &&
+          (path !== cur.path || chapterId !== cur.chapterId || cur.node !== node) &&
+          (!focus() || playedMyself)
+        ) {
           cur.chapterId = chapterId;
           cur.path = path;
           cur.node = node;
@@ -135,7 +139,7 @@ export function view(root: AnalyseCtrl): VNode {
               el.onblur = function () {
                 ctrl.focus(false);
               };
-              vnode.data!.hash = current.chapterId + current.path;
+              vnode.data!.path = current.chapterId + current.path;
             },
             postpatch(old, vnode) {
               const newKey = current.chapterId + current.path;


### PR DESCRIPTION
Didn't mean to dig up the closed issue (https://github.com/ornicar/lila/issues/8220) but I found one case where a bug is reproducible and identified the code responsible for it.

The bug is from https://lichess.org/forum/lichess-feedback/new-comments-disappearing-in-my-studies?page=3#21, which says:

> Put a longish (17 lines) comment before the first move. REC button was green. Clicked it twice. Now green. Edited the comment to have one more line. Clicked REC twice. Now the line I just added is in the move window (Inline notation is on) but missing from in the comment window below the board!

As far as I can tell, this is due to the prop `CommentForm.current: Prop<Current | null>` holds a stale `Tree.Node` object after a user clicks REC button twice. The prop is updated by `CommentForm.start` or `CommentForm.onSetPath` with different path, but "REC button twice" case only runs `CommentForm.onSetPath` with same path, so it skips updating the prop.

So, my fix is to check `Tree.Node` object identity in addition to path (note that the identity changes because "REC button twice" refreshes node tree data via `StudyCtrl.onReload`). Probably there was some reason not to check object identity in that line, but I couldn't tell. Let me know what you think.