### PR TITLE
ceval: Cache wasm binary via IndexedDB

### DIFF
--- a/ui/ceval/package.json
+++ b/ui/ceval/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "chessops": "^0.8.1",
     "common": "2.0.0",
+    "idb-keyval": "^5.0.4",
     "snabbdom": "^0.7.4"
   }
 }

--- a/ui/ceval/src/cache.ts
+++ b/ui/ceval/src/cache.ts
@@ -1,0 +1,27 @@
+import * as idb from 'idb-keyval';
+
+export class Cache {
+  private store;
+
+  constructor(name: string) {
+    this.store = idb.createStore(`${name}--db`, `${name}--store`);
+  }
+
+  async get(key: string, version: string): Promise<[boolean, any]> {
+    const cachedVersion = await idb.get(`${key}--version`, this.store);
+    if (cachedVersion !== version) {
+      return [false, undefined];
+    }
+    const data = await idb.get(`${key}--data`, this.store);
+    return [true, data];
+  }
+
+  async set(key: string, version: string, data: any): Promise<void> {
+    const cachedVersion = await idb.get(`${key}--version`, this.store);
+    if (cachedVersion === version) {
+      return;
+    }
+    await idb.set(`${key}--version`, version, this.store);
+    await idb.set(`${key}--data`, data, this.store);
+  }
+}

--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -6,6 +6,7 @@ import { storedProp } from 'common/storage';
 import throttle from 'common/throttle';
 import { povChances } from './winningChances';
 import { sanIrreversible } from './util';
+import { Cache } from './cache';
 
 function sharedWasmMemory(initial: number, maximum: number): WebAssembly.Memory {
   return new WebAssembly.Memory({ shared: true, initial, maximum } as WebAssembly.MemoryDescriptor);
@@ -228,6 +229,7 @@ export default function (opts: CevalOpts): CevalCtrl {
           }),
           version: '85a969',
           wasmMemory: sharedWasmMemory(2048, growableSharedMem ? 32768 : 2048),
+          cache: new Cache('ceval-wasm-cache'),
         });
       else if (technology == 'hce')
         worker = new ThreadedWasmWorker(protocolOpts, {

--- a/ui/ceval/src/worker.ts
+++ b/ui/ceval/src/worker.ts
@@ -1,6 +1,7 @@
 import { sync, Sync } from 'common/sync';
 import { ProtocolOpts, Work } from './types';
 import Protocol from './stockfishProtocol';
+import { Cache } from './cache';
 
 export abstract class AbstractWorker<T> {
   protected protocol: Sync<Protocol>;
@@ -62,6 +63,7 @@ export interface ThreadedWasmWorkerOpts {
   version?: string;
   downloadProgress?: (mb: number) => void;
   wasmMemory: WebAssembly.Memory;
+  cache?: Cache;
 }
 
 export class ThreadedWasmWorker extends AbstractWorker<ThreadedWasmWorkerOpts> {
@@ -71,14 +73,23 @@ export class ThreadedWasmWorker extends AbstractWorker<ThreadedWasmWorkerOpts> {
   boot(): Promise<Protocol> {
     const version = this.opts.version;
     const progress = this.opts.downloadProgress;
+    const cache = this.opts.cache;
+    const wasmPath = this.opts.baseUrl + 'stockfish.wasm';
     ThreadedWasmWorker.protocols[this.opts.module] ||= lichess
       .loadScript(this.opts.baseUrl + 'stockfish.js', { version })
       .then(
         _ =>
           progress &&
-          new Promise((resolve, reject) => {
+          new Promise(async (resolve, reject) => {
+            if (cache) {
+              const [found, data] = await cache.get(wasmPath, version!);
+              if (found) {
+                resolve(data);
+                return;
+              }
+            }
             const req = new XMLHttpRequest();
-            req.open('GET', lichess.assetUrl(this.opts.baseUrl + 'stockfish.wasm', { version }), true);
+            req.open('GET', lichess.assetUrl(wasmPath, { version }), true);
             req.responseType = 'arraybuffer';
             req.onerror = event => reject(event);
             req.onprogress = event => progress(event.loaded);
@@ -89,14 +100,17 @@ export class ThreadedWasmWorker extends AbstractWorker<ThreadedWasmWorkerOpts> {
             req.send();
           })
       )
-      .then(wasmBinary =>
-        window[this.opts.module]({
+      .then(async wasmBinary => {
+        if (cache && wasmBinary) {
+          await cache.set(wasmPath, version!, wasmBinary);
+        }
+        return window[this.opts.module]({
           wasmBinary,
           locateFile: (path: string) =>
             lichess.assetUrl(this.opts.baseUrl + path, { version, sameDomain: path.endsWith('.worker.js') }),
           wasmMemory: this.opts.wasmMemory,
-        })
-      )
+        });
+      })
       .then((sf: any) => {
         ThreadedWasmWorker.sf[this.opts.module] = sf;
         const protocol = new Protocol(this.send.bind(this), this.protocolOpts);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2152,6 +2152,11 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+idb-keyval@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/idb-keyval/-/idb-keyval-5.0.4.tgz#182881b1eafbb47d11a269422ae6d5243f0db0c7"
+  integrity sha512-qS0kplHuadZujoE90ze0NUkhW0/Fbfib7d+mYNMXNEn45NSh2NWY3fBewoX4GZUsKkGHBgc8JiAwMx0zrfL3LQ==
+
 ignore@^5.1.1:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"


### PR DESCRIPTION
~~Edit: It seems there are much clearner wrappers than localForage, so I think I will try them. In the mean time, I'll keep this as a draft PR.~~

Edit: For IndexedDB wrapper, I initially used [localForage](https://github.com/localForage/localForage), but I switched to [idb-keyval](https://github.com/jakearchibald/idb-keyval) since the code is much simpler.

---

I added explicit caching (i.e. not relying on browser cache) for nnue wasm binary with IndexedDB. Using local storage wasn't option because its size limit is 10M (also saving 20MB synchronously on UI thread would be a bit disastrous).

~~I used  [localForage](https://github.com/localForage/localForage) wrapper library for managing IndexedDB. The code looks a bit bloated but probably it would still be better than writing wrapper myself, so I hope it's okay to add a bit of dependencies for this.~~

Regarding the browser support of IndexedDB, I believe it should be fine, especially for browsers which even run wasm simd, https://caniuse.com/indexeddb.

To show how it looks in Chrome devtools, after successful initial download of wasm binary, here is the screenshot of "Application > Storage > IndexedDB" tab:

![Screenshot from 2021-03-11 19-58-24](https://user-images.githubusercontent.com/4232207/110778847-388ed980-82a6-11eb-88d8-032912d26ce0.png)


~~Firefox doesn't seem to have a convenient viewer in devtool~~ Firefox also has similar devtool.
