### PR TITLE
change cursor on form-label to text

### DIFF
--- a/ui/common/css/form/_form3.scss
+++ b/ui/common/css/form/_form3.scss
@@ -31,6 +31,7 @@
   font-weight: bold;
   display: inline-block;
   margin-bottom: 0.5rem;
+  cursor: text;
 }
 
 .form-control {


### PR DESCRIPTION
hovering over text should show a text cursor

this PR makes it so.