### PR TITLE
Add non-color indicator to cmn-toggle

### DIFF
--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -34,17 +34,18 @@
   display: block;
   position: absolute;
   content: '';
+  width: 22px;
+  height: 22px;
+  bottom: 0.1px;
+  left: 0;
 }
 
 .cmn-toggle + label::before {
   @extend %data-icon;
   font-size: 1em;
   z-index: 1;
-  width: 22px;
-  top: 0;
-  right: 16px;
-  line-height: 22px;
   text-align: center;
+  line-height: 22px;
 }
 
 .cmn-toggle:focus + label {
@@ -60,16 +61,12 @@
 .cmn-toggle + label::after {
   @extend %metal;
 
-  width: 22px;
-  height: 22px;
   border-radius: 100%;
   box-shadow: 0 1px 2.5px rgba(0, 0, 0, 0.3);
-  bottom: 0.1px;
-  left: 0;
 }
 
 .cmn-toggle:hover + label::before {
-  transition: right $transition-duration, color $transition-duration;
+  transition: margin $transition-duration, color $transition-duration;
 }
 
 .cmn-toggle:hover + label::after {
@@ -92,6 +89,7 @@
 }
 
 .cmn-toggle:checked + label {
+  &::before,
   &::after {
     margin-left: 15.5px;
   }
@@ -99,6 +97,5 @@
   &::before {
     content: 'E';
     color: $c-good;
-    right: 0;
   }
 }

--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -10,41 +10,48 @@
   outline: none;
   -webkit-user-select: none;
   -moz-user-select: none;
-}
-
-.cmn-toggle + label {
   padding: 1px;
   width: 40px;
   height: 24px;
-  background-color: $c-border;
+  border: 1px solid $c-border;
   border-radius: 24px;
+}
+
+.cmn-toggle:not(:checked) + label {
+  background-color: $c-bad;
+}
+
+.cmn-toggle--subtle:not(:checked) + label {
+  background-color: $c-font-dimmer;
+}
+
+.cmn-toggle:checked + label {
+  background-color: $c-good;
 }
 
 .cmn-toggle + label::before,
 .cmn-toggle + label::after {
   display: block;
   position: absolute;
-  top: 1px;
-  left: 1px;
-  bottom: 1px;
   content: '';
 }
 
 .cmn-toggle + label::before {
-  right: 1px;
-  background-color: $c-bad;
-  border-radius: 24px;
+  @extend %data-icon;
+  font-size: 1em;
+  z-index: 1;
+  width: 22px;
+  top: 0;
+  right: 16px;
+  line-height: 22px;
+  text-align: center;
 }
 
-.cmn-toggle:focus + label::before {
+.cmn-toggle:focus + label {
   @extend %focus-shadow;
 }
 
-.cmn-toggle--subtle + label::before {
-  background-color: $c-font-dimmer;
-}
-
-.cmn-toggle:hover + label::before {
+.cmn-toggle:hover + label {
   @extend %focus-shadow;
 
   @include transition(background);
@@ -54,8 +61,15 @@
   @extend %metal;
 
   width: 22px;
+  height: 22px;
   border-radius: 100%;
   box-shadow: 0 1px 2.5px rgba(0, 0, 0, 0.3);
+  bottom: 0.1px;
+  left: 0;
+}
+
+.cmn-toggle:hover + label::before {
+  transition: right $transition-duration, color $transition-duration;
 }
 
 .cmn-toggle:hover + label::after {
@@ -64,10 +78,27 @@
   @include transition(margin);
 }
 
-.cmn-toggle:checked + label::before {
-  background-color: $c-good;
+.cmn-toggle:not(:checked) + label {
+  &::before {
+    content: 'L';
+    color: $c-bad;
+  }
 }
 
-.cmn-toggle:checked + label::after {
-  margin-left: 16px;
+.cmn-toggle--subtle:not(:checked) + label {
+  &::before {
+    color: $c-font-dimmer;
+  }
+}
+
+.cmn-toggle:checked + label {
+  &::after {
+    margin-left: 15.5px;
+  }
+
+  &::before {
+    content: 'E';
+    color: $c-good;
+    right: 0;
+  }
 }


### PR DESCRIPTION
Closes #7667
Closes #6534

Basically the same as #8584 but I hope it stays positioned correctly now. At least it seems consistent for me in Chrome and FF on any zoom level.