### PR TITLE
Improve tournament requirements display

### DIFF
--- a/app/views/swiss/side.scala
+++ b/app/views/swiss/side.scala
@@ -70,11 +70,12 @@ object side {
         teamLink(s.teamId),
         if (verdicts.relevant)
           st.section(
-            dataIcon := "7",
+            dataIcon := (if (ctx.isAuth && verdicts.accepted) "E"
+                         else "L"),
             cls := List(
               "conditions" -> true,
               "accepted"   -> (ctx.isAuth && verdicts.accepted),
-              "refused"    -> (ctx.isAuth && !verdicts.accepted)
+              "refused"    -> (!ctx.isAuth || !verdicts.accepted)
             )
           )(
             div(
@@ -82,9 +83,9 @@ object side {
               verdicts.list map { v =>
                 p(
                   cls := List(
-                    "condition text" -> true,
-                    "accepted"       -> v.verdict.accepted,
-                    "refused"        -> !v.verdict.accepted
+                    "condition" -> true,
+                    "accepted"  -> (v.verdict.accepted && ctx.isAuth),
+                    "refused"   -> (!v.verdict.accepted || !ctx.isAuth)
                   )
                 )(v.condition.name(s.perfType))
               }

--- a/app/views/tournament/side.scala
+++ b/app/views/tournament/side.scala
@@ -78,9 +78,9 @@ object side {
             verdicts.list map { v =>
               p(
                 cls := List(
-                  "condition text" -> true,
-                  "accepted"       -> v.verdict.accepted,
-                  "refused"        -> !v.verdict.accepted
+                  "condition" -> true,
+                  "accepted"  -> (v.verdict.accepted && ctx.isAuth),
+                  "refused"   -> (!v.verdict.accepted || !ctx.isAuth)
                 )
               )(v.condition match {
                 case lila.tournament.Condition.TeamMember(teamId, teamName) =>

--- a/ui/swiss/css/_side.scss
+++ b/ui/swiss/css/_side.scss
@@ -65,6 +65,17 @@
       .refused {
         color: $c-bad;
       }
+
+      .condition:first-child,
+      .condition + .condition {
+        &.accepted::after {
+          content: '\a0\2713';
+        }
+
+        &.refused::after {
+          content: '\a0\2718';
+        }
+      }
     }
   }
 

--- a/ui/tournament/css/_side.scss
+++ b/ui/tournament/css/_side.scss
@@ -62,13 +62,14 @@
         color: $c-bad;
       }
 
-      .condition {
+      .condition:first-child,
+      .condition + .condition {
         &.accepted::after {
-          content: ' \2713';
+          content: '\a0\2713';
         }
 
         &.refused::after {
-          content: ' \2718';
+          content: '\a0\2718';
         }
       }
     }


### PR DESCRIPTION
Closes #8799

Changes:
- Add `nbsp` before postfix symbol
- Make everything red for anons
- Make swiss tournaments consistent with arenas

For anons, it seems pretty weird that all conditions are considered true. Seems like it's because rejected conditions need a reason but as far as I can tell that reason is actually never used for Swiss tournaments and for arenas it's only used when you press the join button without meeting one but it should always be disabled anyway in that case.

So maybe we should just remove the rejected reason and everything related to it? Or I guess if we want to keep the code around, we might as well use it and display it, e.g. as tooltips. But if we keep them, we should probably reject all conditions for anons and just use something like "You are not a registered user" as the reason. Or is there some other reason for this that I'm missing?