### PR TITLE
Create challenge list page

### DIFF
--- a/app/controllers/Challenge.scala
+++ b/app/controllers/Challenge.scala
@@ -442,4 +442,13 @@ final class Challenge(
         }
       }
     }
+
+  def toUser(username: String) =
+    Open { implicit ctx =>
+      OptionFuResult(env.user.repo.enabledNamed(username)) { user =>
+        api.createdByDestId(user.id) map { challenges =>
+          Ok(views.html.challenge.toUser(user, challenges))
+        }
+      }
+    }
 }

--- a/app/views/challenge/toUser.scala
+++ b/app/views/challenge/toUser.scala
@@ -1,0 +1,57 @@
+package views
+package html.challenge
+
+import controllers.routes
+
+import lila.api.Context
+import lila.app.templating.Environment._
+import lila.app.ui.ScalatagsTemplate._
+import lila.user.User
+import lila.challenge.Challenge
+
+object toUser {
+
+  def apply(user: User, challenges: List[Challenge])(implicit ctx: Context) = {
+    val name         = user.username
+    val challengeUrl = s"${routes.Lobby.home}?user=$name#friend"
+    views.html.base.layout(
+      title = s"Challenge to ${name}",
+      moreCss = cssTag("challenge.page")
+    )(
+      main(cls := "page-menu")(
+        div(cls := "page-menu__content challenge-list box")(
+          div(cls := "box__top")(
+            h1(
+              s"Challenge to ",
+              userLink(user)
+            ),
+            ctx.isAuth option div(cls := "box__top__actions")(
+              a(
+                href := challengeUrl,
+                cls := "button button-green text",
+                dataIcon := "O"
+              )("Create a challenge")
+            )
+          ),
+          table(cls := "slist slist-pad")(
+            tbody(
+              challenges.zipWithIndex.map { case (c, i) =>
+                tr(
+                  td(i + 1),
+                  td(
+                    userIdLink(c.challengerUserId),
+                    c.challengerUser.map(u => frag(" (", u.rating.show, ")"))
+                  ),
+                  td(modeName(c.mode)),
+                  td(c.clock.fold("No Clock")(_.show)),
+                  td(variantName(c.variant)),
+                  td(momentFromNow(c.createdAt))
+                )
+              }
+            )
+          )
+        )
+      )
+    )
+  }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -392,6 +392,7 @@ POST  /challenge/$id<\w{8}>/decline    controllers.Challenge.decline(id: String)
 POST  /challenge/$id<\w{8}>/cancel     controllers.Challenge.cancel(id: String)
 POST  /challenge/$id<\w{8}>/to-friend  controllers.Challenge.toFriend(id: String)
 POST  /challenge/rematch-of/$id<\w{8}> controllers.Challenge.rematchOf(id: String)
+GET   /challenge/to/:username          controllers.Challenge.toUser(username: String)
 
 # Notify
 GET /notify                            controllers.Notify.recent(page: Int ?= 1)

--- a/ui/challenge/css/build/_challenge.page.scss
+++ b/ui/challenge/css/build/_challenge.page.scss
@@ -1,3 +1,4 @@
 @import '../../../common/css/plugin';
 @import '../../../common/css/component/quote';
+@import '../../../common/css/component/slist';
 @import '../page';


### PR DESCRIPTION
I implemented a simple challenge list page, which looks like this:

![Screenshot from 2021-04-12 23-13-47](https://user-images.githubusercontent.com/4232207/114408717-aa7b7b00-9be4-11eb-939f-8035c3c7db76.png)

When I watch a viewer challenge stream, I sometimes see that stream/viewer having a trouble with challenge order, so I thought lichess having this page would help a situation little bit. Yet, I didn't find this type of feature request specifically, so my expectation might be off. Please let me know if this feature is worth included.

Also, functionality wise, users cannot accept/decline/cancel there challenges, so this page might be too simple to be useful. I would appreciate any feedback. Thanks!

EDIT:

Added user link:

![Screenshot from 2021-04-14 00-00-54](https://user-images.githubusercontent.com/4232207/114574647-65267e80-9cb4-11eb-86dd-426fca7918b6.png)

