### PR TITLE
restyle training themes page, add transtions

### DIFF
--- a/ui/puzzle/css/_page.scss
+++ b/ui/puzzle/css/_page.scss
@@ -21,8 +21,11 @@
 
   &__link {
     @extend %box-radius;
+    @include transition;
 
+    color: $c-font;
     display: flex;
+    align-items: center;
     padding: 1.5em 1em 1.5em 0;
 
     &::before {

--- a/ui/puzzle/css/_page.scss
+++ b/ui/puzzle/css/_page.scss
@@ -23,6 +23,7 @@
     @extend %box-radius;
 
     display: flex;
+    align-items: center;
     padding: 1.5em 1em 1.5em 0;
 
     &::before {

--- a/ui/puzzle/css/_page.scss
+++ b/ui/puzzle/css/_page.scss
@@ -21,11 +21,8 @@
 
   &__link {
     @extend %box-radius;
-    @include transition;
 
-    color: $c-font;
     display: flex;
-    align-items: center;
     padding: 1.5em 1em 1.5em 0;
 
     &::before {


### PR DESCRIPTION
Restyles training themes page so that the text is only blue when you hover over it, consistent with the style of other pages. Also aligns the text with the icons. Lastly, it adds transitions to the hover effect to be consistent with other pages. All changes have been tested.

Screenshots below.

**BEFORE ("Openings" is hovered)**
![1617440350](https://user-images.githubusercontent.com/1687121/113473724-a944a280-94ae-11eb-81a7-c3361a4d67af.png)


**AFTER ("Openings" is hovered)**
![1617440162](https://user-images.githubusercontent.com/1687121/113473716-9cc04a00-94ae-11eb-9681-30ac570b46a4.png)

If a portion of this PR is unwanted, feel free to comment and I can update.