### PR TITLE
Learn: Completion modal dark mode

### DIFF
--- a/ui/learn/css/_screen.scss
+++ b/ui/learn/css/_screen.scss
@@ -1,7 +1,7 @@
 .learn__screen-overlay {
   @extend %fullscreen-mask;
 
-  background: rgba(79, 195, 247, 0.9);
+  background: rgba(0, 0, 0, 0.65);
   cursor: pointer;
   display: grid;
 }
@@ -10,11 +10,7 @@
   @extend %popup-shadow, %box-radius;
 
   margin: auto;
-  @if $theme-dark {
-    background-color: #262421;
-  } @else {
-    background-color: #fff;
-  }
+  background-color: $c-bg-box;
   width: 350px;
   overflow: hidden;
   text-align: center;
@@ -44,10 +40,6 @@
 
   .stars {
     margin-bottom: 20px;
-
-    @if $theme-dark {
-      opacity: 0.9;
-    }
   }
 
   @keyframes star-appear {
@@ -121,11 +113,7 @@
 
   h1 {
     font-weight: bold;
-    @if $theme-dark {
-      color: #bababa;
-    } @else {
-      color: #181818;
-    }
+    color: $c-font-clear;
     font-size: 24px;
     margin-bottom: 22px;
   }
@@ -161,11 +149,6 @@
   }
 
   p {
-    @if $theme-dark {
-      color: #999999;
-    } @else {
-      color: #555;
-    }
     padding: 0 15%;
     line-height: 24px;
     margin-bottom: 17px;

--- a/ui/learn/css/_screen.scss
+++ b/ui/learn/css/_screen.scss
@@ -10,7 +10,11 @@
   @extend %popup-shadow, %box-radius;
 
   margin: auto;
-  background-color: #fff;
+  @if $theme-dark {
+    background-color: #262421;
+  } @else {
+    background-color: #fff;
+  }
   width: 350px;
   overflow: hidden;
   text-align: center;
@@ -40,6 +44,10 @@
 
   .stars {
     margin-bottom: 20px;
+
+    @if $theme-dark {
+      opacity: 0.9;
+    }
   }
 
   @keyframes star-appear {
@@ -113,7 +121,11 @@
 
   h1 {
     font-weight: bold;
-    color: #181818;
+    @if $theme-dark {
+      color: #bababa;
+    } @else {
+      color: #181818;
+    }
     font-size: 24px;
     margin-bottom: 22px;
   }
@@ -144,11 +156,16 @@
 
   .score span {
     font-weight: bold;
-    font-family: 'Roboto Mono';
+    font-family: monospace;
+    font-size: 1rem;
   }
 
   p {
-    color: #999999;
+    @if $theme-dark {
+      color: #999999;
+    } @else {
+      color: #555;
+    }
     padding: 0 15%;
     line-height: 24px;
     margin-bottom: 17px;
@@ -178,12 +195,12 @@
 
     .next {
       font-size: 0.9em;
-      background: #4fc3f7;
+      background: #3692e7;
     }
 
     .back {
       font-size: 0.85em;
-      background: #f57c00;
+      background: #e53935f0;
     }
 
     a:hover {


### PR DESCRIPTION
Also adjusts the light mode styling a bit:

| Before | Light | Dark
|:--:|:--:|:--:|
|![prev](https://user-images.githubusercontent.com/19309705/116197365-fa098d00-a734-11eb-90b1-2b1307192b44.png)|![light](https://user-images.githubusercontent.com/19309705/116197383-ffff6e00-a734-11eb-8b59-782ead0a714c.png)|![dark](https://user-images.githubusercontent.com/19309705/116197404-042b8b80-a735-11eb-8f21-b0cc9c3f45fd.png)|

(Click images for a full resolution preview)

Closes #8762