### PR TITLE
ceval: Implement pv line wrap toggle

### DIFF
--- a/ui/ceval/css/_pv.scss
+++ b/ui/ceval/css/_pv.scss
@@ -4,11 +4,19 @@
   font-size: 13px;
 
   .pv {
-    @extend %nowrap-ellipsis;
-
-    height: 2em;
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
     line-height: 2em;
     border-top: $border;
+    padding-right: 14px;
+
+    &.pv--nowrap {
+      display: block; // "flex" doesn't support ellipsis so switch back to "block"
+      flex-wrap: initial;
+      height: 2em;
+      @extend %nowrap-ellipsis;
+    }
 
     &[data-uci]:hover {
       background: mix($c-secondary, $c-bg-box, 20%);
@@ -29,6 +37,23 @@
 
     &[data-uci] .pv-san:hover {
       color: $c-primary;
+    }
+
+    .pv-wrap-toggle {
+      position: absolute;
+      right: 0;
+      padding: 0 4px;
+      margin: 0;
+      cursor: pointer;
+      top: 2px;
+
+      &::before {
+        content: '⯆';
+      }
+    }
+
+    &.pv--nowrap .pv-wrap-toggle {
+      transform: rotate(180deg);
     }
   }
 


### PR DESCRIPTION
I implemented multiline wrapping toggle for PV move display. All logic/state is in css, so the change is rather simple (other changes are mostly refactoring).

As revoof mentions here https://github.com/ornicar/lila/issues/8271#issuecomment-791929729, the usefulness of those shallow pv move is questionable, but I guess it's not bad to be able to show them anyway (for example, it can show mate in 8).

Here is the screenshot of current design (just triangle mark and some padding):

![Screenshot from 2021-03-13 20-51-05](https://user-images.githubusercontent.com/4232207/111029019-bdf8c200-843d-11eb-9a53-caf89cb5e4a0.png)
