### PR TITLE
Changed quiet move description

### DIFF
--- a/translation/source/puzzleTheme.xml
+++ b/translation/source/puzzleTheme.xml
@@ -96,7 +96,7 @@
   <string name="queensideAttack">Queenside attack</string>
   <string name="queensideAttackDescription">An attack of the opponent's king, after they castled on the queen side.</string>
   <string name="quietMove">Quiet move</string>
-  <string name="quietMoveDescription">A move that does not alter material, thus no captures nor promotions. It also exclude moves that present imminent threats, such as check.</string>
+  <string name="quietMoveDescription">A move that does not alter material, thus no captures nor promotions. It also exclude moves that present eminent threats, such as check.</string>
   <string name="rookEndgame">Rook endgame</string>
   <string name="rookEndgameDescription">An endgame with only rooks and pawns.</string>
   <string name="sacrifice">Sacrifice</string>

--- a/translation/source/puzzleTheme.xml
+++ b/translation/source/puzzleTheme.xml
@@ -96,7 +96,7 @@
   <string name="queensideAttack">Queenside attack</string>
   <string name="queensideAttackDescription">An attack of the opponent's king, after they castled on the queen side.</string>
   <string name="quietMove">Quiet move</string>
-  <string name="quietMoveDescription">A move that does not make a check or capture, but does prepare an unavoidable threat for a later move.</string>
+  <string name="quietMoveDescription">A move that does not alter material, thus no captures nor promotions. It also exclude moves that present imminent threats, such as check.</string>
   <string name="rookEndgame">Rook endgame</string>
   <string name="rookEndgameDescription">An endgame with only rooks and pawns.</string>
   <string name="sacrifice">Sacrifice</string>


### PR DESCRIPTION
fixes #8814 
> A move that does not alter material, thus no captures nor promotions. It also exclude moves that present eminent threats, such as check.