### PR TITLE
adds a separator between ratings on profile page

### DIFF
--- a/app/views/user/show/side.scala
+++ b/app/views/user/show/side.scala
@@ -70,7 +70,7 @@ object side {
         showPerf(u.perfs.rapid, PerfType.Rapid),
         showPerf(u.perfs.classical, PerfType.Classical),
         showPerf(u.perfs.correspondence, PerfType.Correspondence),
-        if (!u.hasVariantRating) hr,
+        if (u.hasVariantRating) hr,
         showNonEmptyPerf(u.perfs.crazyhouse, PerfType.Crazyhouse),
         showNonEmptyPerf(u.perfs.chess960, PerfType.Chess960),
         showNonEmptyPerf(u.perfs.kingOfTheHill, PerfType.KingOfTheHill),

--- a/app/views/user/show/side.scala
+++ b/app/views/user/show/side.scala
@@ -70,7 +70,7 @@ object side {
         showPerf(u.perfs.rapid, PerfType.Rapid),
         showPerf(u.perfs.classical, PerfType.Classical),
         showPerf(u.perfs.correspondence, PerfType.Correspondence),
-        if (u.hasVariantRating) hr,
+        u.hasVariantRating option hr,
         showNonEmptyPerf(u.perfs.crazyhouse, PerfType.Crazyhouse),
         showNonEmptyPerf(u.perfs.chess960, PerfType.Chess960),
         showNonEmptyPerf(u.perfs.kingOfTheHill, PerfType.KingOfTheHill),

--- a/app/views/user/show/side.scala
+++ b/app/views/user/show/side.scala
@@ -70,7 +70,7 @@ object side {
         showPerf(u.perfs.rapid, PerfType.Rapid),
         showPerf(u.perfs.classical, PerfType.Classical),
         showPerf(u.perfs.correspondence, PerfType.Correspondence),
-        br,
+        if (!u.hasVariantRating) hr,
         showNonEmptyPerf(u.perfs.crazyhouse, PerfType.Crazyhouse),
         showNonEmptyPerf(u.perfs.chess960, PerfType.Chess960),
         showNonEmptyPerf(u.perfs.kingOfTheHill, PerfType.KingOfTheHill),
@@ -79,8 +79,8 @@ object side {
         showNonEmptyPerf(u.perfs.atomic, PerfType.Atomic),
         showNonEmptyPerf(u.perfs.horde, PerfType.Horde),
         showNonEmptyPerf(u.perfs.racingKings, PerfType.RacingKings),
-        br,
         u.noBot option frag(
+          hr,
           showPerf(u.perfs.puzzle, PerfType.Puzzle),
           showStorm(u.perfs.storm, u),
           showRacer(u.perfs.racer, u),

--- a/modules/user/src/main/User.scala
+++ b/modules/user/src/main/User.scala
@@ -55,6 +55,8 @@ case class User(
 
   def titleUsername = title.fold(username)(t => s"$t $username")
 
+  def hasVariantRating = List(perfs.crazyhouse, perfs.chess960, perfs.kingOfTheHill, perfs.threeCheck, perfs.antichess, perfs.atomic, perfs.horde, perfs.racingKings).map(_.isEmpty).contains(true)
+
   def titleUsernameWithBestRating =
     title.fold(usernameWithBestRating) { t =>
       s"$t $usernameWithBestRating"

--- a/modules/user/src/main/User.scala
+++ b/modules/user/src/main/User.scala
@@ -55,7 +55,16 @@ case class User(
 
   def titleUsername = title.fold(username)(t => s"$t $username")
 
-  def hasVariantRating = List(perfs.crazyhouse, perfs.chess960, perfs.kingOfTheHill, perfs.threeCheck, perfs.antichess, perfs.atomic, perfs.horde, perfs.racingKings).map(_.isEmpty).contains(true)
+  def hasVariantRating = List(
+    perfs.crazyhouse,
+    perfs.chess960,
+    perfs.kingOfTheHill,
+    perfs.threeCheck,
+    perfs.antichess,
+    perfs.atomic,
+    perfs.horde,
+    perfs.racingKings
+  ).map(_.isEmpty).contains(true)
 
   def titleUsernameWithBestRating =
     title.fold(usernameWithBestRating) { t =>

--- a/modules/user/src/main/User.scala
+++ b/modules/user/src/main/User.scala
@@ -55,16 +55,7 @@ case class User(
 
   def titleUsername = title.fold(username)(t => s"$t $username")
 
-  def hasVariantRating = List(
-    perfs.crazyhouse,
-    perfs.chess960,
-    perfs.kingOfTheHill,
-    perfs.threeCheck,
-    perfs.antichess,
-    perfs.atomic,
-    perfs.horde,
-    perfs.racingKings
-  ).map(_.isEmpty).contains(true)
+  def hasVariantRating = PerfType.variants.exists(perfs.apply(_).nonEmpty)
 
   def titleUsernameWithBestRating =
     title.fold(usernameWithBestRating) { t =>

--- a/ui/site/css/user/_sub-rating.scss
+++ b/ui/site/css/user/_sub-rating.scss
@@ -78,7 +78,7 @@
 
   hr {
     margin: $block-gap auto;
-    width: 15em;
+    width: 80%;
   }
 
   h3 {

--- a/ui/site/css/user/_sub-rating.scss
+++ b/ui/site/css/user/_sub-rating.scss
@@ -76,6 +76,11 @@
     }
   }
 
+  hr {
+    margin: $block-gap auto;
+    width: 15em;
+  }
+
   h3 {
     @extend %roboto;
 
@@ -109,7 +114,7 @@
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(9ch, 1fr));
 
-    br,
+    hr,
     .rank {
       display: none;
     }

--- a/ui/site/css/user/_sub-rating.scss
+++ b/ui/site/css/user/_sub-rating.scss
@@ -104,6 +104,7 @@
 
     a > i,
     h3,
+    hr,
     rating .rp,
     rating span {
       display: none;


### PR DESCRIPTION
As opposed to just a gap between the standard ratings and variant ratings (that is **always** there, even if you don't have a variant rating) and between the variant/standard ratings and the puzzle ratings (that is **always** there, even if you are a bot and don't have puzzle ratings), I propose adding a line separator.

The gap is very hard to see (I only just noticed it) so it clearly doesn't serve it's purpose of separating the ratings. It is also currently displayed **always**, as noted above. Instead, a line should be added (this also helps visually-impaired people) to separate the ratings.

The lines also only appear when you have a variant rating for the top separator and when you aren't a bot for the bottom separator.

**Before**             |  **After**
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/1687121/114668905-9fd7f780-9d44-11eb-9e59-77a9b8b23c05.png) |  ![image](https://user-images.githubusercontent.com/1687121/114668914-a36b7e80-9d44-11eb-82cd-598f3251b1f5.png)