### PR TITLE
Update prize regex

### DIFF
--- a/modules/common/src/main/String.scala
+++ b/modules/common/src/main/String.scala
@@ -117,7 +117,7 @@ object String {
   }
 
   private val prizeRegex =
-    """(?i)(prize|\$|€|£|¥|₽|元|₹|₱|₿|rupee|rupiah|ringgit|usd|dollar|paypal|cash|award|\bfees?\b|\beuros?\b|price|btc|bitcoin)""".r.unanchored
+    """(?i)(prize|\$|€|£|¥|₽|元|₹|₱|₿|rupee|rupiah|ringgit|(\b|\d)usd|dollar|paypal|cash|award|\bfees?\b|\beuros?\b|price|(\b|\d)btc|bitcoin)""".r.unanchored
 
   def looksLikePrize(txt: String) = prizeRegex matches txt
 }

--- a/modules/common/src/test/StringTest.scala
+++ b/modules/common/src/test/StringTest.scala
@@ -36,9 +36,11 @@ class StringTest extends Specification {
     }
 
     "prize regex" should {
-      String.looksLikePrize(s"HqVrbTcy") must beFalse
-      String.looksLikePrize("10btc") must beTrue
-      String.looksLikePrize("ten btc") must beTrue
+      "not find btc in url" in {
+        String.looksLikePrize(s"HqVrbTcy") must beFalse
+        String.looksLikePrize(s"10btc") must beTrue
+        String.looksLikePrize(s"ten btc") must beTrue
+      }
     }
   }
 

--- a/modules/common/src/test/StringTest.scala
+++ b/modules/common/src/test/StringTest.scala
@@ -34,6 +34,12 @@ class StringTest extends Specification {
         """a <a rel="nofollow noopener noreferrer" href="https://example.com/foo--" target="_blank">example.com/foo--</a>. b"""
       }
     }
+
+    "prize regex" should {
+      String.looksLikePrize(s"HqVrbTcy") must beFalse
+      String.looksLikePrize("10btc") must beTrue
+      String.looksLikePrize("ten btc") must beTrue
+    }
   }
 
 }


### PR DESCRIPTION
Random id of a tournament contained the substring `btc`, which triggered the regex, updating it to avoid that