### PR TITLE
Fix 'a hourly' -> 'an hourly'

### DIFF
--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -98,7 +98,7 @@ Do not ask for the LM title.</string>
   <string name="uniqueTrophies">Unique trophies</string>
   <string name="ownerUniqueTrophies">That trophy is unique in the history of Lichess, nobody other than %1$s will ever have it.</string>
   <string name="wayOfBerserkExplanation">To get it, hiimgosu challenged himself to berserk and win 100%% games of %s.</string>
-  <string name="aHourlyBulletTournament">a hourly Bullet tournament</string>
+  <string name="aHourlyBulletTournament">an hourly Bullet tournament</string>
   <string name="goldenZeeExplanation">ZugAddict was streaming and for the last 2 hours he had been trying to defeat A.I. level 8 in a 1+0 game, without success. Thibault told him that if he successfully did it on stream, he'd get a unique trophy. One hour later, he smashed Stockfish, and the promise was honoured.</string>
   <string name="lichessRatings">Lichess ratings</string>
   <string name="whichRatingSystemUsedByLichess">What rating system does Lichess use?</string>


### PR DESCRIPTION
On the [FAQ page](https://lichess.org/faq#trophies).

It seems to be wrong in some other languages as well, e.g. the German translation is roughly "berserk and win 100% of the an hourly bullet arena games" but I suspect that should be fixed on crowdin.