### PR TITLE
Actually fix username contains title check

### DIFF
--- a/modules/common/src/main/LameName.scala
+++ b/modules/common/src/main/LameName.scala
@@ -5,12 +5,20 @@ import scala.util.matching.Regex
 object LameName {
 
   def username(name: String): Boolean =
-    usernameRegex.find(name.replaceIf('_', "")) || containsTitlePattern.matcher(name).lookingAt
+    usernameRegex.find(name.replaceIf('_', "")) || containsTitleRegex.matches(name)
 
   def tournament(name: String): Boolean = tournamentRegex find name
 
-  private val containsTitlePattern =
-    "_*[Ww]?[NCFIG1Lncfigl][Mm]_+|_+[Ww]?[NCFIG1Lncfigl][Mm]_*|(?<![A-Z])[W]?[NCFIG1L][M]".r.pattern
+  private val titlePattern = "W*(?:[NCFI1L]|I?G)"
+  private val containsTitleRegex = (
+    "^"
+    + "(?i:" + titlePattern + "M[^a-z].*)|"          // title at start, separated by non-letter
+    + "(?:(?i:" + titlePattern + ")m[^a-z].*)|"      // title at start with lowercase m, not followed by lowercase letter
+    + "(?i:.*[^a-z]" + titlePattern + "M)|"          // title at end, separated by non-letter
+    + "(?i:.*[^a-z]" + titlePattern + "M[^a-z].*)|"  // title in middle, surrounded non-letter
+    + "(?:(?:.*[^A-Z])?" + titlePattern + "M.*)"     // uppercase title not preceeded by uppercase letter
+    + "$"
+  ).r
 
   private val baseWords = List(
     "1488",

--- a/modules/common/src/main/LameName.scala
+++ b/modules/common/src/main/LameName.scala
@@ -14,11 +14,11 @@ object LameName {
     "^"
     + "(?i:" + titlePattern + "M[^a-z].*)|"                   // title at start, separated by non-letter
     + "(?:(?i:" + titlePattern + ")m[^a-z].*)|"               // title at start with lowercase m, not followed by lowercase letter
-    + "(?:" + titlePattern + "M.*)"                           // uppercase title at start
+    + "(?:" + titlePattern + "M.*)|"                          // uppercase title at start
     + "(?i:.*[^a-z]" + titlePattern + "M)|"                   // title at end, separated by non-letter
     + "(?i:.*[^a-z]" + titlePattern + "M[^a-z].*)|"           // title in middle, surrounded by non-letters
-    + "(?:.*[^A-Z]" + titlePattern + "M(?:[A-Z]?[^A-Z].*)?)"  // uppercase title not preceeded by uppercase letter, either at end or followed by at most one uppercase letter and then something else
-    + "$"
+    + "(?:.*[^A-Z]" + titlePattern + "M(?:[A-Z]?[^A-Z].*)?)"  // uppercase title not preceeded by uppercase letter,
+    + "$"                                                     //   either at end or followed by at most one uppercase letter and then something else
   ).r
 
   private val baseWords = List(

--- a/modules/common/src/main/LameName.scala
+++ b/modules/common/src/main/LameName.scala
@@ -12,11 +12,12 @@ object LameName {
   private val titlePattern = "W*(?:[NCFI1L]|I?G)"
   private val containsTitleRegex = (
     "^"
-    + "(?i:" + titlePattern + "M[^a-z].*)|"          // title at start, separated by non-letter
-    + "(?:(?i:" + titlePattern + ")m[^a-z].*)|"      // title at start with lowercase m, not followed by lowercase letter
-    + "(?i:.*[^a-z]" + titlePattern + "M)|"          // title at end, separated by non-letter
-    + "(?i:.*[^a-z]" + titlePattern + "M[^a-z].*)|"  // title in middle, surrounded non-letter
-    + "(?:(?:.*[^A-Z])?" + titlePattern + "M.*)"     // uppercase title not preceeded by uppercase letter
+    + "(?i:" + titlePattern + "M[^a-z].*)|"                   // title at start, separated by non-letter
+    + "(?:(?i:" + titlePattern + ")m[^a-z].*)|"               // title at start with lowercase m, not followed by lowercase letter
+    + "(?:" + titlePattern + "M.*)"                           // uppercase title at start
+    + "(?i:.*[^a-z]" + titlePattern + "M)|"                   // title at end, separated by non-letter
+    + "(?i:.*[^a-z]" + titlePattern + "M[^a-z].*)|"           // title in middle, surrounded by non-letters
+    + "(?:.*[^A-Z]" + titlePattern + "M(?:[A-Z]?[^A-Z].*)?)"  // uppercase title not preceeded by uppercase letter, either at end or followed by at most one uppercase letter and then something else
     + "$"
   ).r
 

--- a/modules/common/src/test/LameNameTest.scala
+++ b/modules/common/src/test/LameNameTest.scala
@@ -15,6 +15,8 @@ class LameNameTest extends Specification {
       test("gmFoobar") must beTrue
       test("gm007") must beTrue
       test("GmFoo") must beTrue
+      test("nm_brianmatthews") must beTrue
+      test("the_nm_brianmatthews") must beTrue
     }
     "uppercase titles" in {
       test("GMfoo") must beTrue
@@ -22,6 +24,10 @@ class LameNameTest extends Specification {
       test("WFMfoo") must beTrue
       test("WIMfoo") must beTrue
       test("1Mfoo") must beTrue
+      test("BriaNMatthews") must beTrue
+      test("NMBrianMatthews") must beTrue
+      test("BrianMatthews_NM") must beTrue
+      test("BrianMatthewsNM") must beTrue
     }
     "gross" in {
       test("Shit") must beTrue
@@ -44,6 +50,9 @@ class LameNameTest extends Specification {
       test("agm-foo") must beFalse
       test("atf90") must beFalse
       test("a_b") must beFalse
+      test("BRIANMATTHEWS") must beFalse
+      test("BrianMatthews") must beFalse
+      test("BrianMatthewsnm") must beFalse
     }
   }
 }

--- a/modules/common/src/test/LameNameTest.scala
+++ b/modules/common/src/test/LameNameTest.scala
@@ -28,6 +28,7 @@ class LameNameTest extends Specification {
       test("NMBrianMatthews") must beTrue
       test("BrianMatthews_NM") must beTrue
       test("BrianMatthewsNM") must beTrue
+      test("TheGMBrianMatthews") must beTrue
     }
     "gross" in {
       test("Shit") must beTrue
@@ -53,6 +54,7 @@ class LameNameTest extends Specification {
       test("BRIANMATTHEWS") must beFalse
       test("BrianMatthews") must beFalse
       test("BrianMatthewsnm") must beFalse
+      test("TheGMBRianMatthews") must beFalse
     }
   }
 }

--- a/modules/user/src/main/User.scala
+++ b/modules/user/src/main/User.scala
@@ -219,13 +219,13 @@ object User {
   implicit def playTimeHandler = reactivemongo.api.bson.Macros.handler[PlayTime]
 
   // what existing usernames are like
-  val historicalUsernameRegex = """(?i)[a-z0-9][\w-]{0,28}[a-z0-9]""".r
+  val historicalUsernameRegex = "(?i)[a-z0-9][a-z0-9_-]{0,28}[a-z0-9]".r
   // what new usernames should be like -- now split into further parts for clearer error messages
-  val newUsernameRegex   = """(?i)[a-z][\w-]{0,28}[a-z0-9]""".r
-  val newUsernamePrefix  = """(?i)[a-z].*""".r
-  val newUsernameSuffix  = """(?i).*[a-z0-9]""".r
-  val newUsernameChars   = """(?i)[\w-]*""".r
-  val newUsernameLetters = """(?i)^([a-z0-9][\w-]?)+$""".r
+  val newUsernameRegex   = "(?i)[a-z][a-z0-9_-]{0,28}[a-z0-9]".r
+  val newUsernamePrefix  = "(?i)^[a-z].*".r
+  val newUsernameSuffix  = "(?i).*[a-z0-9]$".r
+  val newUsernameChars   = "(?i)^[a-z0-9_-]*$".r
+  val newUsernameLetters = "(?i)^([a-z0-9][_-]?)+$".r
 
   def couldBeUsername(str: User.ID) = historicalUsernameRegex.matches(str)
 


### PR DESCRIPTION
Related: #8567 (caused test failure)

This implements the check discussed in the above PR but this time properly.

The changes to the `User` regexes are only stylistic since I find the regexes a bit clearer this way but I can revert them if you want.

Also, is there a reason for the `newUsernameChars` check? It seems like `newUsernameLetters` should already cover that and they both produce the same error message.