### PR TITLE
Fix touch on analysis treeView

### DIFF
--- a/ui/analyse/css/_context-menu.scss
+++ b/ui/analyse/css/_context-menu.scss
@@ -6,6 +6,7 @@
   display: none;
   z-index: z('context-menu');
   cursor: default;
+  user-select: none;
 
   &.visible {
     display: block;

--- a/ui/analyse/src/treeView/contextMenu.ts
+++ b/ui/analyse/src/treeView/contextMenu.ts
@@ -14,22 +14,29 @@ interface Coords {
   y: number;
 }
 
+interface PageOrClientPos {
+  pageX?: number;
+  pageY?: number;
+  clientX?: number;
+  clientY?: number;
+}
+
 const elementId = 'analyse-cm';
 
-function getPosition(e: MouseEvent): Coords | null {
-  let posx = 0,
-    posy = 0;
-  if (e.pageX || e.pageY) {
-    posx = e.pageX;
-    posy = e.pageY;
-  } else if (e.clientX || e.clientY) {
-    posx = e.clientX + document.body.scrollLeft + document.documentElement!.scrollLeft;
-    posy = e.clientY + document.body.scrollTop + document.documentElement!.scrollTop;
-  } else return null;
-  return {
-    x: posx,
-    y: posy,
-  };
+function getPosition(e: MouseEvent | TouchEvent): Coords | null {
+  let pos = e as PageOrClientPos;
+  if (e instanceof TouchEvent && e.touches.length > 0) pos = e.touches[0];
+  if (pos.pageX || pos.pageY)
+    return {
+      x: pos.pageX!,
+      y: pos.pageY!,
+    };
+  else if (pos.clientX || pos.clientY)
+    return {
+      x: pos.clientX! + document.body.scrollLeft + document.documentElement!.scrollLeft,
+      y: pos.clientY! + document.body.scrollTop + document.documentElement!.scrollTop,
+    };
+  else return null;
 }
 
 function positionMenu(menu: HTMLElement, coords: Coords): void {
@@ -65,7 +72,10 @@ function view(opts: Opts, coords: Coords): VNode {
     'div#' + elementId + '.visible',
     {
       hook: {
-        insert: vnode => positionMenu(vnode.elm as HTMLElement, coords),
+        insert: vnode => {
+          vnode.elm!.addEventListener('contextmenu', e => (e.preventDefault(), false));
+          positionMenu(vnode.elm as HTMLElement, coords);
+        },
         postpatch: (_, vnode) => positionMenu(vnode.elm as HTMLElement, coords),
       },
     },
@@ -81,6 +91,12 @@ function view(opts: Opts, coords: Coords): VNode {
 }
 
 export default function (e: MouseEvent, opts: Opts): void {
+  let pos = getPosition(e);
+  if (pos === null) {
+    if (opts.root.contextMenuPath) return;
+    pos = { x: 0, y: 0 };
+  }
+
   const el = ($('#' + elementId)[0] || $('<div id="' + elementId + '">').appendTo($('body'))[0]) as HTMLElement;
   opts.root.contextMenuPath = opts.path;
   function close(e: MouseEvent) {
@@ -92,6 +108,5 @@ export default function (e: MouseEvent, opts: Opts): void {
   }
   document.addEventListener('click', close, false);
   el.innerHTML = '';
-  const pos = getPosition(e);
-  if (pos) patch(el, view(opts, pos));
+  patch(el, view(opts, pos));
 }

--- a/ui/analyse/src/treeView/contextMenu.ts
+++ b/ui/analyse/src/treeView/contextMenu.ts
@@ -16,7 +16,7 @@ interface Coords {
 
 const elementId = 'analyse-cm';
 
-function getPosition(e: MouseEvent): Coords {
+function getPosition(e: MouseEvent): Coords | null {
   let posx = 0,
     posy = 0;
   if (e.pageX || e.pageY) {
@@ -25,7 +25,7 @@ function getPosition(e: MouseEvent): Coords {
   } else if (e.clientX || e.clientY) {
     posx = e.clientX + document.body.scrollLeft + document.documentElement!.scrollLeft;
     posy = e.clientY + document.body.scrollTop + document.documentElement!.scrollTop;
-  }
+  } else return null;
   return {
     x: posx,
     y: posy,
@@ -92,5 +92,6 @@ export default function (e: MouseEvent, opts: Opts): void {
   }
   document.addEventListener('click', close, false);
   el.innerHTML = '';
-  patch(el, view(opts, getPosition(e)));
+  const pos = getPosition(e);
+  if (pos) patch(el, view(opts, pos));
 }

--- a/ui/analyse/src/treeView/treeView.ts
+++ b/ui/analyse/src/treeView/treeView.ts
@@ -135,14 +135,12 @@ export function mainHook(ctrl: AnalyseCtrl): Hooks {
       el.oncontextmenu = callback;
       bindMobileTapHold(el, callback, ctrl.redraw);
 
-      for (const mousedownEvent of ['touchstart', 'mousedown']) {
-        el.addEventListener(mousedownEvent, (e: MouseEvent) => {
-          if (defined(e.button) && e.button !== 0) return; // only touch or left click
-          const path = eventPath(e);
-          if (path) ctrl.userJump(path);
-          ctrl.redraw();
-        });
-      }
+      el.addEventListener('click', (e: MouseEvent) => {
+        if (defined(e.button) && e.button !== 0) return; // only touch or left click
+        const path = eventPath(e);
+        if (path) ctrl.userJump(path);
+        ctrl.redraw();
+      });
     },
     postpatch: (_, vnode) => {
       if (ctrl.autoScrollRequested) {

--- a/ui/analyse/src/treeView/treeView.ts
+++ b/ui/analyse/src/treeView/treeView.ts
@@ -5,7 +5,7 @@ import inline from './inlineView';
 import isCol1 from 'common/isCol1';
 import throttle from 'common/throttle';
 import { authorText as commentAuthorText } from '../study/studyComments';
-import { enrichText, innerHTML, bindMobileTapHold, clearSelection } from '../util';
+import { enrichText, innerHTML, bindMobileTapHold } from '../util';
 import { h, Hooks, VNode } from 'snabbdom';
 import { isEmpty, defined } from 'common';
 import { MaybeVNodes, ConcealOf } from '../interfaces';
@@ -126,7 +126,6 @@ export function mainHook(ctrl: AnalyseCtrl): Hooks {
             path,
             root: ctrl,
           });
-          clearSelection();
         }
         ctrl.redraw();
         return false;

--- a/ui/analyse/src/treeView/treeView.ts
+++ b/ui/analyse/src/treeView/treeView.ts
@@ -119,7 +119,7 @@ export function mainHook(ctrl: AnalyseCtrl): Hooks {
     insert: vnode => {
       const el = vnode.elm as HTMLElement;
       if (ctrl.path !== '') autoScroll(ctrl, el);
-      const callback = (e: MouseEvent) => {
+      const ctxMenuCallback = (e: MouseEvent) => {
         const path = eventPath(e);
         if (path !== null) {
           contextMenu(e, {
@@ -132,10 +132,10 @@ export function mainHook(ctrl: AnalyseCtrl): Hooks {
         return false;
       };
 
-      el.oncontextmenu = callback;
-      bindMobileTapHold(el, callback, ctrl.redraw);
+      el.oncontextmenu = ctxMenuCallback;
+      bindMobileTapHold(el, ctxMenuCallback, ctrl.redraw);
 
-      el.addEventListener('click', (e: MouseEvent) => {
+      el.addEventListener('mousedown', (e: MouseEvent) => {
         if (defined(e.button) && e.button !== 0) return; // only touch or left click
         const path = eventPath(e);
         if (path) ctrl.userJump(path);

--- a/ui/analyse/src/util.ts
+++ b/ui/analyse/src/util.ts
@@ -7,10 +7,6 @@ export const emptyRedButton = 'button.button.button-red.button-empty';
 
 const longPressDuration = 610; // used in bindMobileTapHold
 
-export function clearSelection() {
-  window.getSelection()?.removeAllRanges();
-}
-
 export function plyColor(ply: number): Color {
   return ply % 2 === 0 ? 'white' : 'black';
 }

--- a/ui/tree/css/_tree.scss
+++ b/ui/tree/css/_tree.scss
@@ -18,6 +18,8 @@ $c-blunder: #df5353;
   move {
     @extend %move;
 
+    user-select: none;
+
     &.inaccuracy {
       color: $c-inaccuracy;
     }


### PR DESCRIPTION
Fixes #8851

Looks like browsers send `mousedown` events when a touch ends (i.e. on `touchend`).