### PR TITLE
fix regex to check for titles in names (#8564)

### DIFF
--- a/modules/common/src/main/LameName.scala
+++ b/modules/common/src/main/LameName.scala
@@ -10,7 +10,7 @@ object LameName {
   def tournament(name: String): Boolean = tournamentRegex find name
 
   private val lameTitlePrefix =
-    ".*[Ww]*[NCFIG1Lncfig1l]Mm.*".r.pattern
+    "_*[Ww]?[NCFIG1Lncfigl][Mm]_+|_+[Ww]?[NCFIG1Lncfigl][Mm]_*|(?<![A-Z])[W]?[NCFIG1L][M]".r.pattern
 
   private val baseWords = List(
     "1488",

--- a/modules/common/src/main/LameName.scala
+++ b/modules/common/src/main/LameName.scala
@@ -10,7 +10,7 @@ object LameName {
   def tournament(name: String): Boolean = tournamentRegex find name
 
   private val lameTitlePrefix =
-    "[Ww]?+[NCFIGl1L]M|(?i:w?+[ncfigl1])m[-_A-Z0-9]".r.pattern
+    ".*[Ww]*[NCFIG1Lncfig1l]Mm.*".r.pattern
 
   private val baseWords = List(
     "1488",


### PR DESCRIPTION
Fixes #8564.

This change changes the lameTitlePrefix regex to include characters before it. This has a consequence that no new players will be able to have "fm", "gm", "wlm", etc. in their name at all. However, it stops usernames such as "The_GM_Kasparov". You need to choose what you'd prefer, I suppose.

Examples of names that are no longer allowed:
The_GM_Kasparov
xGm_Kasparovx
yFMy
I_Am_A_FM_Definitely
zFM_I_Like_Piez
almamater
asdnmasdf
elmolovesyou