### PR TITLE
In /bin/gen/piece-update, replace with #!/bin/bash

### DIFF
--- a/bin/gen/piece-update
+++ b/bin/gen/piece-update
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 file=$1
 single_name=$2

--- a/bin/gen/piece-update
+++ b/bin/gen/piece-update
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash
 
 file=$1
 single_name=$2


### PR DESCRIPTION
While coding in lishogi I have encountered a not found error when running ./bin/gen/piece-update since the double brackets ( [[ ]] ) syntax is not recognized in all sh implementations but is fine with bash.

https://serverfault.com/questions/52034/what-is-the-difference-between-double-and-single-square-brackets-in-bash
> [[ is not as compatible, it won't necessarily work with whatever /bin/sh points to. So [[ is the more modern Bash / Zsh / Ksh option.