### PR TITLE
Fix correspondence alarm display

### DIFF
--- a/ui/notify/src/renderers.ts
+++ b/ui/notify/src/renderers.ts
@@ -131,7 +131,8 @@ export default function makeRenderers(trans: Trans): Renderers {
       html: n =>
         generic(n, '/' + n.content.id, ';', [
           h('span', [h('strong', trans.noarg('timeAlmostUp')), drawTime(n)]),
-          h('span', trans('gameVsX', userFullName(n.content.op))),
+          // not a `LightUser`, could be a game against Stockfish
+          h('span', trans('gameVsX', n.content.op)),
         ]),
       text: _ => trans.noarg('timeAlmostUp'),
     },


### PR DESCRIPTION
Fix correspondence alarm opponent display
![_20210329_121208](https://user-images.githubusercontent.com/56031107/112830465-76ec0d00-908a-11eb-963b-1bd12d74f1d9.jpg)

Could not test but it's like it was before translating: https://github.com/ornicar/lila/blob/37c7cfbec5a5c5d6cdde1feef2b78ebcb698ae56/ui/notify/src/renderers.ts#L133