### PR TITLE
Don't send sandbag warnings when ratings didn't change

### DIFF
--- a/modules/mod/src/main/SandbagWatch.scala
+++ b/modules/mod/src/main/SandbagWatch.scala
@@ -77,7 +77,7 @@ final private class SandbagWatch(
     game.playedTurns <= {
       if (game.variant == chess.variant.Atomic) 3
       else 8
-    }
+    } && game.winner ?? (~_.ratingDiff > 0)
 }
 
 private object SandbagWatch {


### PR DESCRIPTION
Closes #8757

It might make sense to avoid sending warnings in more cases or maybe even never send them at all to bots? But at least this gets rid of some obvious false positives.