### PR TITLE
Mini board for PV

### DIFF
--- a/ui/ceval/css/_pv.scss
+++ b/ui/ceval/css/_pv.scss
@@ -1,4 +1,5 @@
 .pv_box {
+  position: relative;
   background: $c-bg-box;
   font-size: 13px;
 
@@ -24,6 +25,25 @@
       @extend %san;
 
       margin-left: 4px;
+    }
+
+    &[data-uci] .pv-san:hover {
+      color: $c-primary;
+    }
+  }
+
+  .pv-board {
+    position: absolute;
+    width: 80%;
+    max-width: 240px;
+    z-index: 1;
+
+    .pv-board-square {
+      @extend %square;
+
+      .cg-wrap {
+        @extend %abs-100;
+      }
     }
   }
 }

--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -1,4 +1,4 @@
-import { CevalCtrl, CevalOpts, CevalTechnology, Work, Step, Hovering, Started } from './types';
+import { CevalCtrl, CevalOpts, CevalTechnology, Work, Step, Hovering, PvBoard, Started } from './types';
 
 import { AbstractWorker, WebWorker, ThreadedWasmWorker } from './worker';
 import { prop } from 'common';
@@ -99,6 +99,7 @@ export default function (opts: CevalOpts): CevalCtrl {
   let started: Started | false = false;
   let lastStarted: Started | false = false; // last started object (for going deeper even if stopped)
   const hovering = prop<Hovering | null>(null);
+  const pvBoard = prop<PvBoard | null>(null);
   const isDeeper = prop(false);
 
   const protocolOpts = {
@@ -294,6 +295,11 @@ export default function (opts: CevalOpts): CevalCtrl {
           : null
       );
       opts.setAutoShapes();
+    },
+    pvBoard,
+    setPvBoard(_pvBoard: PvBoard | null) {
+      pvBoard(_pvBoard);
+      opts.redraw();
     },
     toggle() {
       if (!opts.possible || !allowed()) return;

--- a/ui/ceval/src/types.ts
+++ b/ui/ceval/src/types.ts
@@ -44,6 +44,11 @@ export interface Hovering {
   uci: string;
 }
 
+export interface PvBoard {
+  fen: string;
+  uci: string;
+}
+
 export interface Started {
   path: string;
   steps: Step[];
@@ -63,6 +68,7 @@ export interface CevalCtrl {
   engineName(): string | undefined;
   variant: Variant;
   setHovering: (fen: string, uci?: string) => void;
+  setPvBoard: (pvBoard: PvBoard | null) => void;
   multiPv: StoredProp<number>;
   start: (path: string, steps: Step[], threatMode?: boolean, deeper?: boolean) => void;
   stop(): void;
@@ -74,6 +80,7 @@ export interface CevalCtrl {
   supportsNnue: boolean;
   enableNnue: StoredBooleanProp;
   hovering: Prop<Hovering | null>;
+  pvBoard: Prop<PvBoard | null>;
   toggle(): void;
   curDepth(): number;
   isDeeper(): boolean;


### PR DESCRIPTION
I implemented a feature to display mini board when user hovers on pv.

This would partly solves this type of feature request https://github.com/ornicar/lila/issues/8271.

Here is the screenshot:

![Screenshot from 2021-03-12 18-51-57](https://user-images.githubusercontent.com/4232207/110923238-05ab1b00-8364-11eb-94e4-0cdd48a1b648.png)

and here is a short demo as video https://imgur.com/YcbYLTe.

The layout/design is a bit of issue currently and looks too intrusive. Another obvious issue is that it's not usable while pv is fluctuating.
So I totally understand if this feature is not acceptable, but I would appreciate any feedback and ideas for improvement.