### PR TITLE
Fix accepting draw via API when not able to send draw

### DIFF
--- a/modules/bot/src/main/BotPlayer.scala
+++ b/modules/bot/src/main/BotPlayer.scala
@@ -91,7 +91,7 @@ final class BotPlayer(
       tellRound(pov.gameId, DrawNo(PlayerId(pov.playerId)))
 
   def offerDraw(pov: Pov): Unit =
-    if (pov.game.drawable && pov.game.playerCanOfferDraw(pov.color))
+    if (pov.game.drawable && (pov.game.playerCanOfferDraw(pov.color) || pov.opponent.isOfferingDraw))
       tellRound(pov.gameId, DrawYes(PlayerId(pov.playerId)))
 
   def setDraw(pov: Pov, v: Boolean): Unit =


### PR DESCRIPTION
Closes #8745

Fixes that you currently can't accept a draw offer via the API when you aren't able to send one. i.e. if you send a draw offer, the opponent declines but then sends their own offer during the next few turns you can't accept it via the API.

Side note: Looking at [RoundSocket.scala](https://github.com/ornicar/lila/blob/master/modules/round/src/main/RoundSocket.scala#L106), it looks like similar checks are only performed client-side when not playing via the API (i.e. via websockets)?

Would it be worth unifying this with the API code?