### PR TITLE
ui/build: Check node version

### DIFF
--- a/ui/build
+++ b/ui/build
@@ -4,8 +4,11 @@ target=${1-dev}
 mode=${2-build} # build | upgrade | css | js
 echo "building ui modules with target=$target and mode=$mode"
 
-echo "node: $(node --version)"
+nodever="$(node --version)"
+echo "node: $nodever"
 echo "yarn: $(yarn --version)"
+
+[[ "$nodever" =~ ^v1[0-5]\.[0-9]+\.[0-9]+$ ]] || { echo "Node version >=10 and <16 required. Found: $nodever"; exit 1; }
 
 cd "$(git rev-parse --show-toplevel)"
 


### PR DESCRIPTION
Since quite a few people have had issues lately because they tried building with `node` 16.

I guess at some point we should try to find out why it doesn't work and fix it (probably requires updating some dependencies?) but for now this is a simple solution to prevent any more people running into this problem.