### PR TITLE
remove the hack for chrome which causes compatibility issues

### DIFF
--- a/ui/common/css/component/_board.scss
+++ b/ui/common/css/component/_board.scss
@@ -14,8 +14,3 @@
 .mini-game .cg-wrap {
   @extend %square;
 }
-
-.cg-wrap,
-.mini-game .cg-wrap {
-  display: table; // part of hack to round to full pixel size in chrome
-}


### PR DESCRIPTION
To fix a problem I identified in issue #7525.

Lichess seems to be working in chrome even without the hack but is not correctly rendering in some other browsers because of the hack.

It will not be enough to run Lichess on iOS 10.3.3 because there are some scripts like `lichess.min.js` `analysisBoard.min.js` which are not transpiled in a compatible way for iOS 10. Those files only appear in lichess.org but not in the development environment, so I don't exactly know how to fix them.
