### PR TITLE
Update tagify to 4.0.5 and type it

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -492,6 +492,4 @@ interface Dictionary<T> {
   [key: string]: T | undefined;
 }
 
-declare module '@yaireo/tagify';
-
 declare const lichess: Lichess;

--- a/ui/analyse/package.json
+++ b/ui/analyse/package.json
@@ -15,11 +15,12 @@
   "license": "AGPL-3.0-or-later",
   "devDependencies": {
     "@build/rollupProject": "2.0.0",
-    "@types/lichess": "2.0.0"
+    "@types/lichess": "2.0.0",
+    "@types/yaireo__tagify": "^4.0.1"
   },
   "dependencies": {
     "@badrap/result": "^0.2.6",
-    "@yaireo/tagify": "^3.22.1",
+    "@yaireo/tagify": "^4.0.5",
     "ceval": "2.0.0",
     "chat": "2.0.0",
     "chess": "2.0.0",

--- a/ui/analyse/src/plugins/studyTopicForm.ts
+++ b/ui/analyse/src/plugins/studyTopicForm.ts
@@ -3,7 +3,7 @@ import * as xhr from 'common/xhr';
 import Tagify from '@yaireo/tagify';
 
 lichess.load.then(() => {
-  const tagify = new Tagify(document.getElementById('form3-topics'), {
+  const tagify = new Tagify(document.getElementById('form3-topics') as HTMLInputElement, {
     pattern: /.{2,}/,
     maxTags: 30,
   });
@@ -14,11 +14,11 @@ lichess.load.then(() => {
   tagify.on('input', e => {
     const term = e.detail.value.trim();
     if (term.length < 2) return;
-    tagify.settings.whitelist.length = 0; // reset the whitelist
+    tagify.settings.whitelist!.length = 0; // reset the whitelist
     // show loading animation and hide the suggestions dropdown
     tagify.loading(true).dropdown.hide.call(tagify);
     doFetch(term).then((list: string[]) => {
-      tagify.settings.whitelist.splice(0, list.length, ...list); // update whitelist Array in-place
+      tagify.settings.whitelist!.splice(0, list.length, ...list); // update whitelist Array in-place
       tagify.loading(false).dropdown.show.call(tagify, term); // render the suggestions dropdown
     });
   });

--- a/ui/analyse/src/study/topics.ts
+++ b/ui/analyse/src/study/topics.ts
@@ -15,7 +15,12 @@ export interface TopicsCtrl {
   redraw: Redraw;
 }
 
-export function ctrl(save: (data: string[]) => void, getTopics: () => Topic[], trans: Trans, redraw: Redraw): TopicsCtrl {
+export function ctrl(
+  save: (data: string[]) => void,
+  getTopics: () => Topic[],
+  trans: Trans,
+  redraw: Redraw
+): TopicsCtrl {
   const open = prop(false);
 
   return {

--- a/ui/analyse/src/study/topics.ts
+++ b/ui/analyse/src/study/topics.ts
@@ -5,22 +5,23 @@ import { h, VNode } from 'snabbdom';
 import { prop, Prop } from 'common';
 import { Redraw } from '../interfaces';
 import { StudyCtrl, Topic } from './interfaces';
+import type Tagify from '@yaireo/tagify';
 
 export interface TopicsCtrl {
   open: Prop<boolean>;
   getTopics(): Topic[];
-  save(data: string): void;
+  save(data: string[]): void;
   trans: Trans;
   redraw: Redraw;
 }
 
-export function ctrl(save: (data: string) => void, getTopics: () => Topic[], trans: Trans, redraw: Redraw): TopicsCtrl {
+export function ctrl(save: (data: string[]) => void, getTopics: () => Topic[], trans: Trans, redraw: Redraw): TopicsCtrl {
   const open = prop(false);
 
   return {
     open,
     getTopics,
-    save(data: string) {
+    save(data: string[]) {
       save(data);
       open(false);
     },
@@ -52,7 +53,7 @@ export function view(ctrl: StudyCtrl): VNode {
   ]);
 }
 
-let tagify: any | undefined;
+let tagify: Tagify | undefined;
 
 export function formView(ctrl: TopicsCtrl, userId?: string): VNode {
   return modal.modal({
@@ -98,21 +99,21 @@ function setupTagify(elm: HTMLElement, userId?: string) {
     tagify = new window.Tagify(elm, {
       pattern: /.{2,}/,
       maxTags: 30,
-    });
-    let abortCtrl: AbortController; // for aborting the call
+    }) as Tagify;
+    let abortCtrl: AbortController | undefined; // for aborting the call
     tagify.on('input', e => {
       const term = e.detail.value.trim();
       if (term.length < 2) return;
-      tagify.settings.whitelist.length = 0; // reset the whitelist
+      tagify!.settings.whitelist!.length = 0; // reset the whitelist
       abortCtrl && abortCtrl.abort();
       abortCtrl = new AbortController();
       // show loading animation and hide the suggestions dropdown
-      tagify.loading(true).dropdown.hide.call(tagify);
+      tagify!.loading(true).dropdown.hide.call(tagify);
       xhr
         .json(xhr.url('/study/topic/autocomplete', { term, user: userId }), { signal: abortCtrl.signal })
         .then(list => {
-          tagify.settings.whitelist.splice(0, list.length, ...list); // update whitelist Array in-place
-          tagify.loading(false).dropdown.show.call(tagify, term); // render the suggestions dropdown
+          tagify!.settings.whitelist!.splice(0, list.length, ...list); // update whitelist Array in-place
+          tagify!.loading(false).dropdown.show.call(tagify, term); // render the suggestions dropdown
         });
     });
     $('.tagify__input').each(function (this: HTMLInputElement) {

--- a/ui/analyse/tsconfig.json
+++ b/ui/analyse/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "esModuleInterop": true
   }
 }

--- a/ui/common/css/component/_tagify.scss
+++ b/ui/common/css/component/_tagify.scss
@@ -1,7 +1,6 @@
 :root {
-  --tagify-dd-color-primary: #{$c-primary};
-
   // should be same as "$tags-focus-border-color"
+  --tagify-dd-color-primary: #{$c-primary};
   --tagify-dd-bg-color: #{$c-bg-box};
 }
 
@@ -15,19 +14,32 @@
   $tagMargin: 5px !default;
   $tag-pad: 0.3em 0.5em !default;
 
+  $tag-min-width: 1ch !default;
+  $tag-max-width: auto !default;
+
   $tag-text-color: $c-font-clearer !default;
   $tag-text-color--edit: $c-font-clearer !default;
   $tag-bg: $c-bg-zebra2 !default;
   $tag-hover: mix($c-primary, $c-bg-zebra2, 20%) !default;
   $tag-remove: mix($c-bad, $c-bg-zebra2, 60%) !default;
+  $tag-remove-btn-color: $tag-text-color !default;
   $tag-remove-btn-bg: none !default;
   $tag-remove-btn-bg--hover: $c-bad !default;
   $tag-invalid-color: $tag-remove !default;
   $tag-invalid-bg: mix($c-bad, $c-bg-zebra2, 20%) !default;
-  $tag-inset-shadow-size: 1.1em !default;
+  $tag-inset-shadow-size: 1.5em !default;
+  $tag-hide-transition: 0.3s !default;
+
+  $placeholder-color: rgba($tag-text-color, 0.4) !default;
+  $placeholder-color-focus: rgba($tag-text-color, 0.25) !default;
+  $input-color: inherit !default;
+  $tagify-dd-bg-color: white !default;
+  $tagify-dd-color-primary: $c-primary !default;
 
   // CSS variables
   --tags-border-color: #{$tags-border-color};
+  --tags-hover-border-color: #{$tags-hover-border-color};
+  --tags-focus-border-color: #{$tags-focus-border-color};
   --tag-bg: #{$tag-bg};
   --tag-hover: #{$tag-hover};
   --tag-text-color: #{$tag-text-color};
@@ -37,12 +49,26 @@
   --tag-invalid-color: #{$tag-invalid-color};
   --tag-invalid-bg: #{$tag-invalid-bg};
   --tag-remove-bg: #{rgba($tag-remove, 0.3)};
+  --tag-remove-btn-color: #{$tag-remove-btn-color};
   --tag-remove-btn-bg: #{$tag-remove-btn-bg};
   --tag-remove-btn-bg--hover: #{$tag-remove-btn-bg--hover};
-  --tag--min-width: 1ch;
-  --tag--max-width: auto;
-  --tag-hide-transition: 0.3s;
+  --input-color: #{$input-color};
+  --tag--min-width: #{$tag-min-width};
+  --tag--max-width: #{$tag-max-width};
+  --tag-hide-transition: #{$tag-hide-transition};
+  --placeholder-color: #{$placeholder-color};
+  --placeholder-color-focus: #{$placeholder-color-focus};
   --loader-size: 0.8em;
+
+  @mixin firefox {
+    @at-root {
+      @-moz-document url-prefix() {
+        & {
+          @content;
+        }
+      }
+    }
+  }
 
   @mixin placeholder($show: true, $opacity: 0.5) {
     transition: 0.2s ease-out;
@@ -54,6 +80,21 @@
       opacity: 0;
       transform: translatex(6px);
     }
+  }
+
+  @mixin loader() {
+    content: '';
+    vertical-align: middle;
+    margin: -2px 0 -2px 0.5em;
+    opacity: 1;
+    width: 0.7em;
+    height: 0.7em;
+    width: var(--loader-size);
+    height: var(--loader-size);
+    border: 3px solid;
+    border-color: #eee #bbb #888 transparent;
+    border-radius: 50%;
+    animation: rotateLoader 0.4s infinite linear;
   }
 
   @mixin tagReadonlyBG {
@@ -93,66 +134,66 @@
   border: 1px solid var(--tags-border-color);
   padding: 0;
   margin: 1em 0;
-  line-height: 1.1;
+  line-height: normal;
   cursor: text;
   outline: none;
   position: relative;
+  box-sizing: border-box;
   transition: 0.1s;
   text-align: left;
   height: auto;
 
   &:hover {
     border-color: $tags-hover-border-color;
+    border-color: var(--tags-hover-border-color);
   }
 
   &.tagify--focus {
     transition: 0s;
     border-color: $tags-focus-border-color;
+    border-color: var(--tags-focus-border-color);
   }
 
   // Global "read-only" mode (no input button)
   &[readonly] {
-    cursor: default;
+    &:not(.tagify--mix) {
+      cursor: default;
 
-    > #{$self}__input {
-      visibility: hidden;
-      width: 0;
-      margin: $tagMargin 0;
-    }
+      > #{$self}__input {
+        visibility: hidden;
+        width: 0;
+        margin: $tagMargin 0;
+      }
 
-    #{$self}__tag__removeBtn {
-      display: none;
-    }
+      #{$self}__tag__removeBtn {
+        display: none;
+      }
 
-    #{$self}__tag > div {
-      padding: $tag-pad;
-      padding: var(--tag-pad);
+      #{$self}__tag > div {
+        padding: $tag-pad;
+        padding: var(--tag-pad);
 
-      &::before {
-        @include tagReadonlyBG;
+        &::before {
+          @include tagReadonlyBG;
+        }
       }
     }
   }
 
   &--loading {
     #{$self}__input {
+      > br:last-child {
+        display: none;
+      }
+
       &::before {
         content: none;
       }
 
       &::after {
-        content: '';
-        vertical-align: middle;
+        @include loader;
+        content: '' !important;
         margin: -2px 0 -2px 0.5em;
-        opacity: 1;
-        width: 0.7em;
-        height: 0.7em;
-        width: var(--loader-size);
-        height: var(--loader-size);
-        border: 3px solid;
-        border-color: #eee #bbb #888 transparent;
-        border-radius: 50%;
-        animation: rotateLoader 0.4s infinite linear;
       }
 
       &:empty {
@@ -167,7 +208,9 @@
   // Hides originals
   + input,
   + textarea {
-    display: none !important;
+    position: absolute !important;
+    left: -9999em !important;
+    transform: scale(0) !important;
   }
 
   &__tag {
@@ -181,27 +224,28 @@
     transition: 0.13s ease-out;
 
     > div {
-      // :not([contenteditable])
       vertical-align: top;
       box-sizing: border-box;
       max-width: 100%;
       padding: $tag-pad;
-      padding: var(--tag-pad);
+      padding: var(--tag-pad, $tag-pad);
       color: $tag-text-color;
-      color: var(--tag-text-color);
+      color: var(--tag-text-color, $tag-text-color);
       line-height: inherit;
       border-radius: 3px;
-      user-select: none;
+      white-space: nowrap;
       transition: 0.13s ease-out;
 
       > * {
-        white-space: nowrap;
+        white-space: pre-wrap;
         overflow: hidden;
         text-overflow: ellipsis;
         display: inline-block;
         vertical-align: top;
-        min-width: var(--tag--min-width);
-        max-width: var(--tag--max-width);
+        min-width: $tag-min-width;
+        max-width: $tag-max-width;
+        min-width: var(--tag--min-width, $tag-min-width);
+        max-width: var(--tag--max-width, $tag-max-width);
         transition: 0.8s ease, 0.1s color;
 
         &[contenteditable] {
@@ -228,14 +272,14 @@
         pointer-events: none;
         transition: 120ms ease;
         animation: tags--bump 0.3s ease-out 1;
+
         box-shadow: 0 0 0 $tag-inset-shadow-size $tag-bg inset;
-        box-shadow: 0 0 0 calc(var(--tag-inset-shadow-size)) var(--tag-bg) inset;
+        box-shadow: 0 0 0 var(--tag-inset-shadow-size, $tag-inset-shadow-size) var(--tag-bg, $tag-bg) inset;
       }
     }
 
     &:hover:not([readonly]) {
       div {
-        // :not([contenteditable])
         &::before {
           $size: -$tagMargin / 2;
           $size: -2px;
@@ -245,15 +289,45 @@
           bottom: $size;
           left: $size;
           box-shadow: 0 0 0 $tag-inset-shadow-size $tag-hover inset;
-          box-shadow: 0 0 0 var(--tag-inset-shadow-size) var(--tag-hover) inset;
-
-          //  box-shadow: 0 0 0 0 $tag-remove inset
+          box-shadow: 0 0 0 var(--tag-inset-shadow-size, $tag-inset-shadow-size) var(--tag-hover, $tag-hover) inset;
         }
+      }
+    }
 
-        // background:nth($tagColor,2);
-        //background:none;
-        // box-shadow: 0 0 0 2px $tag-hover inset;
-        // transition:50ms;
+    &--loading {
+      pointer-events: none;
+
+      .tagify__tag__removeBtn {
+        display: none;
+      }
+
+      &::after {
+        --loader-size: 0.4em;
+        @include loader;
+        margin: 0 0.5em 0 -0.1em;
+      }
+    }
+
+    &--flash {
+      div::before {
+        animation: none;
+      }
+    }
+
+    &--hide {
+      width: 0 !important;
+      padding-left: 0;
+      padding-right: 0;
+      margin-left: 0;
+      margin-right: 0;
+      opacity: 0;
+      transform: scale(0);
+      transition: $tag-hide-transition;
+      transition: var(--tag-hide-transition, $tag-hide-transition);
+      pointer-events: none;
+
+      > div > * {
+        white-space: nowrap;
       }
     }
 
@@ -264,35 +338,16 @@
         }
       }
 
-      &--hide {
-        width: 0 !important;
-        padding-left: 0;
-        padding-right: 0;
-        margin-left: 0;
-        margin-right: 0;
-        opacity: 0;
-        transform: scale(0);
-        transition: 0.3s;
-        transition: var(--tag-hide-transition);
-        pointer-events: none;
-      }
-
-      &--mark {
-        div::before {
-          animation: none;
-        }
-      }
-
       &--notAllowed:not(.tagify__tag--editable) {
         div {
           > span {
             opacity: 0.5;
           }
 
-          // filter:blur(.2px);
           &::before {
             box-shadow: 0 0 0 $tag-inset-shadow-size $tag-invalid-bg inset !important;
-            box-shadow: 0 0 0 var(--tag-inset-shadow-size) var(--tag-invalid-bg) inset !important;
+            box-shadow: 0 0 0 var(--tag-inset-shadow-size, $tag-inset-shadow-size)
+              var(--tag-invalid-bg, $tag-invalid-bg) inset !important;
             transition: 0.2s;
           }
         }
@@ -315,11 +370,20 @@
     &--editable {
       > div {
         color: $tag-text-color--edit;
-        color: var(--tag-text-color--edit);
+        color: var(--tag-text-color--edit, $tag-text-color--edit);
 
         &::before {
           box-shadow: 0 0 0 2px $tag-hover inset !important;
-          box-shadow: 0 0 0 2px var(--tag-hover) inset !important;
+          box-shadow: 0 0 0 2px var(--tag-hover, $tag-hover) inset !important;
+        }
+      }
+
+      > #{$self}__tag__removeBtn {
+        pointer-events: none;
+
+        &::after {
+          opacity: 0;
+          transform: translateX(100%) translateX(5px);
         }
       }
 
@@ -327,53 +391,55 @@
         > div {
           &::before {
             box-shadow: 0 0 0 2px $tag-invalid-color inset !important;
-            box-shadow: 0 0 0 2px var(--tag-invalid-color) inset !important;
+            box-shadow: 0 0 0 2px var(--tag-invalid-color, $tag-invalid-color) inset !important;
           }
         }
       }
     }
-  }
 
-  &__tag__removeBtn {
-    $size: 14px;
+    &__removeBtn {
+      $size: 14px;
 
-    order: 5;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 50px;
-    cursor: pointer;
-    font: #{$size} Serif;
-    background: $tag-remove-btn-bg;
-    background: var(--tag-remove-btn-bg);
-    color: $tag-text-color;
-    color: var(--tag-text-color);
-    width: $size;
-    height: $size;
-    margin-right: $size / 3;
-    margin-left: -$size / 3;
-    transition: 0.2s ease-out;
+      order: 5;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50px;
+      cursor: pointer;
+      font: #{$size} Serif;
+      background: $tag-remove-btn-bg;
+      background: var(--tag-remove-btn-bg, $tag-remove-btn-bg);
+      color: $tag-remove-btn-color;
+      color: var(--tag-remove-btn-color, $tag-remove-btn-color);
 
-    &::after {
-      content: '\00D7';
-    }
+      width: $size;
+      height: $size;
+      margin-right: $size / 3;
+      margin-left: auto;
 
-    &:hover {
-      color: white;
-      background: $tag-remove-btn-bg--hover;
-      background: var(--tag-remove-btn-bg--hover);
+      overflow: hidden;
+      transition: 0.2s ease-out;
 
-      // + span{ box-shadow: 0 0 0 2px $tag-remove inset; transition:.2s; }
-      + div {
-        > span {
-          opacity: 0.5;
-        }
+      &::after {
+        content: '\00D7';
+      }
 
-        // filter:blur(.2px);
-        &::before {
-          box-shadow: 0 0 0 $tag-inset-shadow-size rgba($tag-remove, 0.3) inset !important;
-          box-shadow: 0 0 0 var(--tag-inset-shadow-size) var(--tag-remove-bg) inset !important;
-          transition: 0.2s;
+      &:hover {
+        color: white;
+        background: $tag-remove-btn-bg--hover;
+        background: var(--tag-remove-btn-bg--hover, $tag-remove-btn-bg--hover);
+
+        + div {
+          > span {
+            opacity: 0.5;
+          }
+
+          &::before {
+            box-shadow: 0 0 0 $tag-inset-shadow-size rgba($tag-remove, 0.3) inset !important;
+            box-shadow: 0 0 0 var(--tag-inset-shadow-size, $tag-inset-shadow-size) var(--tag-remove-bg, rgba($tag-remove, .3))
+              inset !important;
+            transition: 0.2s;
+          }
         }
       }
     }
@@ -398,35 +464,38 @@
   &__input {
     $placeholder-width: 110px;
 
-    @mixin placeholder-show {
-      opacity: 0.5;
-      transform: none;
-    }
-
-    display: block;
+    flex-grow: 1;
+    display: inline-block;
     min-width: $placeholder-width;
     margin: $tagMargin;
     padding: $tag-pad;
     padding: var(--tag-pad, $tag-pad);
     line-height: inherit;
     position: relative;
-    white-space: pre-line;
 
     // #160 Line break (\n) as delimeter
+    white-space: pre-wrap;
 
-    &::before {
-      display: inline-block;
-      width: 0;
-    }
+    color: $input-color;
+    color: var(--input-color, $input-color);
+    box-sizing: inherit;
 
     &:empty {
-      display: flex;
+      @include firefox {
+        // clicking twice on the input (not fast) disallows typing (bug) only when the input has "display:flex".
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=904846#c45
+        display: flex;
+      }
 
-      // https://bugzilla.mozilla.org/show_bug.cgi?id=904846#c45
       &::before {
         @include placeholder;
+        display: inline-block;
 
         width: auto;
+
+        #{ $self }--mix & {
+          display: inline-block;
+        }
       }
     }
 
@@ -436,34 +505,54 @@
       &::before {
         @include placeholder(false);
 
-        @supports (-moz-appearance: none) {
+        /* ALL MS BROWSERS: hide placeholder (on focus) otherwise the caret is places after it, which is weird */
+        /* IE10+ CSS styles go here */
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          display: none;
+        }
+        /* IE Edge 12+ CSS styles go here */
+        @supports (-ms-ime-align: auto) {
           display: none;
         }
       }
 
-      &:empty::before {
-        @include placeholder(true, 0.3);
+      &:empty {
+        &::before {
+          @include placeholder(true);
 
-        @supports (-moz-appearance: none) {
-          display: inline-block;
+          @include firefox {
+            // remove ":after" pseudo element: https://bugzilla.mozilla.org/show_bug.cgi?id=904846#c45
+            content: unset;
+            display: inline-block;
+          }
+
+          color: $placeholder-color-focus;
+          color: var(--placeholder-color-focus);
+        }
+
+        &::after {
+          @include firefox {
+            display: none;
+          }
         }
       }
     }
 
-    // &:empty:focus{ padding:$tag-pad; }
-
     &::before {
       content: attr(data-placeholder);
-      line-height: 1.8;
-      position: absolute;
-      top: 0;
+      height: 1em;
+      line-height: 1em;
+      margin: auto 0;
       z-index: 1;
-      color: $tag-text-color;
+      color: $placeholder-color;
+      color: var(--placeholder-color);
       white-space: nowrap;
       pointer-events: none;
       opacity: 0;
+      position: absolute;
 
       #{$self}--mix & {
+        display: none;
         position: static;
         line-height: inherit;
       }
@@ -480,27 +569,22 @@
     &::after {
       content: attr(data-suggest);
       display: inline-block;
-      white-space: pre;
 
       /* allows spaces at the beginning */
+      white-space: pre;
       color: $tag-text-color;
       opacity: 0.3;
       pointer-events: none;
       max-width: 100px;
     }
 
-    // &--invalid{
-    //     // color: $invalid-input-color;
-    // }
-
     /*
         in "mix mode" the tags are inside the "input" element
     */
     #{$self}__tag {
-      margin: 0;
-
       // a developer can choose to have automatic horizontal margin ("1ch" advised) between tags or use manual keyboard spaces
       // line-height: 1.1;
+      margin: 0;
 
       > div {
         padding-top: 0;
@@ -510,14 +594,22 @@
   }
 
   &--mix {
-    line-height: 1.7;
+    // display:flex makes Chrome generates <div><br></div> when pressing ENTER key
+    display: block;
 
     #{$self}__input {
       padding: $tagMargin;
       margin: 0;
       width: 100%;
       height: 100%;
-      line-height: inherit;
+      line-height: 1.5;
+
+      // needed to resolve this bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1182621
+      display: block;
+
+      &::before {
+        height: auto;
+      }
 
       // no suggested-complete are shown in mix-mode while higilighting dropdown options
       &::after {
@@ -583,7 +675,7 @@
 
     &[placement='top'] {
       margin-top: 0;
-      transform: translateY(-2px);
+      transform: translateY(-100%);
 
       #{$dropdown}__wrapper {
         border-top-width: 1px;
@@ -592,7 +684,7 @@
     }
 
     // when the dropdown shows next to the caret while typing
-    &--text {
+    &[position='text'] {
       box-shadow: 0 0 0 3px rgba(var(--tagify-dd-color-primary), 0.1);
       font-size: 0.9em;
 
@@ -608,9 +700,11 @@
       overflow: hidden;
       background: $c-bg-popup;
       border: 1px solid $tags-focus-border-color;
-      border-top-width: 0;
 
-      // box-sizing: border-box;
+      // fixes - https://bugs.chromium.org/p/chromium/issues/detail?id=1147523
+      border-width: 1.1px;
+      border-top-width: 0;
+      box-shadow: 0 2px 4px -2px rgba(black, 0.2);
       transition: $trans;
 
       &:hover {
@@ -649,15 +743,6 @@
       &:active {
         filter: brightness(105%);
       }
-    }
-
-    &__createTagBtn {
-      width: 100%;
-      background: $tags-focus-border-color;
-      background: var(--tagify-dd-color-primary);
-      color: white;
-      color: var(--tagify-dd-bg-color);
-      border: none;
     }
   }
 }

--- a/ui/common/css/component/_tagify.scss
+++ b/ui/common/css/component/_tagify.scss
@@ -436,8 +436,8 @@
 
           &::before {
             box-shadow: 0 0 0 $tag-inset-shadow-size rgba($tag-remove, 0.3) inset !important;
-            box-shadow: 0 0 0 var(--tag-inset-shadow-size, $tag-inset-shadow-size) var(--tag-remove-bg, rgba($tag-remove, .3))
-              inset !important;
+            box-shadow: 0 0 0 var(--tag-inset-shadow-size, $tag-inset-shadow-size)
+              var(--tag-remove-bg, rgba($tag-remove, 0.3)) inset !important;
             transition: 0.2s;
           }
         }

--- a/ui/site/package.json
+++ b/ui/site/package.json
@@ -9,12 +9,13 @@
     "@build/rollupProject": "2.0.0",
     "@rollup/plugin-replace": "^2.3.4",
     "@types/fnando__sparkline": "^0.3.2",
+    "@types/yaireo__tagify": "^4.0.1",
     "@types/zxcvbn": "^4.4.0",
     "rollup-plugin-copy": "^3.3.0"
   },
   "dependencies": {
     "@fnando/sparkline": "^0.3.10",
-    "@yaireo/tagify": "^3.22.1",
+    "@yaireo/tagify": "^4.0.5",
     "debounce-promise": "^3.1.2",
     "flatpickr": "^4.6.9",
     "highcharts": "=4.2.5",

--- a/ui/site/src/coachForm.ts
+++ b/ui/site/src/coachForm.ts
@@ -95,7 +95,7 @@ lichess.load.then(() => {
 
   const langInput = document.getElementById('form3-languages') as HTMLInputElement;
   const whitelistJson = langInput.getAttribute('data-all');
-  const whitelist = whitelistJson ? JSON.parse(whitelistJson) as Tagify.TagData[] : undefined;
+  const whitelist = whitelistJson ? (JSON.parse(whitelistJson) as Tagify.TagData[]) : undefined;
   const tagify = new Tagify(langInput, {
     maxTags: 10,
     whitelist,

--- a/ui/site/src/coachForm.ts
+++ b/ui/site/src/coachForm.ts
@@ -93,10 +93,12 @@ lichess.load.then(() => {
     ($(this).parents('form')[0] as HTMLFormElement).submit();
   });
 
-  const langInput = document.getElementById('form3-languages')!;
+  const langInput = document.getElementById('form3-languages') as HTMLInputElement;
+  const whitelistJson = langInput.getAttribute('data-all');
+  const whitelist = whitelistJson ? JSON.parse(whitelistJson) as Tagify.TagData[] : undefined;
   const tagify = new Tagify(langInput, {
     maxTags: 10,
-    whitelist: JSON.parse(langInput.getAttribute('data-all') || ''),
+    whitelist,
     enforceWhitelist: true,
     dropdown: {
       enabled: 1,
@@ -106,8 +108,8 @@ lichess.load.then(() => {
     langInput
       .getAttribute('data-value')
       ?.split(',')
-      .map(code => tagify.settings.whitelist.find(l => l.code == code))
-      .filter(notNull)
+      .map(code => whitelist?.find(l => l.code == code))
+      .filter(notNull) as Tagify.TagData[]
   );
 
   todo();

--- a/ui/site/src/teamAdmin.ts
+++ b/ui/site/src/teamAdmin.ts
@@ -18,11 +18,11 @@ lichess.load.then(() => {
   tagify.on('input', e => {
     const term = e.detail.value.trim();
     if (term.length < 3) return;
-    tagify.settings.whitelist.length = 0; // reset the whitelist
+    tagify.settings.whitelist!.length = 0; // reset the whitelist
     // show loading animation and hide the suggestions dropdown
     tagify.loading(true).dropdown.hide.call(tagify);
     doFetch(term).then((list: string[]) => {
-      tagify.settings.whitelist.splice(0, list.length, ...list); // update whitelist Array in-place
+      tagify.settings.whitelist!.splice(0, list.length, ...list); // update whitelist Array in-place
       tagify.loading(false).dropdown.show.call(tagify, term); // render the suggestions dropdown
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,6 +197,20 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
   integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react@*":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
+  integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/resolve@1.17.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
@@ -204,10 +218,23 @@
   dependencies:
     "@types/node" "*"
 
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
+
 "@types/webrtc@^0.0.26":
   version "0.0.26"
   resolved "https://registry.yarnpkg.com/@types/webrtc/-/webrtc-0.0.26.tgz#f1bae07215eb84577c35ca050866820e412a07e2"
   integrity sha512-hTDoPKPYbgcogZA9eqhihPO+HnUs5BNPfnoOyc9bzcuq56eYV28zwJ+3tortPN0uXgmDvNs3f1JaT4oTbtWxqg==
+
+"@types/yaireo__tagify@*", "@types/yaireo__tagify@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/yaireo__tagify/-/yaireo__tagify-4.0.1.tgz#1727b5a55e0edec366e45c3b320fc510663aec03"
+  integrity sha512-z0d5Dqi8S3guHZ7K91AejYl6b2qFr7/Iy5l5hrndHvFs4ZLhbtrs0o2teSCegD2ca/zUdi5dzE2cCwmUG5OxEg==
+  dependencies:
+    "@types/react" "*"
+    "@types/yaireo__tagify" "*"
 
 "@types/zxcvbn@^4.4.0":
   version "4.4.1"
@@ -284,10 +311,10 @@
     "@typescript-eslint/types" "4.20.0"
     eslint-visitor-keys "^2.0.0"
 
-"@yaireo/tagify@^3.22.1":
-  version "3.23.1"
-  resolved "https://registry.yarnpkg.com/@yaireo/tagify/-/tagify-3.23.1.tgz#c172e22c632fd4c0902aa73b726277feba8477dc"
-  integrity sha512-Zrw+CUHwhZWG1ZOpZB0vK5Il969AyuOBngXe1E/1urvcXxAjdCPLLE6E+wEqv1e+CGybaIK7RiUVlZtBun+zYA==
+"@yaireo/tagify@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@yaireo/tagify/-/tagify-4.0.5.tgz#476bbbeaa08d53f6cc469b6309ea1540dbdad2a8"
+  integrity sha512-HCIn2bCQ114SBDHafUR+jDutKFDbxDIjlWygg3eQBVpmJIcavKdYX6MdW5Jeh0QEcuDP4Ihby9QnZVNbv3z43Q==
 
 "ab@https://github.com/lichess-org/ab-stub":
   version "1.0.0"
@@ -1165,6 +1192,11 @@ css@^3.0.0:
     inherits "^2.0.4"
     source-map "^0.6.1"
     source-map-resolve "^0.6.0"
+
+csstype@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.7.tgz#2a5fb75e1015e84dd15692f71e89a1450290950b"
+  integrity sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
Tested on all the pages where it's used. I also made sure to keep the important custom adjustments to the CSS.

4.x doesn't actually have any breaking changes for the non-React API.

Also fixes this weird bug in Chrome:

| Before | After |
| :------: | :----: |
|![Screenshot 2021-04-18 181724](https://user-images.githubusercontent.com/19309705/115152685-5a803680-a072-11eb-9b51-2c431cb136d2.png)|![Screenshot 2021-04-18 140536](https://user-images.githubusercontent.com/19309705/115152558-e0e84880-a071-11eb-9424-919a28c7b87b.png)|