### PR TITLE
Several small fixes for the "New game" button on the homepage

### DIFF
--- a/ui/lobby/src/boot.ts
+++ b/ui/lobby/src/boot.ts
@@ -78,7 +78,12 @@ export default function LichessLobby(opts: LobbyOpts) {
       $(this).addClass('active').siblings().removeClass('active');
       lichess.loadCssPath('lobby.setup');
       lobby.leavePool();
-      fetch(this.href, {
+      let url = this.href;
+      if (this.dataset.hrefAddon) {
+        url += this.dataset.hrefAddon;
+        delete this.dataset.hrefAddon;
+      }
+      fetch(url, {
         ...xhr.defaultInit,
         headers: xhr.xhrHeader,
       }).then(res =>
@@ -101,7 +106,7 @@ export default function LichessLobby(opts: LobbyOpts) {
     $startButtons
       .find('.config_' + location.hash.replace('#', ''))
       .each(function (this: HTMLElement) {
-        $(this).attr('href', $(this).attr('href') + location.search);
+        this.dataset.hrefAddon = location.search;
       })
       .trigger(clickEvent);
 

--- a/ui/lobby/src/setup.ts
+++ b/ui/lobby/src/setup.ts
@@ -137,7 +137,7 @@ export default class Setup {
       $variantSelect = $form.find('#sf_variant'),
       $fenPosition = $form.find('.fen_position'),
       $fenInput = $fenPosition.find('input'),
-      forceFormPosition = !!$fenInput.val(),
+      forceFromPosition = !!$fenInput.val(),
       $timeInput = $form.find('.time_choice [name=time]'),
       $incrementInput = $form.find('.increment_choice [name=increment]'),
       $daysInput = $form.find('.days_choice [name=days]'),
@@ -151,8 +151,10 @@ export default class Setup {
           rated = $rated.prop('checked'),
           limit = parseFloat($timeInput.val() as string),
           inc = parseFloat($incrementInput.val() as string),
-          // no rated variants with less than 30s on the clock
-          cantBeRated = variantId != '1' && (timeMode != '1' || (limit < 0.5 && inc == 0) || (limit == 0 && inc < 2));
+          // no rated variants with less than 30s on the clock and no rated unlimited in the lobby
+          cantBeRated =
+            (typ === 'hook' && timeMode === '0') ||
+            (variantId != '1' && (timeMode != '1' || (limit < 0.5 && inc == 0) || (limit == 0 && inc < 2)));
         if (cantBeRated && rated) {
           $casual.trigger('click');
           return toggleButtons();
@@ -174,6 +176,7 @@ export default class Setup {
     if (c) {
       Object.keys(c).forEach(k => {
         $form.find(`[name="${k}"]`).each(function (this: HTMLInputElement) {
+          if (k === 'timeMode' && this.value !== '1') return;
           if (this.type == 'checkbox') this.checked = true;
           else if (this.type == 'radio') this.checked = this.value == c[k];
           else if (k != 'fen' || !this.value) this.value = c[k];
@@ -403,7 +406,7 @@ export default class Setup {
     }, 200);
     $fenInput.on('keyup', validateFen);
 
-    if (forceFormPosition) $variantSelect.val('' + 3);
+    if (forceFromPosition) $variantSelect.val('3');
     $variantSelect
       .on('change', function (this: HTMLElement) {
         const isFen = $(this).val() == '3';

--- a/ui/lobby/src/setup.ts
+++ b/ui/lobby/src/setup.ts
@@ -252,7 +252,6 @@ export default class Setup {
         modal.close();
         if (poolMember) {
           this.root.enterPool(poolMember);
-          this.root.redraw();
         } else {
           this.root.setTab($timeModeSelect.val() === '1' ? 'real_time' : 'seeks');
           xhr.text($form.attr('action')!.replace(/sri-placeholder/, lichess.sri), {
@@ -264,6 +263,7 @@ export default class Setup {
             })(),
           });
         }
+        this.root.redraw();
         return false;
       };
       $submits

--- a/ui/lobby/src/view/correspondence.ts
+++ b/ui/lobby/src/view/correspondence.ts
@@ -44,7 +44,14 @@ function createSeek(ctrl: LobbyController): VNode | undefined {
       h(
         'a.button',
         {
-          attrs: { href: '/?time=correspondence#hook' },
+          hook: bind('click', () => {
+            $('.lobby__start .config_hook')
+              .each(function (this: HTMLElement) {
+                this.dataset.hrefAddon = '?time=correspondence';
+              })
+              .trigger('mousedown')
+              .trigger('click');
+          }),
         },
         ctrl.trans('createAGame')
       ),


### PR DESCRIPTION
Closes #8761

1. Don't reload the page when clicking "New game" in the correspondence tab
2. Immediately switch to the correct tab when creating a game
3. Properly disallow rated unlimited time games in the lobby in the UI
4. Respect preselected `timeMode` from server
5. Remove preselected `timeMode` after modal is closed