### PR TITLE
ceval: Support custom UCI server

### DIFF
--- a/app/templating/AssetHelper.scala
+++ b/app/templating/AssetHelper.scala
@@ -79,7 +79,8 @@ trait AssetHelper { self: I18nHelper with SecurityHelper =>
     }
     ContentSecurityPolicy(
       defaultSrc = List("'self'", assets),
-      connectSrc = "'self'" :: assets :: sockets ::: env.explorerEndpoint :: env.tablebaseEndpoint :: Nil,
+      // TODO: "ws:" is nonsense...
+      connectSrc = "'self'" :: assets :: sockets ::: "ws:" :: env.explorerEndpoint :: env.tablebaseEndpoint :: Nil,
       styleSrc = List("'self'", "'unsafe-inline'", assets),
       fontSrc = List("'self'", assetDomain.value, "https://fonts.gstatic.com"),
       frameSrc = List("'self'", assets, "https://www.youtube.com", "https://player.twitch.tv"),

--- a/ui/analyse/src/actionMenu.ts
+++ b/ui/analyse/src/actionMenu.ts
@@ -332,6 +332,39 @@ export function view(ctrl: AnalyseCtrl): VNode {
                           h('div.range_value', formatHashSize(parseInt(ceval.hashSize()))),
                         ]))('analyse-memory')
                     : undefined,
+                  ctrlBoolSetting(
+                    {
+                      name: 'Use custom server',
+                      title: 'Page reload required after change',
+                      id: 'use-custom-server',
+                      checked: ceval.useCustomServer(),
+                      change: value => {
+                        ceval.useCustomServer(value);
+                        ctrl.redraw();
+                      },
+                    },
+                    ctrl
+                  ),
+                  ceval.useCustomServer()
+                    ? h('div.setting', [
+                        h(
+                          'label',
+                          { attrs: { for: 'custom-server-url', style: 'flex: 0 1 auto; margin-right: 6px;' } },
+                          'URL'
+                        ),
+                        h('input#custom-server-url', {
+                          attrs: { value: ceval.customServerUrl(), style: 'flex: 1 1 auto; height: 24px;' },
+                          hook: {
+                            insert: (vnode: VNode) => {
+                              const el = vnode.elm as HTMLInputElement;
+                              el.addEventListener('input', () => {
+                                ceval.customServerUrl(el.value);
+                              });
+                            },
+                          },
+                        }),
+                      ])
+                    : undefined,
                 ]
               : []
           )

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -826,6 +826,9 @@ export default class AnalyseCtrl {
   }
 
   canEvalGet(): boolean {
+    // Disable evalCache if custom server ceval
+    if (this.ceval.useCustomServer()) return false;
+
     if (this.node.ply >= 15 && !this.opts.study) return false;
 
     // cloud eval does not support threefold repetition

--- a/ui/ceval/src/types.ts
+++ b/ui/ceval/src/types.ts
@@ -2,7 +2,7 @@ import { Outcome } from 'chessops/types';
 import { Prop } from 'common';
 import { StoredProp, StoredBooleanProp } from 'common/storage';
 
-export type CevalTechnology = 'asmjs' | 'wasm' | 'hce' | 'nnue';
+export type CevalTechnology = 'asmjs' | 'wasm' | 'hce' | 'nnue' | 'custom';
 
 export interface Eval {
   cp?: number;
@@ -79,6 +79,8 @@ export interface CevalCtrl {
   infinite: StoredBooleanProp;
   supportsNnue: boolean;
   enableNnue: StoredBooleanProp;
+  useCustomServer: StoredBooleanProp;
+  customServerUrl: StoredProp<string>;
   hovering: Prop<Hovering | null>;
   pvBoard: Prop<PvBoard | null>;
   toggle(): void;


### PR DESCRIPTION
I've made a prototype for this https://github.com/ornicar/lila/issues/7909.
There are many TODOs left in the comment, but maybe code-wise this might not be that complicated.

Currently this client assumes uci engine is directly proxied via websocket. As an example of such proxy server, I made this npm package [uci-ws](https://github.com/hi-ogawa/uci-ws) (for example, you can run stockfish just by `npx uci-ws stockfish`), but possibly more complicated server with authentication can be also implemented via https/wss and putting credentials in url parameter.

![Screenshot from 2021-03-19 00-14-10](https://user-images.githubusercontent.com/4232207/111649667-ede20400-8847-11eb-9372-8ca3b952933b.png)

I really don't know the audience, but my concern is how many people uses this feature and maybe this doesn't worth much.