### PR TITLE
simplify away net.ip config

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -11,7 +11,6 @@ net {
   asset.base_url = "http://"${net.asset.domain}
   asset.minified = false
   base_url = "http://"${net.domain}
-  ip = "127.0.0.1"
   email = ""
   crawlable = false
   ratelimit = true

--- a/modules/common/src/main/ThreadLocalRandom.scala
+++ b/modules/common/src/main/ThreadLocalRandom.scala
@@ -7,7 +7,6 @@ object ThreadLocalRandom {
   import java.util.concurrent.ThreadLocalRandom.current
 
   def nextBoolean(): Boolean              = current.nextBoolean()
-  def nextByte(): Byte                    = current.nextInt(256).toByte
   def nextBytes(bytes: Array[Byte]): Unit = current.nextBytes(bytes)
   def nextDouble(): Double                = current.nextDouble()
   def nextFloat(): Float                  = current.nextFloat()

--- a/modules/common/src/main/config.scala
+++ b/modules/common/src/main/config.scala
@@ -42,8 +42,7 @@ object config {
       @ConfigName("socket.domains") socketDomains: List[String],
       crawlable: Boolean,
       @ConfigName("ratelimit") rateLimit: RateLimit,
-      email: EmailAddress,
-      ip: IpAddress
+      email: EmailAddress
   ) {
     def isProd = domain == prodDomain
   }
@@ -57,7 +56,6 @@ object config {
   implicit val emailAddressLoader = strLoader(EmailAddress.apply)
   implicit val netDomainLoader    = strLoader(NetDomain.apply)
   implicit val assetDomainLoader  = strLoader(AssetDomain.apply)
-  implicit val ipLoader           = strLoader(IpAddress.unchecked)
   implicit val rateLimitLoader    = boolLoader(RateLimit.apply)
   implicit val netLoader          = AutoConfig.loader[NetConfig]
 

--- a/modules/security/src/main/Env.scala
+++ b/modules/security/src/main/Env.scala
@@ -58,7 +58,7 @@ final class Env(
 
   lazy val userLogins = wire[UserLoginsApi]
 
-  lazy val store = new Store(db(config.collection.security), cacheApi, net.ip)
+  lazy val store = new Store(db(config.collection.security), cacheApi)
 
   lazy val ip2proxy: Ip2Proxy =
     if (config.ip2Proxy.enabled) {

--- a/modules/security/src/main/Store.scala
+++ b/modules/security/src/main/Store.scala
@@ -13,7 +13,7 @@ import lila.db.dsl._
 import lila.user.User
 import reactivemongo.api.bson.BSONNull
 
-final class Store(val coll: Coll, cacheApi: lila.memo.CacheApi, localIp: IpAddress)(implicit
+final class Store(val coll: Coll, cacheApi: lila.memo.CacheApi)(implicit
     ec: scala.concurrent.ExecutionContext
 ) {
 
@@ -64,12 +64,7 @@ final class Store(val coll: Coll, cacheApi: lila.memo.CacheApi, localIp: IpAddre
         $doc(
           "_id"  -> sessionId,
           "user" -> userId,
-          "ip" -> (HTTPRequest.ipAddress(req) match {
-            // randomize stresser IPs to relieve mod tools
-            case ip if ip == localIp =>
-              IpV4Address(127, 0, ThreadLocalRandom.nextByte(), ThreadLocalRandom.nextByte())
-            case ip => ip
-          }),
+          "ip"   -> HTTPRequest.ipAddress(req),
           "ua"   -> HTTPRequest.userAgent(req).|("?"),
           "date" -> DateTime.now,
           "up"   -> up,


### PR DESCRIPTION
don't think we need this in prod. if listress needs fake ips, it can just send `X-Forwarded-For: fake-ip` in the test environment.