### PR TITLE
fixes images in team descriptions 

### DIFF
--- a/ui/site/css/team/_show.scss
+++ b/ui/site/css/team/_show.scss
@@ -122,6 +122,10 @@ $section-margin-more: 5vh;
     margin-bottom: 1rem;
   }
 
+  img {
+    max-width: 100%;
+  }
+  
   .userlist > li,
   .userlist > div.paginated {
     padding: 5px 0 5px 25px;


### PR DESCRIPTION
Images in team descriptions are not fully shown; a good example is here: https://lichess.org/team/offerspill-sjakklubb