### PR TITLE
Add httpie tool installation link in Login.md

### DIFF
--- a/doc/mobile/login.md
+++ b/doc/mobile/login.md
@@ -1,5 +1,8 @@
 # Login as a lichess user
 
+## Prerequisites
+Install [httpie tool](https://httpie.io/docs#installation) to be able to run `http` commands to access the endpoints mentioned below.
+
 ## Login
 
 Returns an authentication cookie and a `user` object.


### PR DESCRIPTION
This PR is a minor documentation enhancement which achieves the following:
 - Add link to httpie tool installation to be able to run the `http` commands mentioned in the doc