### PR TITLE
Fix spectators list translation

### DIFF
--- a/app/views/analyse/jsI18n.scala
+++ b/app/views/analyse/jsI18n.scala
@@ -39,6 +39,7 @@ private object jsI18n {
     trans.averageCentipawnLoss,
     trans.viewTheSolution,
     trans.youNeedAnAccountToDoThat,
+    trans.spectators,
     // ceval (also uses gameOver)
     trans.depthX,
     trans.usingServerAnalysis,

--- a/app/views/round/bits.scala
+++ b/app/views/round/bits.scala
@@ -52,7 +52,7 @@ object bits {
       )(
         span(cls := "number")(nbsp),
         " ",
-        trans.spectators.txt().replace(":", ""),
+        trans.spectators.txt(),
         " ",
         span(cls := "list")
       ),

--- a/app/views/team/show.scala
+++ b/app/views/team/show.scala
@@ -91,7 +91,7 @@ object show {
               )(
                 span(cls := "number")(nbsp),
                 " ",
-                trans.spectators.txt().replace(":", ""),
+                trans.spectators.txt(),
                 " ",
                 span(cls := "list")
               )


### PR DESCRIPTION
Make it consistent on all pages (always "spectators: ..." with a colon) and add the translation when analyzing existing games.