### PR TITLE
round: Auto-update berserk icon next to username

### DIFF
--- a/app/templating/GameHelper.scala
+++ b/app/templating/GameHelper.scala
@@ -120,7 +120,6 @@ trait GameHelper { self: I18nHelper with UserHelper with AiHelper with StringHel
     Namer.gameVsTextBlocking(game, withRatings)(lightUser)
 
   val berserkIconSpan = iconTag("`")
-  val statusIconSpan  = i(cls := "status")
 
   def playerLink(
       player: Player,
@@ -129,15 +128,11 @@ trait GameHelper { self: I18nHelper with UserHelper with AiHelper with StringHel
       withRating: Boolean = true,
       withDiff: Boolean = true,
       engine: Boolean = false,
-      withStatus: Boolean = false,
       withBerserk: Boolean = false,
       mod: Boolean = false,
       link: Boolean = true
   )(implicit lang: Lang): Frag = {
-    val statusIcon =
-      if (withStatus) statusIconSpan.some
-      else if (withBerserk && player.berserk) berserkIconSpan.some
-      else none
+    val statusIcon = (withBerserk && player.berserk) option berserkIconSpan
     player.userId.flatMap(lightUser) match {
       case None =>
         val klass = cssClass.??(" " + _)

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -613,6 +613,7 @@ export default class RoundController {
     this.goneBerserk[color] = true;
     if (color !== this.data.player.color) lichess.sound.play('berserk');
     this.redraw();
+    $('<i data-icon="`">').appendTo($(`.game__meta .player.${color} .user-link`));
   };
 
   setLoading = (v: boolean, duration = 1500) => {


### PR DESCRIPTION
Closes #3861

That status stuff was unused and as far as I can tell wouldn't display anything anyway.

Maybe a slightly robuster alternative to doing this via cash would be to reload the side via xhr as is done when the game ends but at the cost of an extra request for each spectator?