### PR TITLE
Add 'download' attribute to PGN download links

### DIFF
--- a/app/ui/scalatags.scala
+++ b/app/ui/scalatags.scala
@@ -24,6 +24,8 @@ trait ScalatagsAttrs {
   val datetimeAttr   = attr("datetime")
   val dataBotAttr    = attr("data-bot").empty
   val deferAttr      = attr("defer").empty
+  val downloadAttr   = attr("download").empty
+
   object frame {
     val scrolling       = attr("scrolling")
     val allowfullscreen = attr("allowfullscreen").empty

--- a/app/views/analyse/replay.scala
+++ b/app/views/analyse/replay.scala
@@ -46,16 +46,17 @@ object replay {
       )
     }
     val pgnLinks = div(
-      a(dataIcon := "x", cls := "text", href := s"${routes.Game.exportOne(game.id)}?literate=1")(
+      a(dataIcon := "x", cls := "text", href := s"${routes.Game.exportOne(game.id)}?literate=1", download := true)(
         trans.downloadAnnotated()
       ),
-      a(dataIcon := "x", cls := "text", href := s"${routes.Game.exportOne(game.id)}?evals=0&clocks=0")(
+      a(dataIcon := "x", cls := "text", href := s"${routes.Game.exportOne(game.id)}?evals=0&clocks=0", download := true)(
         trans.downloadRaw()
       ),
       game.isPgnImport option a(
         dataIcon := "x",
         cls := "text",
-        href := s"${routes.Game.exportOne(game.id)}?imported=1"
+        href := s"${routes.Game.exportOne(game.id)}?imported=1",
+        download := true
       )(trans.downloadImported()),
       ctx.noBlind option frag(
         a(dataIcon := "=", cls := "text embed-howto")(trans.embedInYourWebsite()),

--- a/app/views/analyse/replay.scala
+++ b/app/views/analyse/replay.scala
@@ -46,17 +46,17 @@ object replay {
       )
     }
     val pgnLinks = div(
-      a(dataIcon := "x", cls := "text", href := s"${routes.Game.exportOne(game.id)}?literate=1", download := true)(
+      a(dataIcon := "x", cls := "text", href := s"${routes.Game.exportOne(game.id)}?literate=1", downloadAttr)(
         trans.downloadAnnotated()
       ),
-      a(dataIcon := "x", cls := "text", href := s"${routes.Game.exportOne(game.id)}?evals=0&clocks=0", download := true)(
+      a(dataIcon := "x", cls := "text", href := s"${routes.Game.exportOne(game.id)}?evals=0&clocks=0", downloadAttr)(
         trans.downloadRaw()
       ),
       game.isPgnImport option a(
         dataIcon := "x",
         cls := "text",
         href := s"${routes.Game.exportOne(game.id)}?imported=1",
-        download := true
+        downloadAttr
       )(trans.downloadImported()),
       ctx.noBlind option frag(
         a(dataIcon := "=", cls := "text embed-howto")(trans.embedInYourWebsite()),

--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -114,7 +114,8 @@ object header {
               cls := "btn-rack__btn",
               href := routes.Game.exportByUser(u.username),
               titleOrText(trans.exportGames.txt()),
-              dataIcon := "x"
+              dataIcon := "x",
+              downloadAttr
             )
           else
             (ctx.isAuth && ctx.noKid) option a(

--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -122,6 +122,7 @@ export function view(ctrl: StudyShareCtrl): VNode {
           attrs: {
             'data-icon': 'x',
             href: `/study/${studyId}/${chapter.id}.gif`,
+            download: true,
           },
         },
         'GIF'

--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -100,6 +100,7 @@ export function view(ctrl: StudyShareCtrl): VNode {
           attrs: {
             'data-icon': 'x',
             href: `/study/${studyId}.pgn`,
+            download: true,
           },
         },
         ctrl.trans.noarg(ctrl.relay ? 'downloadAllGames' : 'studyPgn')
@@ -110,6 +111,7 @@ export function view(ctrl: StudyShareCtrl): VNode {
           attrs: {
             'data-icon': 'x',
             href: `/study/${studyId}/${chapter.id}.pgn`,
+            download: true,
           },
         },
         ctrl.trans.noarg(ctrl.relay ? 'downloadGame' : 'chapterPgn')

--- a/ui/swiss/src/view/main.ts
+++ b/ui/swiss/src/view/main.ts
@@ -261,6 +261,7 @@ function stats(ctrl: SwissCtrl): VNode | undefined {
               attrs: {
                 'data-icon': 'x',
                 href: `/swiss/${ctrl.data.id}.trf`,
+                download: true,
               },
             },
             'Download TRF file'
@@ -271,6 +272,7 @@ function stats(ctrl: SwissCtrl): VNode | undefined {
               attrs: {
                 'data-icon': 'x',
                 href: `/api/swiss/${ctrl.data.id}/games`,
+                download: true,
               },
             },
             'Download all games'
@@ -281,6 +283,7 @@ function stats(ctrl: SwissCtrl): VNode | undefined {
               attrs: {
                 'data-icon': 'x',
                 href: `/api/swiss/${ctrl.data.id}/results`,
+                download: true,
               },
             },
             'Download results'

--- a/ui/tournament/src/view/finished.ts
+++ b/ui/tournament/src/view/finished.ts
@@ -59,6 +59,7 @@ function stats(data: TournamentData, trans: Trans): VNode {
           attrs: {
             'data-icon': 'x',
             href: `/api/tournament/${data.id}/games`,
+            download: true,
           },
         },
         'Download all games'
@@ -69,6 +70,7 @@ function stats(data: TournamentData, trans: Trans): VNode {
           attrs: {
             'data-icon': 'x',
             href: `/api/tournament/${data.id}/results`,
+            download: true,
           },
         },
         'Download results'


### PR DESCRIPTION
In order to silence Chrome warning: "Resource interpreted as Document but transferred with MIME type application/x-chess-pgn"

Though, according to [caniuse](https://caniuse.com/download), it doesn't seem to have support for moderately old Safari on iOS. Not sure whether that's relevant. If it is, it seems using `target="_blank"` is a (somewhat weird) alternative.

Also, I found a weird discrepancy between GIF downloads. Using the GIF share on an old game's analysis opens the GIF in a new tab (the link has `target="_blank"` and no `content-disposition` header is sent with the response).

However, GIF downloads in studies send `content-disposition: attachment` and don't have a `target` attribute which results in the GIF getting downloaded immediately and also triggers the above warning in Chrome.

It seems sensible to unify this behavior, although I'm not sure which one should be used. I guess opening in a tab is probably better? Since you can immediately view it and use drag and drop to move it to some applications but still download it simply via the context menu.