### PR TITLE
Add query param overrides for all UI preferences

### DIFF
--- a/modules/pref/src/main/RequestPref.scala
+++ b/modules/pref/src/main/RequestPref.scala
@@ -19,12 +19,12 @@ object RequestPref {
     default.copy(
       bg = paramOrSession("bg").flatMap(Pref.Bg.fromString.get) | default.bg,
       theme = paramOrSession("theme") | default.theme,
-      theme3d = req.session.data.getOrElse("theme3d", default.theme3d),
-      pieceSet = req.session.data.getOrElse("pieceSet", default.pieceSet),
-      pieceSet3d = req.session.data.getOrElse("pieceSet3d", default.pieceSet3d),
-      soundSet = req.session.data.getOrElse("soundSet", default.soundSet),
-      bgImg = req.session.data.get("bgImg"),
-      is3d = req.session.data.get("is3d") has "true"
+      theme3d = paramOrSession("theme3d") | default.theme3d,
+      pieceSet = paramOrSession("pieceSet") | default.pieceSet,
+      pieceSet3d = paramOrSession("pieceSet3d") | default.pieceSet3d,
+      soundSet = paramOrSession("soundSet") | default.soundSet,
+      bgImg = paramOrSession("bgImg"),
+      is3d = paramOrSession("is3d") has "true"
     )
   }
 


### PR DESCRIPTION
This is currently only possible for `bg` and `theme`. With this change URLs like this are possible:
[http://localhost:9663/analysis?bg=dark&theme3d=Classic-Blue&pieceSet3d=CubesAndPi&is3d=true](http://localhost:9663/analysis?bg=dark&theme3d=Classic-Blue&pieceSet3d=CubesAndPi&is3d=true)