### PR TITLE
allow marked closed accounts to login for /appeal only

### DIFF
--- a/app/controllers/LilaController.scala
+++ b/app/controllers/LilaController.scala
@@ -16,7 +16,7 @@ import lila.common.{ ApiVersion, HTTPRequest, Nonce }
 import lila.i18n.I18nLangPicker
 import lila.notify.Notification.Notifies
 import lila.oauth.{ OAuthScope, OAuthServer }
-import lila.security.{ FingerPrintedUser, Granter, Permission }
+import lila.security.{ AppealUser, FingerPrintedUser, Granter, Permission }
 import lila.user.{ UserContext, User => UserModel, Holder }
 
 abstract private[controllers] class LilaController(val env: Env)
@@ -365,11 +365,6 @@ abstract private[controllers] class LilaController(val env: Env)
       _.fold(notFoundJson())(a => fuccess(JsonOk(a)))
     }
 
-  protected def JsOk(fua: Fu[String], headers: (String, String)*) =
-    fua map { a =>
-      Ok(a) as JAVASCRIPT withHeaders (headers: _*)
-    }
-
   protected def FormResult[A](form: Form[A])(op: A => Fu[Result])(implicit req: Request[_]): Fu[Result] =
     form
       .bindFromRequest()
@@ -466,7 +461,9 @@ abstract private[controllers] class LilaController(val env: Env)
   protected def authenticationFailed(implicit ctx: Context): Fu[Result] =
     negotiate(
       html = fuccess {
-        Redirect(routes.Auth.signup) withCookies env.lilaCookie
+        Redirect(
+          if (HTTPRequest.isAppeal(ctx.req)) routes.Auth.login else routes.Auth.signup
+        ) withCookies env.lilaCookie
           .session(env.security.api.AccessUri, ctx.req.uri)
       },
       api = _ =>
@@ -530,9 +527,10 @@ abstract private[controllers] class LilaController(val env: Env)
       env.pref.api.getPref(me, ctx.req) zip {
         if (isPage) {
           env.user.lightUserApi preloadUser me
-          env.team.api.nbRequests(me.id) zip
-            env.challenge.api.countInFor.get(me.id) zip
-            env.notifyM.api.unreadCount(Notifies(me.id)).dmap(_.value) zip
+          val enabledId = me.enabled option me.id
+          enabledId.??(env.team.api.nbRequests) zip
+            enabledId.??(env.challenge.api.countInFor.get) zip
+            enabledId.??(id => env.notifyM.api.unreadCount(Notifies(id)).dmap(_.value)) zip
             env.mod.inquiryApi.forMod(me)
         } else
           fuccess {
@@ -563,13 +561,16 @@ abstract private[controllers] class LilaController(val env: Env)
   type RestoredUser = (Option[FingerPrintedUser], Option[UserModel])
   private def restoreUser(req: RequestHeader): Fu[RestoredUser] =
     env.security.api restoreUser req dmap {
-      case Some(d) if !env.net.isProd =>
+      case Some(Left(AppealUser(user))) if HTTPRequest.isAppeal(req) =>
+        FingerPrintedUser(user, true).some
+      case Some(Right(d)) if !env.net.isProd =>
         d.copy(user =
           d.user
             .addRole(lila.security.Permission.Beta.dbKey)
             .addRole(lila.security.Permission.Prismic.dbKey)
         ).some
-      case d => d
+      case Some(Right(d)) => d.some
+      case _              => none
     } flatMap {
       case None => fuccess(None -> None)
       case Some(d) =>

--- a/app/views/appeal/tree.scala
+++ b/app/views/appeal/tree.scala
@@ -214,22 +214,39 @@ object tree {
     )
   }
 
+  private def altScreen(implicit ctx: Context) = div(cls := "leaf")(
+    h2("Your account was closed by moderators."),
+    div(cls := "content")(
+      p("Did you create multiple accounts? If so, remember that you promised not to, on the sign up page."),
+      p(
+        "If you violated the terms of service on a previous account, then you are not allowed to make a new one, ",
+        "unless it was explicitely allowed by the moderation team during an appeal."
+      ),
+      p(
+        "If you never violated the terms of service, and didn't make several accounts, then you can appeal this account closure:"
+      )
+    ),
+    newAppeal()
+  )
+
   def apply(me: User, playban: Boolean)(implicit ctx: Context) =
     bits.layout("Appeal a moderation decision") {
       val query = isGranted(_.Appeals) ?? ctx.req.queryString.toMap
       main(cls := "page page-small box box-pad appeal")(
         h1("Appeal"),
         div(cls := "nav-tree")(
-          renderNode(
-            {
-              if (playban || query.contains("playban")) playbanMenu
-              else if (me.marks.engine || query.contains("engine")) engineMenu
-              else if (me.marks.boost || query.contains("boost")) boostMenu
-              else if (me.marks.troll || query.contains("shadowban")) muteMenu
-              else cleanMenu
-            },
-            none
-          )
+          if ((me.disabled && me.marks.alt) || query.contains("alt")) altScreen
+          else
+            renderNode(
+              {
+                if (playban || query.contains("playban")) playbanMenu
+                else if (me.marks.engine || query.contains("engine")) engineMenu
+                else if (me.marks.boost || query.contains("boost")) boostMenu
+                else if (me.marks.troll || query.contains("shadowban")) muteMenu
+                else cleanMenu
+              },
+              none
+            )
         ),
         div(cls := "appeal__rules")(
           p(cls := "text", dataIcon := "")(doNotMessageModerators()),

--- a/app/views/base/layout.scala
+++ b/app/views/base/layout.scala
@@ -279,7 +279,7 @@ object layout {
               "is3d"    -> ctx.pref.is3d
             )
           )(body),
-          ctx.isAuth option div(
+          ctx.me.exists(_.enabled) option div(
             id := "friend_box",
             dataI18n := safeJsonValue(i18nJsObject(i18nKeys))
           )(
@@ -344,15 +344,20 @@ object layout {
             )
           ),
           ctx.blind option h2("Navigation"),
-          topnav()
+          !ctx.isAppealUser option topnav()
         ),
         div(cls := "site-buttons")(
-          clinput,
+          !ctx.isAppealUser option clinput,
           reports,
           teamRequests,
-          ctx.me map { me =>
-            frag(allNotifications, dasher(me))
-          } getOrElse { !ctx.pageData.error option anonDasher(playing) }
+          if (ctx.isAppealUser)
+            postForm(action := routes.Auth.logout)(
+              submitButton(cls := "button button-red link")(trans.logOut())
+            )
+          else
+            ctx.me map { me =>
+              frag(allNotifications, dasher(me))
+            } getOrElse { !ctx.pageData.error option anonDasher(playing) }
         )
       )
   }

--- a/modules/common/src/main/HTTPRequest.scala
+++ b/modules/common/src/main/HTTPRequest.scala
@@ -109,6 +109,8 @@ object HTTPRequest {
     }
   }
 
+  def isAppeal(req: RequestHeader) = req.path.startsWith("/appeal")
+
   def clientName(req: RequestHeader) =
     // the mobile app sends XHR headers
     if (isXhr(req)) apiVersion(req).fold("xhr") { v =>

--- a/modules/security/src/main/Granter.scala
+++ b/modules/security/src/main/Granter.scala
@@ -5,10 +5,10 @@ import lila.user.{ Holder, User }
 object Granter {
 
   def apply(permission: Permission)(user: User): Boolean =
-    apply(permission, user.roles)
+    user.enabled && apply(permission, user.roles)
 
   def apply(f: Permission.Selector)(user: User): Boolean =
-    apply(f(Permission), user.roles)
+    user.enabled && apply(f(Permission), user.roles)
 
   def is(permission: Permission)(holder: Holder): Boolean =
     apply(permission)(holder.user)

--- a/modules/security/src/main/MagicLink.scala
+++ b/modules/security/src/main/MagicLink.scala
@@ -44,7 +44,7 @@ ${Mailgun.txt.serviceNote}
 
   def confirm(token: String): Fu[Option[User]] =
     tokener read token flatMap { _ ?? userRepo.byId } map {
-      _.filter(_.canLogin)
+      _.filter(_.canFullyLogin)
     }
 
   private val tokener = LoginToken.makeTokener(tokenerSecret, 10 minutes)

--- a/modules/security/src/main/PasswordReset.scala
+++ b/modules/security/src/main/PasswordReset.scala
@@ -46,7 +46,7 @@ ${Mailgun.txt.serviceNote}
 
   def confirm(token: String): Fu[Option[User]] =
     tokener read token flatMap { _ ?? userRepo.byId } map {
-      _.filter(_.canLogin)
+      _.filter(_.canFullyLogin)
     }
 
   private val tokener = new StringToken[User.ID](

--- a/modules/security/src/main/model.scala
+++ b/modules/security/src/main/model.scala
@@ -17,6 +17,8 @@ case class AuthInfo(user: User.ID, hasFp: Boolean)
 
 case class FingerPrintedUser(user: User, hasFingerPrint: Boolean)
 
+case class AppealUser(user: User)
+
 case class UserSession(
     _id: String,
     ip: IpAddress,

--- a/modules/user/src/main/Authenticator.scala
+++ b/modules/user/src/main/Authenticator.scala
@@ -59,7 +59,7 @@ final class Authenticator(
   private def loginCandidate(select: Bdoc): Fu[Option[User.LoginCandidate]] =
     userRepo.coll.one[AuthData](select, authProjection)(AuthDataBSONHandler) zip userRepo.coll
       .one[User](select) map {
-      case (Some(authData), Some(user)) if user.canLogin =>
+      case (Some(authData), Some(user)) =>
         User.LoginCandidate(user, authWithBenefits(authData)).some
       case _ => none
     }

--- a/modules/user/src/main/User.scala
+++ b/modules/user/src/main/User.scala
@@ -36,7 +36,7 @@ case class User(
   override def hashCode: Int = id.hashCode
 
   override def toString =
-    s"User $username(${perfs.bestRating}) games:${count.game}${marks.troll ?? " troll"}${marks.engine ?? " engine"}"
+    s"User $username(${perfs.bestRating}) games:${count.game}${marks.troll ?? " troll"}${marks.engine ?? " engine"}${!enabled ?? " closed"}"
 
   def light = LightUser(id = id, name = username, title = title.map(_.value), isPatron = isPatron)
 
@@ -79,7 +79,7 @@ case class User(
   def lameOrAlt        = lame || marks.alt
   def lameOrTrollOrAlt = lameOrTroll || marks.alt
 
-  def canLogin = enabled || !lameOrTrollOrAlt
+  def canFullyLogin = enabled || !lameOrTrollOrAlt
 
   def withMarks(f: UserMarks => UserMarks) = copy(marks = f(marks))
 

--- a/modules/user/src/main/UserContext.scala
+++ b/modules/user/src/main/UserContext.scala
@@ -61,6 +61,7 @@ trait UserContextWrapper extends UserContext {
   val impersonatedBy = userContext.impersonatedBy
   def isBot          = me.exists(_.isBot)
   def noBot          = !isBot
+  def isAppealUser   = me.exists(!_.enabled)
 }
 
 object UserContext {

--- a/modules/user/src/main/UserMark.scala
+++ b/modules/user/src/main/UserMark.scala
@@ -31,7 +31,8 @@ case class UserMarks(value: List[UserMark]) extends AnyVal {
   def alt                   = apply(UserMark.Alt)
 
   def nonEmpty = value.nonEmpty option this
-  def clean    = !value.exists(UserMark.bannable.contains)
+  def dirty    = value.exists(UserMark.bannable.contains)
+  def clean    = !dirty
 
   def set(sel: UserMark.type => UserMark, v: Boolean) =
     UserMarks {


### PR DESCRIPTION
The auth is only in heap, lasts at most 7 days or until the next deploy.

Only requests which path start with `/appeal` are authorized.

Websockets are considered anonymous.