### PR TITLE
Type everything in ui/analyse

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -466,6 +466,14 @@ declare namespace Tree {
   export interface Shape {}
 }
 
+interface GameUpdate {
+  id: string;
+  fen: Fen;
+  lm: Uci;
+  wc?: number;
+  bc?: number;
+}
+
 interface CashStatic {
   powerTip: any;
 }
@@ -498,19 +506,6 @@ declare namespace PowerTip {
 
 interface HighchartsHTMLElement extends HTMLElement {
   highcharts: Highcharts.ChartObject;
-}
-
-interface GameUpdate {
-  /** Game ID */
-  id: string;
-  /** New position */
-  fen: Fen;
-  /** Last move */
-  lm: Uci;
-  /** White clock */
-  wc?: number;
-  /** Black clock */
-  bc?: number;
 }
 
 declare namespace Prefs {

--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="highcharts" />
+
 interface Lichess {
   load: Promise<void>; // window.onload promise
   info: any;
@@ -201,7 +203,7 @@ interface Window {
   moment: any;
   Mousetrap: any;
   Chessground: any;
-  Highcharts: any;
+  Highcharts: Highcharts.Static;
   InfiniteScroll(selector: string): void;
   lichessReplayMusic: () => {
     jump(node: Tree.Node): void;
@@ -494,6 +496,10 @@ declare namespace PowerTip {
   }
 }
 
+interface HighchartsHTMLElement extends HTMLElement {
+  highcharts: Highcharts.ChartObject;
+}
+
 interface GameUpdate {
   /** Game ID */
   id: string;
@@ -507,8 +513,48 @@ interface GameUpdate {
   bc?: number;
 }
 
+declare namespace Prefs {
+  const enum Coords {
+    Hidden = 0,
+    Inside = 1,
+    Outside = 2,
+  }
+
+  const enum AutoQueen {
+    Never = 1,
+    OnPremove = 2,
+    Always = 3,
+  }
+
+  const enum ShowClockTenths {
+    Never = 0,
+    Below10Secs = 1,
+    Always = 2,
+  }
+
+  const enum ShowResizeHandle {
+    Never = 0,
+    OnlyAtStart = 1,
+    Always = 2,
+  }
+
+  const enum MoveEvent {
+    Click = 0,
+    Drag = 1,
+    ClickOrDrag = 2,
+  }
+
+  const enum Replay {
+    Never = 0,
+    OnlySlowGames = 1,
+    Always = 2,
+  }
+}
+
 interface Dictionary<T> {
   [key: string]: T | undefined;
 }
+
+type SocketHandlers = Dictionary<(d: any) => void>;
 
 declare const lichess: Lichess;

--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -45,7 +45,7 @@ interface Lichess {
   miniGame: {
     init(node: HTMLElement): string | null;
     initAll(parent?: HTMLElement): void;
-    update(node: HTMLElement, data: { fen: string; lm: string; wc?: number; bc?: number }): void;
+    update(node: HTMLElement, data: GameUpdate): void;
     finish(node: HTMLElement, win?: Color): void;
   };
   ab?: any;
@@ -378,7 +378,13 @@ declare namespace Tree {
     fen: Fen;
     knodes: number;
     depth: number;
-    pvs: PvData[];
+    pvs: PvDataServer[];
+  }
+
+  export interface PvDataServer {
+    moves: string;
+    mate?: number;
+    cp?: number;
   }
 
   export interface PvData {
@@ -486,6 +492,19 @@ declare namespace PowerTip {
     openEvents?: string[];
     closeEvents?: string[];
   }
+}
+
+interface GameUpdate {
+  /** Game ID */
+  id: string;
+  /** New position */
+  fen: Fen;
+  /** Last move */
+  lm: Uci;
+  /** White clock */
+  wc?: number;
+  /** Black clock */
+  bc?: number;
 }
 
 interface Dictionary<T> {

--- a/ui/@types/lichess/package.json
+++ b/ui/@types/lichess/package.json
@@ -7,5 +7,8 @@
   "license": "AGPL-3.0-or-later",
   "devDependencies": {
     "@types/cash": "8.0.0"
+  },
+  "dependencies": {
+    "@types/highcharts": "4.2.57"
   }
 }

--- a/ui/analyse/package.json
+++ b/ui/analyse/package.json
@@ -15,6 +15,7 @@
   "license": "AGPL-3.0-or-later",
   "devDependencies": {
     "@build/rollupProject": "2.0.0",
+    "@types/debounce-promise": "^3.1.3",
     "@types/lichess": "2.0.0",
     "@types/yaireo__tagify": "^4.0.1"
   },

--- a/ui/analyse/src/actionMenu.ts
+++ b/ui/analyse/src/actionMenu.ts
@@ -35,7 +35,7 @@ const cplSpeed: AutoplaySpeed = {
   delay: 'cpl',
 };
 
-function deleteButton(ctrl: AnalyseCtrl, userId: string | null): VNode | undefined {
+function deleteButton(ctrl: AnalyseCtrl, userId?: string): VNode | undefined {
   const g = ctrl.data.game;
   if (g.source === 'import' && g.importedBy && g.importedBy === userId)
     return h(

--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -58,9 +58,10 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
   const hovering = ctrl.explorer.hovering() || instance.hovering();
   const { eval: nEval = {} as Partial<Tree.ServerEval>, fen: nFen, ceval: nCeval, threat: nThreat } = ctrl.node;
 
-  let shapes: DrawShape[] = [];
-  if (ctrl.retro && ctrl.retro.showBadNode()) {
-    return makeShapesFromUci(color, ctrl.retro.showBadNode().uci, 'paleRed', {
+  let shapes: DrawShape[] = [],
+    badNode;
+  if (ctrl.retro && (badNode = ctrl.retro.showBadNode())) {
+    return makeShapesFromUci(color, badNode.uci!, 'paleRed', {
       lineWidth: 8,
     });
   }

--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -3,7 +3,7 @@ import { isDrop } from 'chessops/types';
 import { winningChances } from 'ceval';
 import * as cg from 'chessground/types';
 import { opposite } from 'chessground/util';
-import { DrawShape } from 'chessground/draw';
+import { DrawModifiers, DrawShape } from 'chessground/draw';
 import AnalyseCtrl from './ctrl';
 
 function pieceDrop(key: cg.Key, role: cg.Role, color: Color): DrawShape {
@@ -18,7 +18,7 @@ function pieceDrop(key: cg.Key, role: cg.Role, color: Color): DrawShape {
   };
 }
 
-export function makeShapesFromUci(color: Color, uci: Uci, brush: string, modifiers?: any): DrawShape[] {
+export function makeShapesFromUci(color: Color, uci: Uci, brush: string, modifiers?: DrawModifiers): DrawShape[] {
   const move = parseUci(uci)!;
   const to = makeSquare(move.to);
   if (isDrop(move)) return [{ orig: to, brush }, pieceDrop(to, move.role, color)];
@@ -39,14 +39,15 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
   const color = ctrl.node.fen.includes(' w ') ? 'white' : 'black';
   const rcolor = opposite(color);
   if (ctrl.practice) {
-    if (ctrl.practice.hovering()) return makeShapesFromUci(color, ctrl.practice.hovering().uci, 'green');
+    const hovering = ctrl.practice.hovering();
+    if (hovering) return makeShapesFromUci(color, hovering.uci, 'green');
     const hint = ctrl.practice.hinting();
     if (hint) {
       if (hint.mode === 'move') return makeShapesFromUci(color, hint.uci, 'paleBlue');
       else
         return [
           {
-            orig: hint.uci[1] === '@' ? hint.uci.slice(2, 4) : hint.uci.slice(0, 2),
+            orig: (hint.uci[1] === '@' ? hint.uci.slice(2, 4) : hint.uci.slice(0, 2)) as Key,
             brush: 'paleBlue',
           },
         ];

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -158,7 +158,7 @@ export default class AnalyseCtrl {
 
     keyboard.bind(this);
 
-    lichess.pubsub.on('jump', (ply: any) => {
+    lichess.pubsub.on('jump', (ply: string) => {
       this.jumpToMain(parseInt(ply));
       this.redraw();
     });

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -40,7 +40,7 @@ import { Position, PositionError } from 'chessops/chess';
 import { Result } from '@badrap/result';
 import { setupPosition } from 'chessops/variant';
 import { storedProp, StoredBooleanProp } from 'common/storage';
-import { StudyCtrl } from './study/interfaces';
+import { AnaMove, StudyCtrl } from './study/interfaces';
 import { StudyPracticeCtrl } from './study/practice/interfaces';
 import { valid as crazyValid } from './crazy/crazyCtrl';
 
@@ -477,7 +477,7 @@ export default class AnalyseCtrl {
   };
 
   sendMove = (orig: Key, dest: Key, capture?: JustCaptured, prom?: cg.Role): void => {
-    const move: any = {
+    const move: AnaMove = {
       orig,
       dest,
       variant: this.data.game.variant.key,
@@ -844,10 +844,12 @@ export default class AnalyseCtrl {
       variant: this.data.game.variant.key,
       canGet: () => this.canEvalGet(),
       canPut: () =>
-        this.data.evalPut &&
-        this.canEvalGet() &&
-        // if not in study, only put decent opening moves
-        (this.opts.study || (!this.node.ceval!.mate && Math.abs(this.node.ceval!.cp!) < 99)),
+        !!(
+          this.data.evalPut &&
+          this.canEvalGet() &&
+          // if not in study, only put decent opening moves
+          (this.opts.study || (!this.node.ceval!.mate && Math.abs(this.node.ceval!.cp!) < 99))
+        ),
       getNode: () => this.node,
       send: this.opts.socketSend,
       receive: this.onNewCeval,

--- a/ui/analyse/src/evalCache.ts
+++ b/ui/analyse/src/evalCache.ts
@@ -17,6 +17,10 @@ export interface EvalCache {
   onCloudEval(serverEval: CachedEval): void;
 }
 
+interface PutData extends Tree.ServerEval {
+  variant?: string;
+}
+
 const evalPutMinDepth = 20;
 const evalPutMinNodes = 3e6;
 const evalPutMaxMoves = 10;
@@ -28,8 +32,8 @@ function qualityCheck(ev: Tree.ClientEval): boolean {
 }
 
 // from client eval to server eval
-function toPutData(variant: VariantKey, ev: Tree.ClientEval) {
-  const data: any = {
+function toPutData(variant: VariantKey, ev: Tree.ClientEval): PutData {
+  const data: PutData = {
     fen: ev.fen,
     knodes: Math.round(ev.nodes / 1000),
     depth: ev.depth,
@@ -46,14 +50,15 @@ function toPutData(variant: VariantKey, ev: Tree.ClientEval) {
 }
 
 // from server eval to client eval
-function toCeval(e: Tree.ServerEval) {
+function toCeval(e: Tree.ServerEval): Tree.ClientEval {
+  // TODO: this type is not quite right
   const res: any = {
     fen: e.fen,
     nodes: e.knodes * 1000,
     depth: e.depth,
     pvs: e.pvs.map(from => {
-      const to: any = {
-        moves: (from.moves as any).split(' '), // moves come from the server as a single string
+      const to: Tree.PvData = {
+        moves: from.moves.split(' '), // moves come from the server as a single string
       };
       if (defined(from.cp)) to.cp = from.cp;
       else to.mate = from.mate;

--- a/ui/analyse/src/forecast/interfaces.ts
+++ b/ui/analyse/src/forecast/interfaces.ts
@@ -14,13 +14,13 @@ export interface ForecastStep {
 }
 
 export interface ForecastCtrl {
-  reloadToLastPly();
+  reloadToLastPly(): void;
   truncate(fc: ForecastStep[]): ForecastStep[];
-  playAndSave(node: ForecastStep);
+  playAndSave(node: ForecastStep): void;
   findStartingWithNode(node: ForecastStep): ForecastStep[][];
   isCandidate(fc: ForecastStep[]): boolean;
-  addNodes(fc: ForecastStep[]);
-  removeIndex(index: number);
+  addNodes(fc: ForecastStep[]): void;
+  removeIndex(index: number): void;
   list(): ForecastStep[][];
   loading: Prop<boolean>;
   onMyTurn: boolean;

--- a/ui/analyse/src/ground.ts
+++ b/ui/analyse/src/ground.ts
@@ -50,7 +50,7 @@ export function makeConfig(ctrl: AnalyseCtrl): CgConfig {
     check: opts.check,
     lastMove: opts.lastMove,
     orientation: ctrl.bottomColor(),
-    coordinates: pref.coords !== 0 && !ctrl.embed,
+    coordinates: pref.coords !== Prefs.Coords.Hidden && !ctrl.embed,
     addPieceZIndex: pref.is3d,
     viewOnly: !!ctrl.embed,
     movable: {
@@ -64,8 +64,8 @@ export function makeConfig(ctrl: AnalyseCtrl): CgConfig {
       move: ctrl.userMove,
       dropNewPiece: ctrl.userNewPiece,
       insert(elements: cg.Elements) {
-        if (!ctrl.embed) resizeHandle(elements, 2, ctrl.node.ply);
-        if (!ctrl.embed && ctrl.data.pref.coords == 1) changeColorHandle();
+        if (!ctrl.embed) resizeHandle(elements, Prefs.ShowResizeHandle.Always, ctrl.node.ply);
+        if (!ctrl.embed && ctrl.data.pref.coords == Prefs.Coords.Inside) changeColorHandle();
       },
     },
     premovable: {

--- a/ui/analyse/src/interfaces.ts
+++ b/ui/analyse/src/interfaces.ts
@@ -60,7 +60,7 @@ export interface CachedEval {
   fen: Fen;
   knodes: number;
   depth: number;
-  pvs: Tree.PvData[];
+  pvs: Tree.PvDataServer[];
   path: string;
 }
 
@@ -112,7 +112,7 @@ export interface AnalysisSide {
 export interface AnalyseOpts {
   element: HTMLElement;
   data: AnalyseData;
-  userId: string | null;
+  userId?: string;
   hunter: boolean;
   embed: boolean;
   explorer: ExplorerOpts;

--- a/ui/analyse/src/interfaces.ts
+++ b/ui/analyse/src/interfaces.ts
@@ -7,6 +7,8 @@ import { RelayData } from './study/relay/interfaces';
 import AnalyseController from './ctrl';
 import { ChatCtrl } from 'chat';
 import { ExplorerOpts } from './explorer/interfaces';
+import { StudyData } from './study/interfaces';
+import { AnalyseSocketSend } from './socket';
 
 export type MaybeVNode = VNode | string | null | undefined;
 export type MaybeVNodes = MaybeVNode[];
@@ -40,13 +42,23 @@ export interface AnalyseData {
   evalPut?: boolean;
   practiceGoal?: PracticeGoal;
   clock?: Clock;
-  pref: any;
+  pref: AnalysePref;
   url: {
     socket: string;
   };
   userTv?: {
     id: string;
   };
+}
+
+export interface AnalysePref {
+  coords: Prefs.Coords;
+  is3d?: boolean;
+  showDests?: boolean;
+  rookCastle?: boolean;
+  destination?: boolean;
+  highlight?: boolean;
+  animationDuration?: number;
 }
 
 export interface ServerEvalData {
@@ -116,9 +128,9 @@ export interface AnalyseOpts {
   hunter: boolean;
   embed: boolean;
   explorer: ExplorerOpts;
-  socketSend: SocketSend;
+  socketSend: AnalyseSocketSend;
   trans: Trans;
-  study?: any;
+  study?: StudyData;
   tagTypes?: string;
   practice?: StudyPracticeData;
   relay?: RelayData;
@@ -133,6 +145,18 @@ export interface AnalyseOpts {
 
 export interface JustCaptured extends cg.Piece {
   promoted?: boolean;
+}
+
+export interface EvalGetData {
+  fen: Fen;
+  path: string;
+  variant?: VariantKey;
+  mpv?: number;
+  up?: boolean;
+}
+
+export interface EvalPutData extends Tree.ServerEval {
+  variant?: VariantKey;
 }
 
 export type Conceal = false | 'conceal' | 'hide' | null;

--- a/ui/analyse/src/moveView.ts
+++ b/ui/analyse/src/moveView.ts
@@ -31,11 +31,11 @@ export function renderIndex(ply: Ply, withDots?: boolean): VNode {
 }
 
 export function renderMove(ctx: Ctx, node: Tree.Node): VNode[] {
-  const ev: any = cevalView.getBestEval({ client: node.ceval, server: node.eval }) || {};
+  const ev = cevalView.getBestEval({ client: node.ceval, server: node.eval });
   const nodes = [h('san', fixCrazySan(node.san!))];
   if (node.glyphs && ctx.showGlyphs) node.glyphs.forEach(g => nodes.push(renderGlyph(g)));
   if (node.shapes) nodes.push(h('shapes', 'K'));
-  if (ctx.showEval) {
+  if (ev && ctx.showEval) {
     if (defined(ev.cp)) nodes.push(renderEval(normalizeEval(ev.cp)));
     else if (defined(ev.mate)) nodes.push(renderEval('#' + ev.mate));
   }

--- a/ui/analyse/src/practice/practiceCtrl.ts
+++ b/ui/analyse/src/practice/practiceCtrl.ts
@@ -32,11 +32,11 @@ export interface PracticeCtrl {
   onJump(): void;
   isMyTurn(): boolean;
   comment: Prop<Comment | null>;
-  running;
-  hovering;
-  hinting;
-  resume;
-  playableDepth;
+  running: Prop<boolean>;
+  hovering: Prop<{ uci: string } | null>;
+  hinting: Prop<Hinting | null>;
+  resume(): void;
+  playableDepth(): number;
   reset(): void;
   preUserJump(from: Tree.Path, to: Tree.Path): void;
   postUserJump(from: Tree.Path, to: Tree.Path): void;
@@ -53,7 +53,7 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
   const variant = root.data.game.variant.key,
     running = prop(true),
     comment = prop<Comment | null>(null),
-    hovering = prop<any>(null),
+    hovering = prop<{ uci: string } | null>(null),
     hinting = prop<Hinting | null>(null),
     played = prop(false);
 

--- a/ui/analyse/src/practice/practiceCtrl.ts
+++ b/ui/analyse/src/practice/practiceCtrl.ts
@@ -92,7 +92,7 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
   }
 
   function makeComment(prev: Tree.Node, node: Tree.Node, path: Tree.Path): Comment {
-    let verdict: Verdict, best;
+    let verdict: Verdict, best: Uci | undefined;
     const outcome = root.outcome(node);
 
     if (outcome && outcome.winner) verdict = 'goodMove';
@@ -102,8 +102,9 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
       const prevEval: Eval = tbhitToEval(prev.tbhit) || prev.ceval!;
       const shift = -winningChances.povDiff(root.bottomColor(), nodeEval, prevEval);
 
-      best = nodeBestUci(prev)!;
-      if (best === node.uci || (node.san!.startsWith('O-O') && best === altCastles[node.uci!])) best = null;
+      best = nodeBestUci(prev);
+      if (best === node.uci || (node.san!.startsWith('O-O') && best === (altCastles as Dictionary<Uci>)[node.uci!]))
+        best = undefined;
 
       if (!best) verdict = 'goodMove';
       else if (shift < 0.025) verdict = 'goodMove';
@@ -121,7 +122,7 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
         ? {
             uci: best,
             san: root.position(prev).unwrap(
-              pos => makeSan(pos, parseUci(best)!),
+              pos => makeSan(pos, parseUci(best!)!),
               _ => '--'
             ),
           }

--- a/ui/analyse/src/retrospect/retroView.ts
+++ b/ui/analyse/src/retrospect/retroView.ts
@@ -67,7 +67,7 @@ const feedback = {
                     showGlyphs: true,
                     showEval: false,
                   },
-                  ctrl.current().fault.node
+                  ctrl.current()!.fault.node
                 )!
               )
             )
@@ -138,7 +138,7 @@ const feedback = {
                       withDots: true,
                       showEval: false,
                     },
-                    ctrl.current().solution.node
+                    ctrl.current()!.solution.node
                   )!
                 )
               )
@@ -202,7 +202,7 @@ const feedback = {
   },
 };
 
-function renderFeedback(root: AnalyseCtrl, fb) {
+function renderFeedback(root: AnalyseCtrl, fb: Exclude<keyof typeof feedback, 'end'>) {
   const ctrl: RetroCtrl = root.retro!;
   const current = ctrl.current();
   if (ctrl.isSolving() && current && root.path !== current.prev.path) return feedback.offTrack(ctrl);

--- a/ui/analyse/src/serverSideUnderboard.ts
+++ b/ui/analyse/src/serverSideUnderboard.ts
@@ -15,7 +15,7 @@ export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
     $menu = $('.analyse__underboard__menu'),
     $timeChart = $('#movetimes-chart'),
     inputFen = document.querySelector('.analyse__underboard__fen') as HTMLInputElement,
-    unselect = chart => {
+    unselect = (chart: any) => {
       chart.getSelectedPoints().forEach(function (point) {
         point.select(false);
       });

--- a/ui/analyse/src/serverSideUnderboard.ts
+++ b/ui/analyse/src/serverSideUnderboard.ts
@@ -1,9 +1,15 @@
+import type Highcharts from 'highcharts';
+
 import AnalyseCtrl from './ctrl';
 import { baseUrl } from './util';
 import { defined } from 'common';
 import modal from 'common/modal';
 import { formToXhr } from 'common/xhr';
 import { AnalyseData } from './interfaces';
+
+interface PlyChart extends Highcharts.ChartObject {
+  lastPly?: Ply | false;
+}
 
 export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
   $(element).replaceWith(ctrl.opts.$underboard!);
@@ -15,7 +21,7 @@ export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
     $menu = $('.analyse__underboard__menu'),
     $timeChart = $('#movetimes-chart'),
     inputFen = document.querySelector('.analyse__underboard__fen') as HTMLInputElement,
-    unselect = (chart: any) => {
+    unselect = (chart: Highcharts.ChartObject) => {
       chart.getSelectedPoints().forEach(function (point) {
         point.select(false);
       });
@@ -35,7 +41,7 @@ export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
         lastFen = fen;
       }
       if ($chart.length) {
-        const chart = $chart[0]!['highcharts'];
+        const chart: PlyChart = ($chart[0] as HighchartsHTMLElement).highcharts;
         if (chart) {
           if (mainlinePly != chart.lastPly) {
             if (mainlinePly === false) unselect(chart);
@@ -49,7 +55,7 @@ export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
         }
       }
       if ($timeChart.length) {
-        const chart = $timeChart[0]!['highcharts'];
+        const chart: PlyChart = ($timeChart[0] as HighchartsHTMLElement).highcharts;
         if (chart) {
           if (mainlinePly != chart.lastPly) {
             if (mainlinePly === false) unselect(chart);

--- a/ui/analyse/src/socket.ts
+++ b/ui/analyse/src/socket.ts
@@ -1,46 +1,84 @@
 import { initial as initialBoardFen } from 'chessground/fen';
 import { ops as treeOps } from 'tree';
 import AnalyseCtrl from './ctrl';
-import { CachedEval, ServerEvalData } from './interfaces';
+import { CachedEval, EvalGetData, EvalPutData, ServerEvalData } from './interfaces';
+import { AnaDests, AnaDrop, AnaMove, ChapterData, EditChapterData } from './study/interfaces';
+import { FormData as StudyFormData } from './study/studyForm';
 
-type DestsCache = {
+interface DestsCache {
   [fen: string]: AnaDests;
-};
-type AnaDests = {
-  dests: string;
-  path: string;
-  ch?: string;
-  opening?: {
-    eco: string;
-    name: string;
-  };
-};
-
-// TODO: Split into request types
-export interface Req {
-  ch?: string; // TODO: needs to be defined in studies before sending
-  sticky?: boolean;
-  write?: boolean;
-  path: string;
-  variant?: VariantKey;
-  fen?: string;
-  shapes?: Tree.Shape[];
-  jumpTo?: Tree.Path;
-  toMainline?: boolean;
-  force?: boolean;
 }
 
+interface AnaDestsReq {
+  fen: Fen;
+  path: string;
+  ch?: string;
+  variant?: VariantKey;
+}
+
+interface MoveOpts {
+  write?: false;
+  sticky?: false;
+}
+
+export interface ReqPosition {
+  ch: string;
+  path: string;
+}
+
+export type StudySocketSendParams =
+  | [t: 'setPath', d: ReqPosition]
+  | [t: 'deleteNode', d: ReqPosition & { jumpTo: string }]
+  | [t: 'promote', d: ReqPosition & { toMainline: boolean }]
+  | [t: 'forceVariation', d: ReqPosition & { force: boolean }]
+  | [t: 'shapes', d: ReqPosition & { shapes: Tree.Shape[] }]
+  | [t: 'setComment', d: ReqPosition & { text: string }]
+  | [t: 'deleteComment', d: ReqPosition & { id: string }]
+  | [t: 'setGamebook', d: ReqPosition & { gamebook: { deviation?: string; hint?: string } }]
+  | [t: 'toggleGlyph', d: ReqPosition & { id: number }]
+  | [t: 'explorerGame', d: ReqPosition & { gameId: string; insert: boolean }]
+  | [t: 'setChapter', chapterId: string]
+  | [t: 'setRole', d: { userId: string; role: string }]
+  | [t: 'addChapter', d: ChapterData & { sticky?: boolean }]
+  | [t: 'editChapter', d: EditChapterData]
+  | [t: 'descStudy', desc: string]
+  | [t: 'descChapter', d: { id: string; desc: string }]
+  | [t: 'deleteChapter', chapterId: string]
+  | [t: 'clearAnnotations', chapterId: string]
+  | [t: 'sortChapters', chapterIds: string[]]
+  | [t: 'setTag', d: { chapterId: string; name: string; value: string }]
+  | [t: 'anaMove', d: AnaMove & MoveOpts]
+  | [t: 'anaDrop', d: AnaDrop & MoveOpts]
+  | [t: 'anaDests', d: AnaDestsReq]
+  | [t: 'like', d: { liked: boolean }]
+  | [t: 'kick', username: string]
+  | [t: 'editStudy', d: StudyFormData]
+  | [t: 'setTopics', topics: string[]]
+  | [t: 'requestAnalysis', chapterId: string]
+  | [t: 'invite', username: string]
+  | [t: 'relaySync', sync: boolean]
+  | [t: 'leave'];
+
+export type EvalCacheSocketParams = [t: 'evalPut', d: EvalPutData] | [t: 'evalGet', d: EvalGetData];
+
+export type AnalyseSocketSendParams =
+  | StudySocketSendParams
+  | EvalCacheSocketParams
+  | [t: 'startWatching', gameId: string];
+
+export type StudySocketSend = (...[d, t]: StudySocketSendParams) => void;
+export type AnalyseSocketSend = (...[d, t]: AnalyseSocketSendParams) => void;
+
 export interface Socket {
-  send: SocketSend;
+  send: AnalyseSocketSend;
   receive(type: string, data: any): boolean;
-  sendAnaMove(req: Req): void;
-  sendAnaDrop(req: Req): void;
-  sendAnaDests(req: Req): void;
-  sendForecasts(req: Req): void;
+  sendAnaMove(d: AnaMove): void;
+  sendAnaDrop(d: AnaDrop): void;
+  sendAnaDests(d: AnaDestsReq): void;
   clearCache(): void;
 }
 
-export function make(send: SocketSend, ctrl: AnalyseCtrl): Socket {
+export function make(send: AnalyseSocketSend, ctrl: AnalyseCtrl): Socket {
   let anaMoveTimeout: number | undefined;
   let anaDestsTimeout: number | undefined;
 
@@ -70,7 +108,7 @@ export function make(send: SocketSend, ctrl: AnalyseCtrl): Socket {
     return undefined;
   }
 
-  function addStudyData(req: Req, isWrite = false): void {
+  function addStudyData(req: { ch?: string } & MoveOpts, isWrite = false) {
     const c = currentChapterId();
     if (c) {
       req.ch = c;
@@ -83,7 +121,7 @@ export function make(send: SocketSend, ctrl: AnalyseCtrl): Socket {
   }
 
   const handlers = {
-    node(data) {
+    node(data: { ch?: string; node: Tree.Node; path: string }) {
       clearTimeout(anaMoveTimeout);
       // no strict equality here!
       if (data.ch == currentChapterId()) ctrl.addNode(data.node, data.path);
@@ -117,11 +155,11 @@ export function make(send: SocketSend, ctrl: AnalyseCtrl): Socket {
     },
   };
 
-  function withoutStandardVariant(obj: Req) {
+  function withoutStandardVariant(obj: { variant?: VariantKey }) {
     if (obj.variant === 'standard') delete obj.variant;
   }
 
-  function sendAnaDests(req: Req) {
+  function sendAnaDests(req: AnaDestsReq) {
     clearTimeout(anaDestsTimeout);
     if (anaDestsCache[req.path])
       setTimeout(function () {
@@ -138,7 +176,7 @@ export function make(send: SocketSend, ctrl: AnalyseCtrl): Socket {
     }
   }
 
-  function sendAnaMove(req: Req) {
+  function sendAnaMove(req: AnaMove) {
     clearTimeout(anaMoveTimeout);
     withoutStandardVariant(req);
     addStudyData(req, true);
@@ -146,7 +184,7 @@ export function make(send: SocketSend, ctrl: AnalyseCtrl): Socket {
     anaMoveTimeout = setTimeout(() => sendAnaMove(req), 3000);
   }
 
-  function sendAnaDrop(req: Req) {
+  function sendAnaDrop(req: AnaDrop) {
     clearTimeout(anaMoveTimeout);
     withoutStandardVariant(req);
     addStudyData(req, true);
@@ -155,17 +193,17 @@ export function make(send: SocketSend, ctrl: AnalyseCtrl): Socket {
   }
 
   return {
-    receive(type: string, data: any): boolean {
-      const handler = (handlers as Dictionary<(data: any) => void>)[type];
-      if (handler) handler(data);
+    receive(type, data) {
+      const handler = (handlers as SocketHandlers)[type];
+      if (handler) {
+        handler(data);
+        return true;
+      }
       return !!ctrl.study && ctrl.study.socketHandler(type, data);
     },
     sendAnaMove,
     sendAnaDrop,
     sendAnaDests,
-    sendForecasts(req) {
-      send('forecasts', req);
-    },
     clearCache,
     send,
   };

--- a/ui/analyse/src/socket.ts
+++ b/ui/analyse/src/socket.ts
@@ -104,7 +104,7 @@ export function make(send: SocketSend, ctrl: AnalyseCtrl): Socket {
       console.log(data);
       clearTimeout(anaDestsTimeout);
     },
-    fen(e) {
+    fen(e: GameUpdate) {
       if (ctrl.forecast && e.id === ctrl.data.game.id && treeOps.last(ctrl.mainline)!.fen.indexOf(e.fen) !== 0) {
         ctrl.forecast.reloadToLastPly();
       }

--- a/ui/analyse/src/study/chapterEditForm.ts
+++ b/ui/analyse/src/study/chapterEditForm.ts
@@ -4,13 +4,14 @@ import { Redraw } from '../interfaces';
 import { bind, bindSubmit, spinner, option, onInsert, emptyRedButton } from '../util';
 import * as modal from '../modal';
 import * as chapterForm from './chapterNewForm';
-import { StudyChapterConfig, StudyChapterMeta } from './interfaces';
+import { ChapterMode, EditChapterData, Orientation, StudyChapterConfig, StudyChapterMeta } from './interfaces';
+import { StudySocketSend } from '../socket';
 
-interface StudyChapterEditFormCtrl {
+export interface StudyChapterEditFormCtrl {
   current: Prop<StudyChapterMeta | StudyChapterConfig | null>;
   open(data: StudyChapterMeta): void;
   toggle(data: StudyChapterMeta): void;
-  submit(data: any): void;
+  submit(data: Omit<EditChapterData, 'id'>): void;
   delete(id: string): void;
   clearAnnotations(id: string): void;
   isEditing(id: string): boolean;
@@ -19,7 +20,7 @@ interface StudyChapterEditFormCtrl {
 }
 
 export function ctrl(
-  send: SocketSend,
+  send: StudySocketSend,
   chapterConfig: (id: string) => Promise<StudyChapterConfig>,
   trans: Trans,
   redraw: Redraw
@@ -52,8 +53,7 @@ export function ctrl(
     submit(data) {
       const c = current();
       if (c) {
-        data.id = c.id;
-        send('editChapter', data);
+        send('editChapter', { id: c.id, ...data });
         current(null);
       }
       redraw();
@@ -87,11 +87,12 @@ export function view(ctrl: StudyChapterEditFormCtrl): VNode | undefined {
             'form.form3',
             {
               hook: bindSubmit(e => {
-                const o: any = {};
-                'name mode orientation description'.split(' ').forEach(field => {
-                  o[field] = chapterForm.fieldValue(e, field);
+                ctrl.submit({
+                  name: chapterForm.fieldValue(e, 'name'),
+                  mode: chapterForm.fieldValue(e, 'mode') as ChapterMode,
+                  orientation: chapterForm.fieldValue(e, 'orientation') as Orientation,
+                  description: chapterForm.fieldValue(e, 'description'),
                 });
-                ctrl.submit(o);
               }),
             },
             [

--- a/ui/analyse/src/study/commentForm.ts
+++ b/ui/analyse/src/study/commentForm.ts
@@ -1,5 +1,5 @@
 import { h, VNode } from 'snabbdom';
-import { currentComments } from './studyComments';
+import { currentComments, isAuthorObj } from './studyComments';
 import { nodeFullName, bind } from '../util';
 import { prop, Prop } from 'common';
 import throttle from 'common/throttle';
@@ -98,8 +98,8 @@ export function view(root: AnalyseCtrl): VNode {
 
   function setupTextarea(vnode: VNode) {
     const el = vnode.elm as HTMLInputElement,
-      mine = (current!.node.comments || []).find(function (c: any) {
-        return c.by && c.by.id && c.by.id === ctrl.root.opts.userId;
+      mine = (current!.node.comments || []).find(function (c) {
+        return isAuthorObj(c.by) && c.by.id && c.by.id === ctrl.root.opts.userId;
       });
     el.value = mine ? mine.text : '';
     if (ctrl.opening() || ctrl.focus()) requestAnimationFrame(() => el.focus());

--- a/ui/analyse/src/study/description.ts
+++ b/ui/analyse/src/study/description.ts
@@ -2,7 +2,7 @@ import { h, VNode } from 'snabbdom';
 import { StudyCtrl } from './interfaces';
 import { bind, richHTML, onInsert } from '../util';
 
-export type Save = (string) => void;
+export type Save = (t: string) => void;
 
 export class DescriptionCtrl {
   edit = false;

--- a/ui/analyse/src/study/gamebook/gamebookEdit.ts
+++ b/ui/analyse/src/study/gamebook/gamebookEdit.ts
@@ -160,11 +160,11 @@ const saveNode = throttle(500, (ctrl: AnalyseCtrl, gamebook: Tree.Gamebook) => {
   ctrl.redraw();
 });
 
-function nodeGamebookValue(node: Tree.Node, field: string): string {
+function nodeGamebookValue(node: Tree.Node, field: 'deviation' | 'hint'): string {
   return (node.gamebook && node.gamebook[field]) || '';
 }
 
-function textareaHook(ctrl: AnalyseCtrl, field: string): Hooks {
+function textareaHook(ctrl: AnalyseCtrl, field: 'deviation' | 'hint'): Hooks {
   const value = nodeGamebookValue(ctrl.node, field);
   return {
     insert(vnode: VNode) {

--- a/ui/analyse/src/study/gamebook/gamebookPlayCtrl.ts
+++ b/ui/analyse/src/study/gamebook/gamebookPlayCtrl.ts
@@ -2,7 +2,7 @@ import AnalyseCtrl from '../../ctrl';
 import { path as treePath, ops as treeOps } from 'tree';
 import { makeShapesFromUci } from '../../autoShape';
 
-type Feedback = 'play' | 'good' | 'bad' | 'end';
+export type Feedback = 'play' | 'good' | 'bad' | 'end';
 
 export interface State {
   feedback: Feedback;

--- a/ui/analyse/src/study/gamebook/gamebookPlayView.ts
+++ b/ui/analyse/src/study/gamebook/gamebookPlayView.ts
@@ -1,12 +1,14 @@
 import { h, VNode } from 'snabbdom';
-import GamebookPlayCtrl from './gamebookPlayCtrl';
+import GamebookPlayCtrl, { Feedback } from './gamebookPlayCtrl';
 import { bind, dataIcon, iconTag, richHTML } from '../../util';
 // eslint-disable-next-line no-duplicate-imports
 import { State } from './gamebookPlayCtrl';
 
-const defaultComments = {
+const defaultComments: Record<Feedback, string | undefined> = {
   play: 'What would you play in this position?',
   end: 'Congratulations! You completed this lesson.',
+  bad: undefined,
+  good: undefined,
 };
 
 export function render(ctrl: GamebookPlayCtrl): VNode {

--- a/ui/analyse/src/study/interfaces.ts
+++ b/ui/analyse/src/study/interfaces.ts
@@ -1,3 +1,4 @@
+import * as cg from 'chessground/types';
 import { Config as CgConfig } from 'chessground/config';
 import { Prop } from 'common';
 import { NotifCtrl } from './notif';
@@ -17,6 +18,8 @@ import { StudyShareCtrl } from './studyShare';
 import { TagsCtrl } from './studyTags';
 import { StudyFormCtrl } from './studyForm';
 import { StudyMemberCtrl } from './studyMembers';
+import { Opening } from '../explorer/interfaces';
+import { StudySocketSendParams } from '../socket';
 
 export interface StudyCtrl {
   data: StudyData;
@@ -42,7 +45,7 @@ export interface StudyCtrl {
   isChapterOwner(): boolean;
   canJumpTo(path: Tree.Path): boolean;
   onJump(): void;
-  withPosition<T extends {}>(obj: T): T & { ch: string; path: string };
+  withPosition<T>(obj: T): T & { ch: string; path: string };
   setPath(path: Tree.Path, node: Tree.Node, playedMyself: boolean): void;
   deleteNode(path: Tree.Path): void;
   promote(path: Tree.Path, toMainline: boolean): void;
@@ -51,14 +54,14 @@ export interface StudyCtrl {
   toggleSticky(): void;
   toggleWrite(): void;
   isWriting(): boolean;
-  makeChange(t: string, d: any): boolean;
+  makeChange(...args: StudySocketSendParams): boolean;
   startTour(): void;
   userJump(path: Tree.Path): void;
   currentNode(): Tree.Node;
   practice?: StudyPracticeCtrl;
   gamebookPlay(): GamebookPlayCtrl | undefined;
   nextChapter(): StudyChapterMeta | undefined;
-  mutateCgConfig(config: Required<Pick<CgConfig, "drawable">>): void;
+  mutateCgConfig(config: Required<Pick<CgConfig, 'drawable'>>): void;
   isUpdatedRecently(): boolean;
   setGamebookOverride(o: GamebookOverride): void;
   explorerGame(gameId: string, insert: boolean): void;
@@ -69,6 +72,7 @@ export interface StudyCtrl {
 
 export type Tab = 'intro' | 'members' | 'chapters';
 export type ToolTab = 'tags' | 'comments' | 'glyphs' | 'serverEval' | 'share' | 'multiBoard';
+export type Visibility = 'public' | 'unlisted' | 'private';
 
 export interface StudyVm {
   loading: boolean;
@@ -93,7 +97,7 @@ export interface StudyData {
   position: Position;
   ownerId: string;
   settings: StudySettings;
-  visibility: 'public' | 'unlisted' | 'private';
+  visibility: Visibility;
   createdAt: number;
   from: string;
   likes: number;
@@ -225,3 +229,69 @@ export interface ChapterPreviewPlayer {
   title?: string;
   rating?: number;
 }
+
+export type Orientation = 'black' | 'white' | 'auto';
+export type ChapterMode = 'normal' | 'practice' | 'gamebook' | 'conceal';
+
+export interface ChapterData {
+  name: string;
+  game?: string;
+  variant?: VariantKey;
+  fen?: Fen | null;
+  pgn?: string;
+  orientation: Orientation;
+  mode: ChapterMode;
+  initial: boolean;
+  isDefaultName: boolean;
+}
+
+export interface EditChapterData {
+  id: string;
+  name: string;
+  orientation: Orientation;
+  mode: ChapterMode;
+  description: string;
+}
+
+export interface AnaDests {
+  dests: string;
+  path: string;
+  ch?: string;
+  opening?: Opening;
+}
+
+export interface AnaMove {
+  orig: string;
+  dest: string;
+  fen: Fen;
+  path: string;
+  variant?: VariantKey;
+  ch?: string;
+  promotion?: cg.Role;
+}
+
+export interface AnaDrop {
+  role: cg.Role;
+  pos: Key;
+  variant?: VariantKey;
+  fen: Fen;
+  path: string;
+  ch?: string;
+}
+export interface WithWho {
+  w: {
+    s: string;
+    u: string;
+  };
+}
+
+export interface WithPosition {
+  p: Position;
+}
+
+export interface WithChapterId {
+  chapterId: string;
+}
+
+export type WithWhoAndPos = WithWho & WithPosition;
+export type WithWhoAndChap = WithWho & WithChapterId;

--- a/ui/analyse/src/study/interfaces.ts
+++ b/ui/analyse/src/study/interfaces.ts
@@ -1,3 +1,4 @@
+import { Config as CgConfig } from 'chessground/config';
 import { Prop } from 'common';
 import { NotifCtrl } from './notif';
 import { AnalyseData, Redraw } from '../interfaces';
@@ -12,6 +13,10 @@ import { TopicsCtrl } from './topics';
 import RelayCtrl from './relay/relayCtrl';
 import { ServerEvalCtrl } from './serverEval';
 import { MultiBoardCtrl } from './multiBoard';
+import { StudyShareCtrl } from './studyShare';
+import { TagsCtrl } from './studyTags';
+import { StudyFormCtrl } from './studyForm';
+import { StudyMemberCtrl } from './studyMembers';
 
 export interface StudyCtrl {
   data: StudyData;
@@ -20,16 +25,16 @@ export interface StudyCtrl {
   vm: StudyVm;
   relay?: RelayCtrl;
   multiBoard: MultiBoardCtrl;
-  form: any;
-  members: any;
+  form: StudyFormCtrl;
+  members: StudyMemberCtrl;
   chapters: StudyChaptersCtrl;
   notif: NotifCtrl;
   commentForm: CommentForm;
   glyphForm: GlyphCtrl;
   topics: TopicsCtrl;
   serverEval: ServerEvalCtrl;
-  share: any;
-  tags: any;
+  share: StudyShareCtrl;
+  tags: TagsCtrl;
   studyDesc: DescriptionCtrl;
   chapterDesc: DescriptionCtrl;
   toggleLike(): void;
@@ -37,7 +42,7 @@ export interface StudyCtrl {
   isChapterOwner(): boolean;
   canJumpTo(path: Tree.Path): boolean;
   onJump(): void;
-  withPosition(obj: any): any;
+  withPosition<T extends {}>(obj: T): T & { ch: string; path: string };
   setPath(path: Tree.Path, node: Tree.Node, playedMyself: boolean): void;
   deleteNode(path: Tree.Path): void;
   promote(path: Tree.Path, toMainline: boolean): void;
@@ -53,7 +58,7 @@ export interface StudyCtrl {
   practice?: StudyPracticeCtrl;
   gamebookPlay(): GamebookPlayCtrl | undefined;
   nextChapter(): StudyChapterMeta | undefined;
-  mutateCgConfig(config: any): void;
+  mutateCgConfig(config: Required<Pick<CgConfig, "drawable">>): void;
   isUpdatedRecently(): boolean;
   setGamebookOverride(o: GamebookOverride): void;
   explorerGame(gameId: string, insert: boolean): void;

--- a/ui/analyse/src/study/inviteForm.ts
+++ b/ui/analyse/src/study/inviteForm.ts
@@ -3,6 +3,7 @@ import { h, VNode } from 'snabbdom';
 import { modal } from '../modal';
 import { prop, Prop } from 'common';
 import { StudyMemberMap } from './interfaces';
+import { AnalyseSocketSend } from '../socket';
 
 export interface StudyInviteFormCtrl {
   open: Prop<boolean>;
@@ -15,7 +16,7 @@ export interface StudyInviteFormCtrl {
 }
 
 export function makeCtrl(
-  send: SocketSend,
+  send: AnalyseSocketSend,
   members: Prop<StudyMemberMap>,
   setTab: () => void,
   redraw: () => void,

--- a/ui/analyse/src/study/inviteForm.ts
+++ b/ui/analyse/src/study/inviteForm.ts
@@ -4,13 +4,23 @@ import { modal } from '../modal';
 import { prop, Prop } from 'common';
 import { StudyMemberMap } from './interfaces';
 
+export interface StudyInviteFormCtrl {
+  open: Prop<boolean>;
+  members: Prop<StudyMemberMap>;
+  spectators: Prop<string[]>;
+  toggle(): void;
+  invite(titleName: string): void;
+  redraw(): void;
+  trans: Trans;
+}
+
 export function makeCtrl(
   send: SocketSend,
   members: Prop<StudyMemberMap>,
   setTab: () => void,
   redraw: () => void,
   trans: Trans
-) {
+): StudyInviteFormCtrl {
   const open = prop(false),
     spectators = prop<string[]>([]);
   return {

--- a/ui/analyse/src/study/relay/relayCtrl.ts
+++ b/ui/analyse/src/study/relay/relayCtrl.ts
@@ -1,6 +1,8 @@
 import { RelayData, LogEvent, RelayIntro } from './interfaces';
 import { StudyChapter, StudyChapterRelay } from '../interfaces';
 import { isFinished } from '../studyChapters';
+import { StudyMemberCtrl } from '../studyMembers';
+import { AnalyseSocketSend } from '../../socket';
 
 export default class RelayCtrl {
   log: LogEvent[] = [];
@@ -10,9 +12,9 @@ export default class RelayCtrl {
 
   constructor(
     public data: RelayData,
-    readonly send: SocketSend,
+    readonly send: AnalyseSocketSend,
     readonly redraw: () => void,
-    readonly members: any,
+    readonly members: StudyMemberCtrl,
     chapter: StudyChapter
   ) {
     this.applyChapterRelay(chapter, chapter.relay);
@@ -54,7 +56,6 @@ export default class RelayCtrl {
       this.redraw();
     },
     relayLog: (event: LogEvent) => {
-      if (event.id !== this.data.id) return;
       this.data.sync.log.push(event);
       this.data.sync.log = this.data.sync.log.slice(-20);
       this.cooldown = true;
@@ -67,12 +68,12 @@ export default class RelayCtrl {
     },
   };
 
-  socketHandler = (t: string, d: any) => {
-    const handler = this.socketHandlers[t];
+  socketHandler(t: string, d: any) {
+    const handler = (this.socketHandlers as SocketHandlers)[t];
     if (handler && d.id === this.data.id) {
       handler(d);
       return true;
     }
     return false;
-  };
+  }
 }

--- a/ui/analyse/src/study/relay/relayCtrl.ts
+++ b/ui/analyse/src/study/relay/relayCtrl.ts
@@ -68,12 +68,12 @@ export default class RelayCtrl {
     },
   };
 
-  socketHandler(t: string, d: any) {
+  socketHandler = (t: string, d: any): boolean => {
     const handler = (this.socketHandlers as SocketHandlers)[t];
     if (handler && d.id === this.data.id) {
       handler(d);
       return true;
     }
     return false;
-  }
+  };
 }

--- a/ui/analyse/src/study/serverEval.ts
+++ b/ui/analyse/src/study/serverEval.ts
@@ -2,6 +2,7 @@ import AnalyseCtrl from '../ctrl';
 import { h, VNode } from 'snabbdom';
 import { Prop, prop, defined } from 'common';
 import { spinner, bind, onInsert } from '../util';
+import Highcharts from 'highcharts';
 
 export interface ServerEvalCtrl {
   requested: Prop<boolean>;
@@ -9,7 +10,7 @@ export interface ServerEvalCtrl {
   chapterId(): string;
   request(): void;
   onMergeAnalysisData(): void;
-  chartEl: Prop<HTMLElement | null>;
+  chartEl: Prop<HighchartsHTMLElement | null>;
   reset(): void;
   lastPly: Prop<number | false>;
 }
@@ -17,17 +18,17 @@ export interface ServerEvalCtrl {
 export function ctrl(root: AnalyseCtrl, chapterId: () => string): ServerEvalCtrl {
   const requested = prop(false),
     lastPly = prop<number | false>(false),
-    chartEl = prop<HTMLElement | null>(null);
+    chartEl = prop<HighchartsHTMLElement | null>(null);
 
-  function unselect(chart: any) {
-    chart.getSelectedPoints().forEach((p: any) => p.select(false));
+  function unselect(chart: Highcharts.ChartObject) {
+    chart.getSelectedPoints().forEach(p => p.select(false));
   }
 
   lichess.pubsub.on('analysis.change', (_fen: string, _path: string, mainlinePly: number | false) => {
     if (!lichess.advantageChart || lastPly() === mainlinePly) return;
     const lp = lastPly(typeof mainlinePly === 'undefined' ? lastPly() : mainlinePly),
       el = chartEl(),
-      chart = el && el['highcharts'];
+      chart = el && el.highcharts;
     if (chart) {
       if (lp === false) unselect(chart);
       else {
@@ -73,7 +74,7 @@ export function view(ctrl: ServerEvalCtrl): VNode {
           () =>
             lichess.loadScript('javascripts/chart/acpl.js').then(() => {
               lichess.advantageChart!(ctrl.root.data, ctrl.root.trans, el);
-              ctrl.chartEl(el);
+              ctrl.chartEl(el as HighchartsHTMLElement);
             }),
           800
         );

--- a/ui/analyse/src/study/serverEval.ts
+++ b/ui/analyse/src/study/serverEval.ts
@@ -19,8 +19,8 @@ export function ctrl(root: AnalyseCtrl, chapterId: () => string): ServerEvalCtrl
     lastPly = prop<number | false>(false),
     chartEl = prop<HTMLElement | null>(null);
 
-  function unselect(chart) {
-    chart.getSelectedPoints().forEach(p => p.select(false));
+  function unselect(chart: any) {
+    chart.getSelectedPoints().forEach((p: any) => p.select(false));
   }
 
   lichess.pubsub.on('analysis.change', (_fen: string, _path: string, mainlinePly: number | false) => {

--- a/ui/analyse/src/study/studyChapters.ts
+++ b/ui/analyse/src/study/studyChapters.ts
@@ -2,13 +2,14 @@ import { h, VNode } from 'snabbdom';
 import { prop, Prop } from 'common';
 import { bind, dataIcon, iconTag, scrollTo } from '../util';
 import { ctrl as chapterNewForm, StudyChapterNewFormCtrl } from './chapterNewForm';
-import { ctrl as chapterEditForm } from './chapterEditForm';
+import { ctrl as chapterEditForm, StudyChapterEditFormCtrl } from './chapterEditForm';
 import AnalyseCtrl from '../ctrl';
 import { StudyCtrl, StudyChapterMeta, LocalPaths, StudyChapter, TagArray, StudyChapterConfig } from './interfaces';
+import { StudySocketSend } from '../socket';
 
 export interface StudyChaptersCtrl {
   newForm: StudyChapterNewFormCtrl;
-  editForm: any;
+  editForm: StudyChapterEditFormCtrl;
   list: Prop<StudyChapterMeta[]>;
   get(id: string): StudyChapterMeta | undefined;
   size(): number;
@@ -20,7 +21,7 @@ export interface StudyChaptersCtrl {
 
 export function ctrl(
   initChapters: StudyChapterMeta[],
-  send: SocketSend,
+  send: StudySocketSend,
   setTab: () => void,
   chapterConfig: (id: string) => Promise<StudyChapterConfig>,
   root: AnalyseCtrl
@@ -116,8 +117,10 @@ export function view(ctrl: StudyCtrl): VNode {
             const target = e.target as HTMLElement;
             const id = (target.parentNode as HTMLElement).getAttribute('data-id') || target.getAttribute('data-id');
             if (!id) return;
-            if (target.tagName === 'ACT') ctrl.chapters.editForm.toggle(ctrl.chapters.get(id));
-            else ctrl.setChapter(id);
+            if (target.tagName === 'ACT') {
+              const chapter = ctrl.chapters.get(id);
+              if (chapter) ctrl.chapters.editForm.toggle(chapter);
+            } else ctrl.setChapter(id);
           });
           vnode.data!.li = {};
           update(vnode);

--- a/ui/analyse/src/study/studyComments.ts
+++ b/ui/analyse/src/study/studyComments.ts
@@ -3,11 +3,11 @@ import AnalyseCtrl from '../ctrl';
 import { nodeFullName, bind, richHTML } from '../util';
 import { StudyCtrl } from './interfaces';
 
-type AuthorObj = {
+export type AuthorObj = {
   id: string;
   name: string;
 };
-type Author = AuthorObj | string | undefined;
+export type Author = AuthorObj | string;
 
 function authorDom(author: Author): string | VNode {
   if (!author) return 'Unknown';
@@ -21,7 +21,11 @@ function authorDom(author: Author): string | VNode {
   );
 }
 
-export function authorText(author: Author): string {
+export function isAuthorObj(author: Author): author is AuthorObj {
+  return typeof author === 'object';
+}
+
+export function authorText(author?: Author): string {
   if (!author) return 'Unknown';
   if (typeof author === 'string') return author;
   return author.name;
@@ -37,8 +41,8 @@ export function currentComments(ctrl: AnalyseCtrl, includingMine: boolean): VNod
   return h(
     'div',
     comments.map((comment: Tree.Comment) => {
-      const by: any = comment.by;
-      const isMine = by.id && ctrl.opts.userId === by.id;
+      const by: Author = comment.by;
+      const isMine = isAuthorObj(by) && by.id === ctrl.opts.userId;
       if (!includingMine && isMine) return;
       const canDelete = isMine || study.members.isOwner();
       return h('div.study__comment.' + comment.id, [

--- a/ui/analyse/src/study/studyComments.ts
+++ b/ui/analyse/src/study/studyComments.ts
@@ -3,9 +3,15 @@ import AnalyseCtrl from '../ctrl';
 import { nodeFullName, bind, richHTML } from '../util';
 import { StudyCtrl } from './interfaces';
 
-function authorDom(author) {
+type AuthorObj = {
+  id: string;
+  name: string;
+};
+type Author = AuthorObj | string | undefined;
+
+function authorDom(author: Author): string | VNode {
   if (!author) return 'Unknown';
-  if (!author.name) return author;
+  if (typeof author === 'string') return author;
   return h(
     'span.user-link.ulpt',
     {
@@ -15,9 +21,9 @@ function authorDom(author) {
   );
 }
 
-export function authorText(author): string {
+export function authorText(author: Author): string {
   if (!author) return 'Unknown';
-  if (!author.name) return author;
+  if (typeof author === 'string') return author;
   return author.name;
 }
 

--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -1,3 +1,4 @@
+import { Config as CgConfig } from 'chessground/config';
 import { prop } from 'common';
 import throttle from 'common/throttle';
 import debounce from 'common/debounce';
@@ -64,7 +65,7 @@ export default function (
 
   const members = memberCtrl({
     initDict: data.members,
-    myId: practiceData ? null : ctrl.opts.userId,
+    myId: practiceData ? undefined : ctrl.opts.userId,
     ownerId: data.ownerId,
     send,
     tab: vm.tab,
@@ -200,9 +201,15 @@ export default function (
     const sameChapter = data.chapter.id === s.chapter.id;
     vm.mode.sticky = (vm.mode.sticky && s.features.sticky) || (!data.features.sticky && s.features.sticky);
     if (vm.mode.sticky) vm.behind = 0;
-    'position name visibility features settings chapter likes liked description'.split(' ').forEach(key => {
-      data[key] = s[key];
-    });
+    data.position = s.position;
+    data.name = s.name;
+    data.visibility = s.visibility;
+    data.features = s.features;
+    data.settings = s.settings;
+    data.chapter = s.chapter;
+    data.likes = s.likes;
+    data.liked = s.liked;
+    data.description = s.description;
     chapterDesc.set(data.chapter.description);
     studyDesc.set(data.description);
     document.title = data.name;
@@ -283,7 +290,7 @@ export default function (
   }
   instanciateGamebookPlay();
 
-  function mutateCgConfig(config) {
+  function mutateCgConfig(config: Required<Pick<CgConfig, 'drawable'>>) {
     config.drawable.onChange = (shapes: Tree.Shape[]) => {
       if (vm.mode.write) {
         ctrl.tree.setShapes(shapes, ctrl.path);
@@ -313,10 +320,11 @@ export default function (
     vm.updatedAt = Date.now();
   }
 
-  function withPosition(obj: any) {
-    obj.ch = vm.chapterId;
-    obj.path = ctrl.path;
-    return obj;
+  function withPosition<T extends {}>(obj: T): T & { ch: string; path: string } {
+    const o = obj as any;
+    o.ch = vm.chapterId;
+    o.path = ctrl.path;
+    return o;
   }
 
   const likeToggler = debounce(() => send('like', { liked: data.liked }), 1000);

--- a/ui/analyse/src/study/studyForm.ts
+++ b/ui/analyse/src/study/studyForm.ts
@@ -17,8 +17,15 @@ export interface StudyFormCtrl {
   relay?: RelayCtrl;
 }
 
-interface FormData {
-  [key: string]: string;
+export interface FormData {
+  name: string;
+  visibility: string;
+  computer: string;
+  explorer: string;
+  cloneable: string;
+  chat: string;
+  sticky: 'true' | 'false';
+  description: 'true' | 'false';
 }
 
 interface Select {
@@ -119,12 +126,24 @@ export function view(ctrl: StudyFormCtrl): VNode {
         'form.form3',
         {
           hook: bindSubmit(e => {
-            const obj: FormData = {};
-            'name visibility computer explorer cloneable chat sticky description'.split(' ').forEach(n => {
-              const el = (e.target as HTMLElement).querySelector('#study-' + n) as HTMLInputElement;
-              if (el) obj[n] = el.value;
-            });
-            ctrl.save(obj, isNew);
+            const getVal = (name: string): string => {
+              const el = (e.target as HTMLElement).querySelector('#study-' + name) as HTMLInputElement;
+              if (el) return el.value;
+              else throw `Missing form input: ${name}`;
+            };
+            ctrl.save(
+              {
+                name: getVal('name'),
+                visibility: getVal('visibility'),
+                computer: getVal('computer'),
+                explorer: getVal('explorer'),
+                cloneable: getVal('cloneable'),
+                chat: getVal('chat'),
+                sticky: getVal('sticky') as 'true' | 'false',
+                description: getVal('description') as 'true' | 'false',
+              },
+              isNew
+            );
           }, ctrl.redraw),
         },
         [

--- a/ui/analyse/src/study/studyGlyph.ts
+++ b/ui/analyse/src/study/studyGlyph.ts
@@ -13,7 +13,7 @@ interface AllGlyphs {
 
 export interface GlyphCtrl {
   root: AnalyseCtrl;
-  all: Prop<AllGlyphs>;
+  all: Prop<AllGlyphs | null>;
   loadGlyphs(): void;
   toggleGlyph(id: Tree.GlyphId): void;
   redraw(): void;
@@ -42,8 +42,8 @@ function renderGlyph(ctrl: GlyphCtrl, node: Tree.Node) {
   };
 }
 
-export function ctrl(root: AnalyseCtrl) {
-  const all = prop<any | null>(null);
+export function ctrl(root: AnalyseCtrl): GlyphCtrl {
+  const all = prop<AllGlyphs | null>(null);
 
   function loadGlyphs() {
     if (!all())

--- a/ui/analyse/src/study/studyMembers.ts
+++ b/ui/analyse/src/study/studyMembers.ts
@@ -1,13 +1,35 @@
 import { h, VNode } from 'snabbdom';
 import { titleNameToId, bind, dataIcon, iconTag, onInsert, scrollTo } from '../util';
 import { prop, Prop } from 'common';
-import { makeCtrl as inviteFormCtrl } from './inviteForm';
+import { makeCtrl as inviteFormCtrl, StudyInviteFormCtrl } from './inviteForm';
 import { StudyCtrl, StudyMember, StudyMemberMap, Tab } from './interfaces';
 import { NotifCtrl } from './notif';
 
+export interface StudyMemberCtrl {
+  dict: Prop<StudyMemberMap>;
+  confing: Prop<string | undefined>;
+  myId?: string;
+  inviteForm: StudyInviteFormCtrl;
+  update(members: StudyMemberMap): void;
+  setActive(id: string): void;
+  isActive(id: string): boolean;
+  owner(): StudyMember;
+  myMember(): StudyMember | undefined;
+  isOwner(): boolean;
+  canContribute(): boolean;
+  max: number;
+  setRole(id: string, role: string): void;
+  kick(id: string): void;
+  leave(): void;
+  ordered(): StudyMember[];
+  size(): number;
+  isOnline(userId: string): boolean;
+  hasOnlineContributor(): boolean;
+}
+
 interface Opts {
   initDict: StudyMemberMap;
-  myId: string | null;
+  myId: string | undefined;
   ownerId: string;
   send: SocketSend;
   tab: Prop<Tab>;
@@ -29,7 +51,7 @@ function memberActivity(onIdle: () => void) {
   return schedule;
 }
 
-export function ctrl(opts: Opts) {
+export function ctrl(opts: Opts): StudyMemberCtrl {
   const dict = prop<StudyMemberMap>(opts.initDict);
   const confing = prop<string | undefined>(undefined);
   const active: { [id: string]: () => void } = {};
@@ -46,7 +68,7 @@ export function ctrl(opts: Opts) {
   }
 
   function myMember() {
-    return opts.myId ? dict()[opts.myId] : null;
+    return opts.myId ? dict()[opts.myId] : undefined;
   }
 
   function canContribute(): boolean {
@@ -194,7 +216,7 @@ export function view(ctrl: StudyCtrl): VNode {
         hook: bind(
           'click',
           _ => {
-            members.confing(members.confing() === member.user.id ? null : member.user.id);
+            members.confing(members.confing() === member.user.id ? undefined : member.user.id);
           },
           ctrl.redraw
         ),

--- a/ui/analyse/src/study/studyMembers.ts
+++ b/ui/analyse/src/study/studyMembers.ts
@@ -4,6 +4,7 @@ import { prop, Prop } from 'common';
 import { makeCtrl as inviteFormCtrl, StudyInviteFormCtrl } from './inviteForm';
 import { StudyCtrl, StudyMember, StudyMemberMap, Tab } from './interfaces';
 import { NotifCtrl } from './notif';
+import { AnalyseSocketSend } from '../socket';
 
 export interface StudyMemberCtrl {
   dict: Prop<StudyMemberMap>;
@@ -31,7 +32,7 @@ interface Opts {
   initDict: StudyMemberMap;
   myId: string | undefined;
   ownerId: string;
-  send: SocketSend;
+  send: AnalyseSocketSend;
   tab: Prop<Tab>;
   startTour(): void;
   notif: NotifCtrl;

--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -4,7 +4,7 @@ import { prop, Prop } from 'common';
 import { renderIndexAndMove } from '../moveView';
 import { StudyData, StudyChapterMeta } from './interfaces';
 
-interface StudyShareCtrl {
+export interface StudyShareCtrl {
   studyId: string;
   chapter: () => StudyChapterMeta;
   isPrivate(): boolean;

--- a/ui/analyse/src/study/studyTags.ts
+++ b/ui/analyse/src/study/studyTags.ts
@@ -105,7 +105,7 @@ function renderPgnTags(
 }
 
 export function ctrl(root: AnalyseCtrl, getChapter: () => StudyChapter, types: string[]): TagsCtrl {
-  const submit = throttle(500, function (name, value) {
+  const submit = throttle(500, function (name: string, value: string) {
     root.study!.makeChange('setTag', {
       chapterId: getChapter().id,
       name,

--- a/ui/analyse/src/treeView/columnView.ts
+++ b/ui/analyse/src/treeView/columnView.ts
@@ -113,7 +113,7 @@ function renderLines(ctx: Ctx, nodes: Tree.Node[], opts: Opts): VNode {
     },
     nodes.map(n => {
       return (
-        retroLine(ctx, n, opts) ||
+        retroLine(ctx, n) ||
         h(
           'line',
           renderMoveAndChildrenOf(ctx, n, {

--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -67,7 +67,7 @@ function renderLines(ctx: Ctx, nodes: Tree.Node[], opts: Opts): VNode {
     'lines',
     nodes.map(n => {
       return (
-        retroLine(ctx, n, opts) ||
+        retroLine(ctx, n) ||
         h(
           'line',
           renderMoveAndChildrenOf(ctx, n, {

--- a/ui/analyse/src/treeView/treeView.ts
+++ b/ui/analyse/src/treeView/treeView.ts
@@ -88,9 +88,10 @@ export function nodeClasses(ctx: Ctx, node: Tree.Node, path: Tree.Path): NodeCla
 }
 
 export function findCurrentPath(c: AnalyseCtrl): Tree.Path | undefined {
+  let cur;
   return (
     (!c.synthetic && playable(c.data) && c.initialPath) ||
-    (c.retro && c.retro.current() && c.retro.current().prev.path) ||
+    (c.retro && (cur = c.retro.current()) && cur.prev.path) ||
     (c.study && c.study.data.chapter.relay && c.study.data.chapter.relay.path)
   );
 }
@@ -152,8 +153,8 @@ export function mainHook(ctrl: AnalyseCtrl): Hooks {
   };
 }
 
-export function retroLine(ctx: Ctx, node: Tree.Node, opts: Opts): VNode | undefined {
-  return node.comp && ctx.ctrl.retro && ctx.ctrl.retro.hideComputerLine(node, opts.parentPath)
+export function retroLine(ctx: Ctx, node: Tree.Node): VNode | undefined {
+  return node.comp && ctx.ctrl.retro && ctx.ctrl.retro.hideComputerLine(node)
     ? h('line', ctx.ctrl.trans.noarg('learnFromThisMistake'))
     : undefined;
 }
@@ -176,4 +177,4 @@ export const autoScroll = throttle(200, (ctrl: AnalyseCtrl, el: HTMLElement) => 
   cont.scrollTop = target.offsetTop - cont.offsetHeight / 2 + target.offsetHeight;
 });
 
-export const nonEmpty = (x: any): boolean => !!x;
+export const nonEmpty = (x: unknown): boolean => !!x;

--- a/ui/analyse/src/util.ts
+++ b/ui/analyse/src/util.ts
@@ -13,7 +13,7 @@ export function plyColor(ply: number): Color {
   return ply % 2 === 0 ? 'white' : 'black';
 }
 
-export function bindMobileMousedown(el: HTMLElement, f: (e: Event) => any, redraw?: () => void) {
+export function bindMobileMousedown(el: HTMLElement, f: (e: Event) => unknown, redraw?: () => void) {
   for (const mousedownEvent of ['touchstart', 'mousedown']) {
     el.addEventListener(mousedownEvent, e => {
       f(e);
@@ -23,7 +23,7 @@ export function bindMobileMousedown(el: HTMLElement, f: (e: Event) => any, redra
   }
 }
 
-export function bindMobileTapHold(el: HTMLElement, f: (e: Event) => any, redraw?: () => void) {
+export function bindMobileTapHold(el: HTMLElement, f: (e: Event) => unknown, redraw?: () => void) {
   let longPressCountdown: number;
 
   el.addEventListener('touchstart', e => {
@@ -46,7 +46,7 @@ export function bindMobileTapHold(el: HTMLElement, f: (e: Event) => any, redraw?
   });
 }
 
-function listenTo(el: HTMLElement, eventName: string, f: (e: Event) => any, redraw?: () => void) {
+function listenTo(el: HTMLElement, eventName: string, f: (e: Event) => unknown, redraw?: () => void) {
   el.addEventListener(eventName, e => {
     const res = f(e);
     if (res === false) e.preventDefault();
@@ -55,11 +55,11 @@ function listenTo(el: HTMLElement, eventName: string, f: (e: Event) => any, redr
   });
 }
 
-export function bind(eventName: string, f: (e: Event) => any, redraw?: () => void): Hooks {
+export function bind(eventName: string, f: (e: Event) => unknown, redraw?: () => void): Hooks {
   return onInsert(el => listenTo(el, eventName, f, redraw));
 }
 
-export function bindSubmit(f: (e: Event) => any, redraw?: () => void): Hooks {
+export function bindSubmit(f: (e: Event) => unknown, redraw?: () => void): Hooks {
   return bind(
     'submit',
     e => {

--- a/ui/analyse/src/util.ts
+++ b/ui/analyse/src/util.ts
@@ -222,13 +222,12 @@ export function scrollTo(el: HTMLElement | undefined, target: HTMLElement | null
   if (el && target) el.scrollTop = target.offsetTop - el.offsetHeight / 2 + target.offsetHeight / 2;
 }
 
-export function treeReconstruct(parts: any): Tree.Node {
+export function treeReconstruct(parts: Tree.Node[]): Tree.Node {
   const root = parts[0],
     nb = parts.length;
-  let node = root,
-    i: number;
+  let node = root;
   root.id = '';
-  for (i = 1; i < nb; i++) {
+  for (let i = 1; i < nb; i++) {
     const n = parts[i];
     if (node.children) node.children.unshift(n);
     else node.children = [n];

--- a/ui/analyse/src/view.ts
+++ b/ui/analyse/src/view.ts
@@ -284,7 +284,7 @@ function controls(ctrl: AnalyseCtrl) {
 }
 
 function forceInnerCoords(ctrl: AnalyseCtrl, v: boolean) {
-  if (ctrl.data.pref.coords == 2) {
+  if (ctrl.data.pref.coords === Prefs.Coords.Outside) {
     $('body').toggleClass('coords-in', v).toggleClass('coords-out', !v);
     changeColorHandle();
   }

--- a/ui/analyse/tsconfig.json
+++ b/ui/analyse/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "noImplicitAny": false,
     "esModuleInterop": true
   }
 }

--- a/ui/common/src/resize.ts
+++ b/ui/common/src/resize.ts
@@ -6,8 +6,8 @@ type MouchEvent = Event & Partial<MouseEvent & TouchEvent>;
 
 type Visible = (ply: Ply) => boolean;
 
-export default function resizeHandle(els: cg.Elements, pref: number, ply: number, visible?: Visible) {
-  if (!pref) return;
+export default function resizeHandle(els: cg.Elements, pref: Prefs.ShowResizeHandle, ply: number, visible?: Visible) {
+  if (pref === Prefs.ShowResizeHandle.Never) return;
 
   const el = document.createElement('cg-resize');
   els.container.appendChild(el);
@@ -52,7 +52,7 @@ export default function resizeHandle(els: cg.Elements, pref: number, ply: number
   el.addEventListener('touchstart', startResize, { passive: false });
   el.addEventListener('mousedown', startResize, { passive: false });
 
-  if (pref == 1) {
+  if (pref === Prefs.ShowResizeHandle.OnlyAtStart) {
     const toggle = (ply: number) => el.classList.toggle('none', visible ? !visible(ply) : ply >= 2);
     toggle(ply);
     lichess.pubsub.on('ply', toggle);

--- a/ui/puz/src/interfaces.ts
+++ b/ui/puz/src/interfaces.ts
@@ -15,7 +15,7 @@ export interface Promotion {
 }
 
 export interface PuzPrefs {
-  coords: 0 | 1 | 2;
+  coords: Prefs.Coords;
   is3d: boolean;
   destination: boolean;
   rookCastle: boolean;

--- a/ui/puz/src/view/chessground.ts
+++ b/ui/puz/src/view/chessground.ts
@@ -10,7 +10,7 @@ export function makeConfig(opts: CgConfig, pref: PuzPrefs, userMove: UserMove): 
     turnColor: opts.turnColor,
     check: opts.check,
     lastMove: opts.lastMove,
-    coordinates: pref.coords !== 0,
+    coordinates: pref.coords !== Prefs.Coords.Hidden,
     addPieceZIndex: pref.is3d,
     movable: {
       free: false,
@@ -29,8 +29,8 @@ export function makeConfig(opts: CgConfig, pref: PuzPrefs, userMove: UserMove): 
     events: {
       move: userMove,
       insert(elements) {
-        resizeHandle(elements, 1, 0, p => p == 0);
-        if (pref.coords == 1) changeColorHandle();
+        resizeHandle(elements, Prefs.ShowResizeHandle.OnlyAtStart, 0, p => p == 0);
+        if (pref.coords == Prefs.Coords.Inside) changeColorHandle();
       },
     },
     premovable: {

--- a/ui/puzzle/src/interfaces.ts
+++ b/ui/puzzle/src/interfaces.ts
@@ -107,7 +107,7 @@ export interface PuzzleOpts {
 }
 
 export interface PuzzlePrefs {
-  coords: 0 | 1 | 2;
+  coords: Prefs.Coords;
   is3d: boolean;
   destination: boolean;
   rookCastle: boolean;

--- a/ui/puzzle/src/view/chessground.ts
+++ b/ui/puzzle/src/view/chessground.ts
@@ -22,7 +22,7 @@ function makeConfig(ctrl: Controller): CgConfig {
     turnColor: opts.turnColor,
     check: opts.check,
     lastMove: opts.lastMove,
-    coordinates: ctrl.pref.coords !== 0,
+    coordinates: ctrl.pref.coords !== Prefs.Coords.Hidden,
     addPieceZIndex: ctrl.pref.is3d,
     movable: {
       free: false,
@@ -41,8 +41,8 @@ function makeConfig(ctrl: Controller): CgConfig {
     events: {
       move: ctrl.userMove,
       insert(elements) {
-        resizeHandle(elements, 2, ctrl.vm.node.ply, _ => true);
-        if (ctrl.pref.coords == 1) changeColorHandle();
+        resizeHandle(elements, Prefs.ShowResizeHandle.Always, ctrl.vm.node.ply, _ => true);
+        if (ctrl.pref.coords === Prefs.Coords.Inside) changeColorHandle();
       },
     },
     premovable: {

--- a/ui/puzzle/src/view/main.ts
+++ b/ui/puzzle/src/view/main.ts
@@ -87,7 +87,7 @@ export default function (ctrl: Controller): VNode {
       hook: {
         postpatch(old, vnode) {
           if (old.data!.gaugeOn !== gaugeOn) {
-            if (ctrl.pref.coords == 2) {
+            if (ctrl.pref.coords === Prefs.Coords.Outside) {
               $('body').toggleClass('coords-in', gaugeOn).toggleClass('coords-out', !gaugeOn);
               changeColorHandle();
             }

--- a/ui/round/src/clock/clockCtrl.ts
+++ b/ui/round/src/clock/clockCtrl.ts
@@ -12,8 +12,6 @@ interface ClockOpts {
   nvui: boolean;
 }
 
-export type TenthsPref = 0 | 1 | 2;
-
 export interface ClockData {
   running: boolean;
   initial: Seconds;
@@ -21,7 +19,7 @@ export interface ClockData {
   white: Seconds;
   black: Seconds;
   emerg: Seconds;
-  showTenths: TenthsPref;
+  showTenths: Prefs.ShowClockTenths;
   showBar: boolean;
   moretime: number;
 }
@@ -80,9 +78,9 @@ export class ClockController {
   constructor(d: RoundData, readonly opts: ClockOpts) {
     const cdata = d.clock!;
 
-    if (cdata.showTenths === 0) this.showTenths = () => false;
+    if (cdata.showTenths === Prefs.ShowClockTenths.Never) this.showTenths = () => false;
     else {
-      const cutoff = cdata.showTenths === 1 ? 10000 : 3600000;
+      const cutoff = cdata.showTenths === Prefs.ShowClockTenths.Below10Secs ? 10000 : 3600000;
       this.showTenths = time => time < cutoff;
     }
 

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -253,8 +253,8 @@ export default class RoundController {
   replayEnabledByPref = (): boolean => {
     const d = this.data;
     return (
-      d.pref.replay === 2 ||
-      (d.pref.replay === 1 &&
+      d.pref.replay === Prefs.Replay.Always ||
+      (d.pref.replay === Prefs.Replay.OnlySlowGames &&
         (d.game.speed === 'classical' || d.game.speed === 'unlimited' || d.game.speed === 'correspondence'))
     );
   };

--- a/ui/round/src/ground.ts
+++ b/ui/round/src/ground.ts
@@ -21,7 +21,7 @@ export function makeConfig(ctrl: RoundController): Config {
     turnColor: step.ply % 2 === 0 ? 'white' : 'black',
     lastMove: util.uci2move(step.uci),
     check: !!step.check,
-    coordinates: data.pref.coords !== 0,
+    coordinates: data.pref.coords !== Prefs.Coords.Hidden,
     addPieceZIndex: ctrl.data.pref.is3d,
     highlight: {
       lastMove: data.pref.highlight,
@@ -32,7 +32,7 @@ export function makeConfig(ctrl: RoundController): Config {
       dropNewPiece: hooks.onNewPiece,
       insert(elements) {
         resizeHandle(elements, ctrl.data.pref.resizeHandle, ctrl.ply);
-        if (data.pref.coords == 1) changeColorHandle();
+        if (data.pref.coords === Prefs.Coords.Inside) changeColorHandle();
       },
     },
     movable: {
@@ -69,11 +69,11 @@ export function makeConfig(ctrl: RoundController): Config {
       },
     },
     draggable: {
-      enabled: data.pref.moveEvent > 0,
+      enabled: data.pref.moveEvent !== Prefs.MoveEvent.Click,
       showGhost: data.pref.highlight,
     },
     selectable: {
-      enabled: data.pref.moveEvent !== 1,
+      enabled: data.pref.moveEvent !== Prefs.MoveEvent.Drag,
     },
     drawable: {
       enabled: true,

--- a/ui/round/src/interfaces.ts
+++ b/ui/round/src/interfaces.ts
@@ -164,24 +164,24 @@ export interface StepCrazy extends Untyped {}
 
 export interface Pref {
   animationDuration: number;
-  autoQueen: 1 | 2 | 3;
+  autoQueen: Prefs.AutoQueen;
   blindfold: boolean;
   clockBar: boolean;
   clockSound: boolean;
-  clockTenths: 0 | 1 | 2;
+  clockTenths: Prefs.ShowClockTenths;
   confirmResign: boolean;
-  coords: 0 | 1 | 2;
+  coords: Prefs.Coords;
   destination: boolean;
   enablePremove: boolean;
   highlight: boolean;
   is3d: boolean;
   keyboardMove: boolean;
-  moveEvent: 0 | 1 | 2;
-  replay: 0 | 1 | 2;
+  moveEvent: Prefs.MoveEvent;
+  replay: Prefs.Replay;
   rookCastle: boolean;
   showCaptured: boolean;
   submitMove: boolean;
-  resizeHandle: 0 | 1 | 2;
+  resizeHandle: Prefs.ShowResizeHandle;
 }
 
 export interface MoveMetadata {

--- a/ui/round/src/promotion.ts
+++ b/ui/round/src/promotion.ts
@@ -46,7 +46,9 @@ export function start(
     if (
       !meta.ctrlKey &&
       !promoting &&
-      (d.pref.autoQueen === 3 || (d.pref.autoQueen === 2 && premovePiece) || ctrl.keyboardMove?.justSelected())
+      (d.pref.autoQueen === Prefs.AutoQueen.Always ||
+        (d.pref.autoQueen === Prefs.AutoQueen.OnPremove && premovePiece) ||
+        ctrl.keyboardMove?.justSelected())
     ) {
       if (premovePiece) setPrePromotion(ctrl, dest, 'queen');
       else sendPromotion(ctrl, orig, dest, 'queen', meta);

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,6 +152,11 @@
   dependencies:
     moment "^2.10.2"
 
+"@types/debounce-promise@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@types/debounce-promise/-/debounce-promise-3.1.3.tgz#dd0d6b96ee61da0dd4c413e3ea03a425ffa36b3f"
+  integrity sha512-mjcCf//DAUQ6YLQMhqYJAv/+a4BsE1GQFmy1el5K62wLJJmQwGi3TsnshhOFynPpuBF9Gh2Vvb+5ImPi47KaZw==
+
 "@types/estree@*":
   version "0.0.47"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.47.tgz#d7a51db20f0650efec24cd04994f523d93172ed4"
@@ -174,6 +179,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/geojson@*":
+  version "7946.0.7"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.7.tgz#c8fa532b60a0042219cdf173ca21a975ef0666ad"
+  integrity sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -181,6 +191,13 @@
   dependencies:
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/highcharts@4.2.57":
+  version "4.2.57"
+  resolved "https://registry.yarnpkg.com/@types/highcharts/-/highcharts-4.2.57.tgz#f756907fc1756c3148a6226efabd3520a8929db9"
+  integrity sha512-8/RF3I2Zy4I8ll9Ksa+wTbHA7ne/OHilmaTBQTVpQdNtOX6dL7EWFXfcfwiXQAfL+0r48LifHjYDmqug0t8mQA==
+  dependencies:
+    "@types/geojson" "*"
 
 "@types/json-schema@^7.0.3":
   version "7.0.7"


### PR DESCRIPTION
Maybe this has gotten a bit too big ...

Summary:
- Add `@types` for `highcharts` and `debounce-promise`
- Replace numeric preference types with `const enum`s
- Add types to socket sending and receiving functions in `ui/analyse`
- Remove as many `any`s as possible and generally improve type-safety wherever possible in `ui/analyse` 
- Add/adjust types and type annotaitons as necessary so that everything typechecks correctly
- Remove `sendForecasts()` (It seems to be handled via HTTP requests instead of WS messages now? At least I didn't find any usage or handler of this stuff and it still works without it.)
- A few other small fixes here and there

I think pretty much the only remaining loose type-situation in `ui/analyse` is in ` ui/analyse/src/evalCache.ts::toCeval`. Somehow, the return type doesn't really match because it's missing several properties like `maxDepth`?

Feel free to ask if anything looks strange. I hope it's still manageable to review. If you find it too bad I guess I can probably also split it up into smaller parts.