### PR TITLE
Show coords on `Storm` and `Puzzle Racer`

### DIFF
--- a/app/controllers/Racer.scala
+++ b/app/controllers/Racer.scala
@@ -38,7 +38,7 @@ final class Racer(env: Env)(implicit mat: akka.stream.Materializer) extends Lila
             html.racer.show(
               race,
               env.racer.json.data(race, player),
-              env.storm.json.pref(ctx.pref.copy(coords = lila.pref.Pref.Coords.NONE))
+              env.storm.json.pref(ctx.pref)
             )
           ).fuccess dmap NoCache
       }

--- a/app/controllers/Storm.scala
+++ b/app/controllers/Storm.scala
@@ -17,7 +17,7 @@ final class Storm(env: Env)(implicit mat: akka.stream.Materializer) extends Lila
               Ok(
                 views.html.storm.home(
                   env.storm.json(puzzles, ctx.me),
-                  env.storm.json.pref(ctx.pref.copy(coords = lila.pref.Pref.Coords.NONE)),
+                  env.storm.json.pref(ctx.pref),
                   high
                 )
               )

--- a/ui/puz/css/_puz.scss
+++ b/ui/puz/css/_puz.scss
@@ -1,3 +1,5 @@
+@import '../../common/css/vendor/chessground/_coords';
+
 @import 'font';
 @import 'side';
 @import 'combo';


### PR DESCRIPTION
Looking at the code never showing coords was intentional but from what I have tested (all coords setting from both white and black perspective for Storm, on laptop), they are displayed fine.