### PR TITLE
clarify appeal notification message

### DIFF
--- a/modules/security/src/main/AutomaticEmail.scala
+++ b/modules/security/src/main/AutomaticEmail.scala
@@ -136,7 +136,7 @@ ${Mailer.txt.serviceNote}
     alsoSendAsPrivateMessage(user) { implicit lang =>
       s"""Hello,
 
-      Your appeal has received a response from the moderation team: ${baseUrl}/appeal
+      Your appeal has received a response from the moderation team, to see it click here: ${baseUrl}/appeal
 
 $regards
 """


### PR DESCRIPTION
When there is a new reply from a mod.

Some players didn't find it otherwise.