### PR TITLE
Add round number to Swiss tournament documentation

### DIFF
--- a/app/views/swiss/home.scala
+++ b/app/views/swiss/home.scala
@@ -228,7 +228,7 @@ object home {
       i("?"),
       p(
         strong("Can players late-join?"),
-        "Yes, until more than half the rounds have started; for example in a 11-rounds swiss players can join before round 6 starts and in a 12-rounds before round starts.",
+        "Yes, until more than half the rounds have started; for example in a 11-rounds swiss players can join before round 6 starts and in a 12-rounds before round 7 starts.",
         br,
         "Late joiners get a single bye, even if they missed several rounds."
       )


### PR DESCRIPTION
The answer to the question *"Can players late-join?"* was missing the number for the second example. 
The change adds "7 " to match the style of the previous example.