### PR TITLE
allow patrons to post in forums

### DIFF
--- a/modules/forum/src/main/Granter.scala
+++ b/modules/forum/src/main/Granter.scala
@@ -17,7 +17,7 @@ trait Granter {
 
   private def canForum(u: User) =
     !u.isBot && {
-      (u.count.game > 0 && u.createdSinceDays(2)) || u.hasTitle || u.isVerified
+      (u.count.game > 0 && u.createdSinceDays(2)) || u.hasTitle || u.isVerified || u.isPatron
     }
 
   def isGrantedMod(categSlug: String)(implicit ctx: UserContext): Fu[Boolean] =


### PR DESCRIPTION
According to #8582, some patrons aren't happy that they can't post in the forums without having played games (to prove they aren't a bot?). If they have donated, they are very likely not a bot and should be able to post in the forums. This PR allows patrons to post in the forums.