### PR TITLE
i18n: Remove leading spaces

### DIFF
--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -848,9 +848,9 @@ computer analysis, game chat and shareable URL.</string>
   <string name="youCannotPostYetPlaySomeGames">You can't post in the forums yet. Play some games!</string>
   <string name="subscribe">Subscribe</string>
   <string name="unsubscribe">Unsubscribe</string>
-  <string name="mentionedYouInX"> mentioned you in "%1$s".</string>
-  <string name="xMentionedYouInY"> %1$s mentioned you in "%2$s".</string>
-  <string name="invitedYouToX"> invited you to "%1$s".</string>
+  <string name="mentionedYouInX">mentioned you in "%1$s".</string>
+  <string name="xMentionedYouInY">%1$s mentioned you in "%2$s".</string>
+  <string name="invitedYouToX">invited you to "%1$s".</string>
   <string name="xInvitedYouToY">%1$s invited you to "%2$s".</string>
   <string name="youAreNowPartOfTeam">You are now part of the team.</string>
   <string name="youHaveJoinedTeamX">You have joined "%1$s".</string>


### PR DESCRIPTION
They aren't rendered anyway. (Those messages are used for notifications and are always in a separate row with the initiating user in the header so the leading space is auto-stripped by the browser.)

Is there some way to automatically update all other languages on crowdin?