### PR TITLE
Change direction of triangle

### DIFF
--- a/ui/ceval/css/_pv.scss
+++ b/ui/ceval/css/_pv.scss
@@ -52,7 +52,7 @@
         color: $c-secondary-over;
       }
       &::before {
-        content: '⯆';
+        content: '⯅';
       }
     }
 


### PR DESCRIPTION
I don't know if the current behaviour is intended, but even if it was, please consider this as a proposal.

Seeing an upward pointing triangle at the end of the non-expanded variation didn't make me clear that it was an actual button to expand the variation.
I personally find the change in this PR to be more intuitive: when the variation is not expanded, the button is a downward pointing triangle, which suggests a downwards expansion of the variation, just like any drop-down list. When the variation is expanded, the upward pointing triangle suggests a collapse of the variation.