### PR TITLE
Fix #8555

### DIFF
--- a/ui/puzzle/src/xhr.ts
+++ b/ui/puzzle/src/xhr.ts
@@ -16,7 +16,7 @@ export function complete(
     body: xhr.form({
       win,
       ...(replay ? { replayDays: replay.days } : {}),
-      ...(streak ? { streakId: streak.nextId(), streakScore: streak.data.index + 1 } : {}),
+      ...(streak ? { streakId: streak.nextId(), streakScore: streak.data.index } : {}),
     }),
   });
 }


### PR DESCRIPTION
Almost makes it seem like it's intended? But given that the endpoint checks for `score > 0` (https://github.com/ornicar/lila/blob/master/app/controllers/Puzzle.scala#L132) it doesn't look right and it obviously also doesn't make sense logically.

Another question would be whether the current values in the database should be corrected (i.e. reduced by one and probably entries with a then zero score removed)? It probably doesn't matter that much since even very good high scores are likely to be beaten in the future but if it's easy to do it might still be worth it.