### PR TITLE
added report forum post shortcut (reports user)

### DIFF
--- a/app/controllers/Report.scala
+++ b/app/controllers/Report.scala
@@ -160,7 +160,7 @@ final class Report(
               case (Some(u), Some(pid)) =>  form.fill(lila.report.ReportSetup(user=u.light, "", text=pid, "", ""))
               case _ =>  form
             }
-            Ok(html.report.form(form, user, captcha))
+            Ok(html.report.form(form, user, captcha)).pp("form")
           }
       }
     }

--- a/app/controllers/Report.scala
+++ b/app/controllers/Report.scala
@@ -9,6 +9,8 @@ import lila.common.HTTPRequest
 import lila.report.{ Room, Report => ReportModel, Mod => AsMod, Reporter, Suspect }
 import lila.user.{ User => UserModel, Holder }
 
+import play.api.data._
+
 final class Report(
     env: Env,
     userC: => User,
@@ -154,6 +156,10 @@ final class Report(
         if (user.map(_.id) has UserModel.lichessId) Redirect(routes.Main.contact).fuccess
         else
           env.report.forms.createWithCaptcha map { case (form, captcha) =>
+            val filledForm: Form[lila.report.ReportSetup] = (user, get("postUrl")) match {
+              case (Some(u), Some(pid)) =>  form.fill(lila.report.ReportSetup(user=u.light, "", text=pid, "", ""))
+              case _ =>  form
+            }
             Ok(html.report.form(form, user, captcha))
           }
       }

--- a/app/controllers/Report.scala
+++ b/app/controllers/Report.scala
@@ -160,7 +160,7 @@ final class Report(
               case (Some(u), Some(pid)) =>  form.fill(lila.report.ReportSetup(user=u.light, "", text=pid, "", ""))
               case _ =>  form
             }
-            Ok(html.report.form(form, user, captcha)).pp("form")
+            Ok(html.report.form(filledForm, user, captcha))
           }
       }
     }

--- a/app/views/forum/post.scala
+++ b/app/views/forum/post.scala
@@ -78,7 +78,7 @@ object post {
                 a(
                   titleOrText(trans.reportXToModerators.txt(userId)),
                   cls := "mod report button button-empty",
-                  href := s"${routes.Report.form}?username=${userId}&postUrl=${post.categId}%2F${topic.name}%23${post.number}",
+                  href := s"${routes.Report.form}?username=${userId}&postUrl=lichess.org%2Fforum%2F${post.categId}%2F${topic.name}%23${post.number}",
                   dataIcon := "!"
                 )
             }

--- a/app/views/forum/post.scala
+++ b/app/views/forum/post.scala
@@ -78,7 +78,7 @@ object post {
                 a(
                   titleOrText(trans.reportXToModerators.txt(userId)),
                   cls := "mod report button button-empty",
-                  href := s"${routes.Report.form}?username=${userId}",
+                  href := s"${routes.Report.form}?username=${userId}&postUrl=${post.categId}/${topic.name}#${post.number}",
                   dataIcon := "!"
                 )
             }

--- a/app/views/forum/post.scala
+++ b/app/views/forum/post.scala
@@ -78,7 +78,7 @@ object post {
                 a(
                   titleOrText(trans.reportXToModerators.txt(userId)),
                   cls := "mod report button button-empty",
-                  href := s"${routes.Report.form}?username=${userId}&postUrl=lichess.org%2Fforum%2F${post.categId}%2F${topic.name}%23${post.number}",
+                  href := s"${routes.Report.form}?username=${userId}&postUrl=${netBaseUrl}${routes.ForumPost.redirect(post.id).url}",
                   dataIcon := "!"
                 )
             }

--- a/app/views/forum/post.scala
+++ b/app/views/forum/post.scala
@@ -72,7 +72,14 @@ object post {
               dataIcon := "q",
               title := "Delete"
             )
-          else emptyFrag
+          else {
+            a(
+              titleOrText(trans.reportXToModerators.txt(post.userId.get)),
+              cls := "mod report button button-empty",
+              href := s"${routes.Report.form}?username=${post.userId.get}",
+              dataIcon := "!"
+            )
+          }
         ),
         a(cls := "anchor", href := url)(s"#${post.number}")
       ),

--- a/app/views/forum/post.scala
+++ b/app/views/forum/post.scala
@@ -72,14 +72,16 @@ object post {
               dataIcon := "q",
               title := "Delete"
             )
-          else {
-            a(
-              titleOrText(trans.reportXToModerators.txt(post.userId.get)),
-              cls := "mod report button button-empty",
-              href := s"${routes.Report.form}?username=${post.userId.get}",
-              dataIcon := "!"
-            )
-          }
+          else
+            post.userId map {
+              userId =>
+                a(
+                  titleOrText(trans.reportXToModerators.txt(userId)),
+                  cls := "mod report button button-empty",
+                  href := s"${routes.Report.form}?username=${userId}",
+                  dataIcon := "!"
+                )
+            }
         ),
         a(cls := "anchor", href := url)(s"#${post.number}")
       ),

--- a/app/views/forum/post.scala
+++ b/app/views/forum/post.scala
@@ -78,7 +78,7 @@ object post {
                 a(
                   titleOrText(trans.reportXToModerators.txt(userId)),
                   cls := "mod report button button-empty",
-                  href := s"${routes.Report.form}?username=${userId}&postUrl=${post.categId}/${topic.name}#${post.number}",
+                  href := s"${routes.Report.form}?username=${userId}&postUrl=${post.categId}%2F${topic.name}%23${post.number}",
                   dataIcon := "!"
                 )
             }

--- a/modules/report/src/main/ReportForm.scala
+++ b/modules/report/src/main/ReportForm.scala
@@ -68,7 +68,7 @@ private[report] case class ReportFlag(
     text: String
 )
 
-private[report] case class ReportSetup(
+case class ReportSetup(
     user: LightUser,
     reason: String,
     text: String,


### PR DESCRIPTION
for closing https://github.com/ornicar/lila/issues/6869

Ideally it would auto populate with the post text or the post link but I couldn't work out how to edit the form pre-fill.

I looked at appeal for inspiration where the preset message was just an argument passed to the render function but wasn't sure where to start with modifying form3.textarea.