### PR TITLE
Ensure board editor in study new chapter modal initializes with existing orientation

### DIFF
--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -213,6 +213,7 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
                         data.embed = true;
                         data.options = {
                           inlineCastling: true,
+                          orientation: currentChapter.setup.orientation,
                           onChange: ctrl.vm.editorFen,
                         };
                         ctrl.vm.editor = window['LichessEditor'](vnode.elm as HTMLElement, data);


### PR DESCRIPTION
Currently the board editor tab in the "create new chapter" modal on a study page always initially displays with white orientation, even if the "Orientation" select input below shows black. I believe the desired behavior is to initialize the editor view to the current orientation of whatever is currently displayed in the study.

Example of current behavior:
![Screenshot from 2021-03-12 13-53-02](https://user-images.githubusercontent.com/2890946/111002788-e0ee7d80-833a-11eb-9cee-2728f7d5d999.png)

Repro steps:

1. Create a study, or navigate to an existing study
2. Configure the view to have a black orientation
3. Click on "Add a new chapter" and navigate to the editor tab
