### PR TITLE
Fix simul editing for titled players

### DIFF
--- a/modules/simul/src/main/Simul.scala
+++ b/modules/simul/src/main/Simul.scala
@@ -27,7 +27,8 @@ case class Simul(
     hostSeenAt: Option[DateTime],
     color: Option[String],
     text: String,
-    team: Option[String]
+    team: Option[String],
+    featurable: Option[Boolean]
 ) {
   def id = _id
 
@@ -152,7 +153,8 @@ object Simul {
       position: Option[FEN],
       color: String,
       text: String,
-      team: Option[String]
+      team: Option[String],
+      featurable: Option[Boolean]
   ): Simul =
     Simul(
       _id = lila.common.ThreadLocalRandom nextString 8,
@@ -180,6 +182,7 @@ object Simul {
       hostSeenAt = DateTime.now.some,
       color = color.some,
       text = text,
-      team = team
+      team = team,
+      featurable = featurable
     )
 }

--- a/modules/simul/src/main/SimulApi.scala
+++ b/modules/simul/src/main/SimulApi.scala
@@ -58,9 +58,10 @@ final class SimulApi(
       host = me,
       color = setup.color,
       text = setup.text,
-      team = setup.team
+      team = setup.team,
+      featurable = some(~setup.featured && canBeFeatured(me))
     )
-    repo.create(simul, canBeFeatured(me) && ~setup.featured) >>- publish() >>- {
+    repo.create(simul) >>- publish() >>- {
       timeline ! (Propagate(SimulCreate(me.id, simul.id, simul.fullName)) toFollowersOf me.id)
     } inject simul
   }
@@ -73,9 +74,10 @@ final class SimulApi(
       position = setup.realPosition,
       color = setup.color.some,
       text = setup.text,
-      team = setup.team
+      team = setup.team,
+      featurable = some(~setup.featured && canBeFeatured(me))
     )
-    repo.update(simul, some(canBeFeatured(me) && ~setup.featured)) >>- publish() inject simul
+    repo.update(simul) >>- publish() inject simul
   }
 
   private def canBeFeatured(user: User) = user.hasTitle && !user.lameOrTroll
@@ -271,7 +273,7 @@ final class SimulApi(
     }
 
   private def update(simul: Simul): Funit =
-    repo.update(simul, none) >>- socket.reload(simul.id) >>- publish()
+    repo.update(simul) >>- socket.reload(simul.id) >>- publish()
 
   private def WithSimul(
       finding: Simul.ID => Fu[Option[Simul]],

--- a/modules/simul/src/main/SimulForm.scala
+++ b/modules/simul/src/main/SimulForm.scala
@@ -80,7 +80,7 @@ object SimulForm {
       color = simul.color | "random",
       text = simul.text,
       team = simul.team,
-      featured = host.hasTitle.some
+      featured = simul.featurable
     )
 
   private def baseForm(host: User, teams: List[LeaderTeam]) =

--- a/modules/simul/src/main/SimulRepo.scala
+++ b/modules/simul/src/main/SimulRepo.scala
@@ -118,18 +118,16 @@ final private[simul] class SimulRepo(val coll: Coll)(implicit ec: scala.concurre
   def allNotFinished =
     coll.list[Simul]($doc("status" $ne SimulStatus.Finished.id))
 
-  def create(simul: Simul, featurable: Boolean): Funit =
+  def create(simul: Simul): Funit =
     coll.insert one {
-      SimulBSONHandler.writeTry(simul).get ++ featurable.??(featurableSelect)
+      SimulBSONHandler.writeTry(simul).get
     } void
 
-  def update(simul: Simul, featurable: Option[Boolean]) =
+  def update(simul: Simul) =
     coll.update
       .one(
         $id(simul.id),
-        $set(SimulBSONHandler writeTry simul get) ++ featurable.?? { feat =>
-          if (feat) $set(featurableSelect) else $unset("featurable")
-        }
+        $set(SimulBSONHandler writeTry simul get)
       )
       .void
 


### PR DESCRIPTION
Actually makes it possible to update whether a simul is featured and correctly displays the current featured status in the settings.

For some reason, this also seems to fix a current bug where titled players can't update their simuls after creating them, at least not when the simul is set as featureable (at least that seems to be what's causing the issue).

I assume it's related to [this part of the code](https://github.com/ornicar/lila/pull/8537/files#diff-e6e9a3250fb6ce30c70426d60fc1ea60ddc20de2572fa6b9010cf2ea0a19a131L130).