### PR TITLE
Improve clarity of met/failed tournament requirements

### DIFF
--- a/app/views/tournament/side.scala
+++ b/app/views/tournament/side.scala
@@ -65,7 +65,8 @@ object side {
         },
         tour.looksLikePrize option bits.userPrizeDisclaimer(tour.createdBy),
         verdicts.relevant option st.section(
-          dataIcon := "7",
+          dataIcon := (if (ctx.isAuth && verdicts.accepted) "E"
+                       else "L"),
           cls := List(
             "conditions" -> true,
             "accepted"   -> (ctx.isAuth && verdicts.accepted),

--- a/app/views/tournament/side.scala
+++ b/app/views/tournament/side.scala
@@ -70,7 +70,7 @@ object side {
           cls := List(
             "conditions" -> true,
             "accepted"   -> (ctx.isAuth && verdicts.accepted),
-            "refused"    -> (ctx.isAuth && !verdicts.accepted)
+            "refused"    -> (!ctx.isAuth || !verdicts.accepted)
           )
         )(
           div(

--- a/ui/tournament/css/_side.scss
+++ b/ui/tournament/css/_side.scss
@@ -66,6 +66,10 @@
         &.accepted::after {
             content: ' \2713';
           }
+
+        &.refused::after {
+          content: ' \2718';
+        }
       }
     }
   }

--- a/ui/tournament/css/_side.scss
+++ b/ui/tournament/css/_side.scss
@@ -61,6 +61,12 @@
       .refused {
         color: $c-bad;
       }
+
+      &.condition{
+        &.accepted::after {
+            content: ' \2713';
+          }
+      }
     }
   }
 

--- a/ui/tournament/css/_side.scss
+++ b/ui/tournament/css/_side.scss
@@ -62,10 +62,10 @@
         color: $c-bad;
       }
 
-      .condition{
+      .condition {
         &.accepted::after {
-            content: ' \2713';
-          }
+          content: ' \2713';
+        }
 
         &.refused::after {
           content: ' \2718';

--- a/ui/tournament/css/_side.scss
+++ b/ui/tournament/css/_side.scss
@@ -62,7 +62,7 @@
         color: $c-bad;
       }
 
-      &.condition{
+      .condition{
         &.accepted::after {
             content: ' \2713';
           }


### PR DESCRIPTION
https://github.com/ornicar/lila/issues/8702

When all conditions are met:

![image](https://user-images.githubusercontent.com/29963548/116014909-73a25d80-a605-11eb-9a9c-8516d90fdbed.png)

When one or more conditions are NOT met:

![image](https://user-images.githubusercontent.com/29963548/116014942-9cc2ee00-a605-11eb-8222-6711f6754bd9.png)