### PR TITLE
Add a noncolor indicator to `cmn-toggle`

### DIFF
--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -74,7 +74,7 @@
     @extend %data-icon;
     content: 'L';
     color: $c-bad;
-    padding-right: 1.05em
+    padding-right: 1.05em;
   }
 }
 
@@ -93,6 +93,6 @@
     @extend %data-icon;
     content: 'E';
     color: $c-good;
-    padding-right: 0.1em
+    padding-right: 0.1em;
   }
 }

--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -21,6 +21,10 @@
   background-color: $c-bad;
 }
 
+.cmn-toggle--subtle:not(:checked) + label {
+  background-color: $c-font-dimmer;
+}
+
 .cmn-toggle:checked + label {
   background-color: $c-good;
 }
@@ -40,10 +44,6 @@
 
 .cmn-toggle:focus + label {
   @extend %focus-shadow;
-}
-
-.cmn-toggle--subtle + label {
-  background-color: $c-font-dimmer;
 }
 
 .cmn-toggle:hover + label {
@@ -75,6 +75,12 @@
     content: 'L';
     color: $c-bad;
     padding-right: 1.1em
+  }
+}
+
+.cmn-toggle--subtle:not(:checked) + label {
+  &::before {
+    color: $c-font-dimmer;
   }
 }
 

--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -11,8 +11,8 @@
   -webkit-user-select: none;
   -moz-user-select: none;
   padding: 1px;
-  width: 42px;
-  height: 26px;
+  width: 40px;
+  height: 24px;
   border: 1px solid $c-border;
   border-radius: 24px;
 }
@@ -54,8 +54,8 @@
 .cmn-toggle + label::after {
   @extend %metal;
 
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   border-radius: 100%;
   box-shadow: 0 1px 2.5px rgba(0, 0, 0, 0.3);
   bottom: 0.1px;
@@ -69,5 +69,5 @@
 }
 
 .cmn-toggle:checked + label::after {
-  margin-left: 15px;
+  margin-left: 15.5px;
 }

--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -10,9 +10,6 @@
   outline: none;
   -webkit-user-select: none;
   -moz-user-select: none;
-}
-
-.cmn-toggle + label {
   padding: 1px;
   width: 40px;
   height: 24px;

--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -35,8 +35,7 @@
 .cmn-toggle + label::before {
   right: 1px;
   border-radius: 24px;
-  font-weight: bold;
-  color: if($theme-light, #fff, #ccc);
+  z-index: 1;
 }
 
 .cmn-toggle:focus + label {
@@ -72,18 +71,22 @@
 
 .cmn-toggle:not(:checked) + label {
   &::before {
-    content: '0';
-    padding-right: .35em;
+    @extend %data-icon;
+    content: 'L';
+    color: $c-bad;
+    padding-right: 1.1em
   }
 }
 
 .cmn-toggle:checked + label {
   &::after {
-  margin-left: 15.5px;
+    margin-left: 15.5px;
   }
 
   &::before {
-    content: '1';
-    padding-right: 1.6em;
+    @extend %data-icon;
+    content: 'E';
+    color: $c-good;
+    padding-right: 0.1em
   }
 }

--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -37,6 +37,7 @@
 }
 
 .cmn-toggle + label::before {
+  @extend %data-icon;
   right: 1px;
   border-radius: 24px;
   z-index: 1;
@@ -71,7 +72,6 @@
 
 .cmn-toggle:not(:checked) + label {
   &::before {
-    @extend %data-icon;
     content: 'L';
     color: $c-bad;
     padding-right: 1.05em;
@@ -90,7 +90,6 @@
   }
 
   &::before {
-    @extend %data-icon;
     content: 'E';
     color: $c-good;
     padding-right: 0.1em;

--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -11,9 +11,9 @@
   -webkit-user-select: none;
   -moz-user-select: none;
   padding: 1px;
-  width: 40px;
-  height: 24px;
-  background-color: $c-border;
+  width: 42px;
+  height: 26px;
+  border: 1px solid $c-border;
   border-radius: 24px;
 }
 
@@ -21,9 +21,7 @@
 .cmn-toggle + label::after {
   display: block;
   position: absolute;
-  top: 1px;
-  left: 1px;
-  bottom: 1px;
+  bottom: 0.1px;
   content: '';
 }
 
@@ -50,7 +48,8 @@
 .cmn-toggle + label::after {
   @extend %metal;
 
-  width: 22px;
+  width: 24px;
+  height: 24px;
   border-radius: 100%;
   box-shadow: 0 1px 2.5px rgba(0, 0, 0, 0.3);
 }

--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -35,6 +35,8 @@
 .cmn-toggle + label::before {
   right: 1px;
   border-radius: 24px;
+  font-weight: bold;
+  color: if($theme-light, #fff, #ccc);
 }
 
 .cmn-toggle:focus + label {
@@ -68,6 +70,20 @@
   @include transition(margin);
 }
 
-.cmn-toggle:checked + label::after {
+.cmn-toggle:not(:checked) + label {
+  &::before {
+    content: '0';
+    padding-right: .35em;
+  }
+}
+
+.cmn-toggle:checked + label {
+  &::after {
   margin-left: 15.5px;
+  }
+
+  &::before {
+    content: '1';
+    padding-right: 1.6em;
+  }
 }

--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -74,7 +74,7 @@
     @extend %data-icon;
     content: 'L';
     color: $c-bad;
-    padding-right: 1.1em
+    padding-right: 1.05em
   }
 }
 

--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -29,7 +29,6 @@
 .cmn-toggle + label::after {
   display: block;
   position: absolute;
-  bottom: 0.1px;
   content: '';
 }
 
@@ -59,6 +58,8 @@
   height: 24px;
   border-radius: 100%;
   box-shadow: 0 1px 2.5px rgba(0, 0, 0, 0.3);
+  bottom: 0.1px;
+  left: 0;
 }
 
 .cmn-toggle:hover + label::after {
@@ -68,5 +69,5 @@
 }
 
 .cmn-toggle:checked + label::after {
-  margin-left: 16px;
+  margin-left: 15px;
 }

--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -17,6 +17,14 @@
   border-radius: 24px;
 }
 
+.cmn-toggle:not(:checked) + label {
+  background-color: $c-bad;
+}
+
+.cmn-toggle:checked + label {
+  background-color: $c-good;
+}
+
 .cmn-toggle + label::before,
 .cmn-toggle + label::after {
   display: block;
@@ -27,19 +35,18 @@
 
 .cmn-toggle + label::before {
   right: 1px;
-  background-color: $c-bad;
   border-radius: 24px;
 }
 
-.cmn-toggle:focus + label::before {
+.cmn-toggle:focus + label {
   @extend %focus-shadow;
 }
 
-.cmn-toggle--subtle + label::before {
+.cmn-toggle--subtle + label {
   background-color: $c-font-dimmer;
 }
 
-.cmn-toggle:hover + label::before {
+.cmn-toggle:hover + label {
   @extend %focus-shadow;
 
   @include transition(background);
@@ -58,10 +65,6 @@
   @extend %metal-hover;
 
   @include transition(margin);
-}
-
-.cmn-toggle:checked + label::before {
-  background-color: $c-good;
 }
 
 .cmn-toggle:checked + label::after {


### PR DESCRIPTION
close https://github.com/ornicar/lila/issues/7667

I tried two version, putting the one I prefer first: 
![Screen Shot 2021-04-06 at 21 21 26](https://user-images.githubusercontent.com/56031107/113774448-3726c480-971f-11eb-8ea6-2c10d931331d.png)
![Screen Shot 2021-04-06 at 21 21 44](https://user-images.githubusercontent.com/56031107/113774456-3aba4b80-971f-11eb-8145-3c26770fea86.png)
![Screen Shot 2021-04-06 at 21 19 57](https://user-images.githubusercontent.com/56031107/113774569-5a517400-971f-11eb-9236-7ac8703f3f83.png)

Older version:
![Screen Shot 2021-04-06 at 20 59 16](https://user-images.githubusercontent.com/56031107/113774688-7fde7d80-971f-11eb-9279-48e48ad8655a.png)
![Screen Shot 2021-04-06 at 20 59 49](https://user-images.githubusercontent.com/56031107/113774835-b74d2a00-971f-11eb-91ff-c110f2128dc8.png)

Feedback welcome, I'm not a css expert