### PR TITLE
align user-link in profile page

### DIFF
--- a/ui/common/css/component/_user-link.scss
+++ b/ui/common/css/component/_user-link.scss
@@ -1,5 +1,7 @@
 .user-link {
   @extend %nowrap-hidden;
+  display: flex;
+  align-items: center;
 
   color: $c-font;
 


### PR DESCRIPTION
Aligns the user link with the online/offline icon on the user profile page, as below.

**Before**             |  **After**
:-------------------------:|:-------------------------:
![1617486574](https://user-images.githubusercontent.com/1687121/113492403-70daae00-951a-11eb-8d2c-ac17612a9ae8.png) |  ![1617486579](https://user-images.githubusercontent.com/1687121/113492406-73d59e80-951a-11eb-81a1-f66cf79b911e.png)
