### PR TITLE
Use of prefers-reduced-motion to skip some animation if the user want (https://github.com/ornicar/lila/issues/8764)

### DIFF
--- a/ui/learn/css/_screen.scss
+++ b/ui/learn/css/_screen.scss
@@ -18,6 +18,7 @@
   max-height: 100%;
   overflow: auto;
 
+  @media (prefers-reduced-motion: no-preference) {
   > :nth-child(1) {
     animation: slideIn 1s cubic-bezier(0.37, 0.82, 0.2, 1);
   }
@@ -36,6 +37,7 @@
 
   > :nth-child(5) {
     animation: slideIn 3s cubic-bezier(0.37, 0.82, 0.2, 1);
+  }
   }
 
   .stars {
@@ -94,6 +96,13 @@
     animation: star-appear 2.5s ease-in-out;
     animation-delay: 0.1s;
     animation-fill-mode: forwards;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .stars .star {
+      opacity: 1;
+      animation : none
+    }
   }
 
   .stars .star-wrap:nth-child(2) .star {

--- a/ui/racer/css/_home.scss
+++ b/ui/racer/css/_home.scss
@@ -45,6 +45,13 @@
           font-size: 0.3em;
           animation: boost 0.1s ease-in infinite;
         }
+        @media (prefers-reduced-motion: reduce) {
+          &::before {
+            animation: none;
+            transform: translateX(0%);
+            opacity: 1;
+          }
+        }
       }
     }
   }

--- a/ui/racer/css/_race.scss
+++ b/ui/racer/css/_race.scss
@@ -112,6 +112,13 @@ $c-bg-position-y: 2px;
           font-size: 0.4em;
           animation: boost 0.1s ease-in infinite;
         }
+        @media (prefers-reduced-motion: reduce) {
+          &::before {
+            animation: none;
+            transform: translateX(0%);
+            opacity: 1;
+          }
+        }
       }
     }
 

--- a/ui/site/css/practice/_side.scss
+++ b/ui/site/css/practice/_side.scss
@@ -32,6 +32,13 @@
     opacity: 0.8;
     animation: 1.2s fat-glide ease-in-out infinite;
   }
+  
+  @media (prefers-reduced-motion: reduce) {
+    .fat{
+      animation: none;
+      opacity: 0.8;
+    }
+  }
 
   .progress {
     @extend %box-radius-force;

--- a/ui/storm/css/_play-again.scss
+++ b/ui/storm/css/_play-again.scss
@@ -54,6 +54,13 @@
       &:after {
         animation-delay: 0.1s;
       }
+
+      @media (prefers-reduced-motion: reduce) {
+        &::before,
+        &::after {
+          animation: none;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
On this commit the start/end animation of any chess basic (like how to move a piece), also the golem animation on the side. The blink animation for the boost of the car in the puzzle racer home and in a race has been removed. And the last one is the storm on the button play again of the storm race. All these animation can be removed if the user want by setting "ui.prefersReducedMotion"