### PR TITLE
Fix BrowserStack link in Readme (for dark mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ HTTP requests and WebSocket connections can be proxied by [nginx](https://nginx.
 The web client is written in [TypeScript](https://www.typescriptlang.org/) and [snabbdom](https://github.com/snabbdom/snabbdom), using [Sass](https://sass-lang.com/) to generate CSS.
 The [blog](https://lichess.org/blog) uses a free open content plan from [prismic.io](https://prismic.io).
 All rated games are published in a [free PGN database](https://database.lichess.org).
-Browser testing done with [![Browserstack](https://raw.githubusercontent.com/ornicar/lila/master/public/images/browserstack.png)](https://www.browserstack.com).
+Browser testing done with [Browserstack](https://www.browserstack.com).
 Proxy detection done with [IP2Proxy database](https://www.ip2location.com/database/ip2proxy).
 Please help us [translate Lichess with Crowdin](https://crowdin.com/project/lichess).
 


### PR DESCRIPTION
This PR is a minor document update that achieves the following:
 - Fix BrowserStack link visibility for dark mode

**Before Fix**
<img width="130" alt="Screenshot 2021-04-24 at 6 43 24 PM" src="https://user-images.githubusercontent.com/18529185/115960101-04f1d100-a52d-11eb-8f51-07ba282e67df.png">

**After Fix**
<img width="138" alt="Screenshot 2021-04-24 at 6 39 28 PM" src="https://user-images.githubusercontent.com/18529185/115959953-6f564180-a52c-11eb-823a-59bcd9e79d06.png">