### PR TITLE
cmn-toggle: Add disabled styling

### DIFF
--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -16,6 +16,32 @@
   height: 24px;
   border: 1px solid $c-border;
   border-radius: 24px;
+
+  &::before,
+  &::after {
+    display: block;
+    position: absolute;
+    content: '';
+    width: 22px;
+    height: 22px;
+    bottom: 0.1px;
+    left: 0;
+  }
+
+  &::before {
+    @extend %data-icon;
+    font-size: 1em;
+    z-index: 1;
+    text-align: center;
+    line-height: 22px;
+  }
+
+  &::after {
+    @extend %metal;
+
+    border-radius: 100%;
+    box-shadow: 0 1px 2.5px rgba(0, 0, 0, 0.3);
+  }
 }
 
 .cmn-toggle:not(:checked) + label {
@@ -30,50 +56,29 @@
   background-color: $c-good;
 }
 
-.cmn-toggle + label::before,
-.cmn-toggle + label::after {
-  display: block;
-  position: absolute;
-  content: '';
-  width: 22px;
-  height: 22px;
-  bottom: 0.1px;
-  left: 0;
+.cmn-toggle:disabled + label {
+  opacity: 60%;
+  cursor: not-allowed !important;
 }
 
-.cmn-toggle + label::before {
-  @extend %data-icon;
-  font-size: 1em;
-  z-index: 1;
-  text-align: center;
-  line-height: 22px;
-}
-
-.cmn-toggle:focus + label {
+.cmn-toggle:focus:not(:disabled) + label {
   @extend %focus-shadow;
 }
 
-.cmn-toggle:hover + label {
-  @extend %focus-shadow;
+.cmn-toggle:hover:not(:disabled) {
+  + label {
+    @extend %focus-shadow;
+    @include transition(background);
 
-  @include transition(background);
-}
+    &::before {
+      transition: margin $transition-duration, color $transition-duration;
+    }
 
-.cmn-toggle + label::after {
-  @extend %metal;
-
-  border-radius: 100%;
-  box-shadow: 0 1px 2.5px rgba(0, 0, 0, 0.3);
-}
-
-.cmn-toggle:hover + label::before {
-  transition: margin $transition-duration, color $transition-duration;
-}
-
-.cmn-toggle:hover + label::after {
-  @extend %metal-hover;
-
-  @include transition(margin);
+    &::after {
+      @extend %metal-hover;
+      @include transition(margin);
+    }
+  }
 }
 
 .cmn-toggle:not(:checked) + label {
@@ -92,7 +97,7 @@
 .cmn-toggle:checked + label {
   &::before,
   &::after {
-    margin-left: 15.5px;
+    margin-left: 16px;
   }
 
   &::before {

--- a/ui/site/css/team/_show.scss
+++ b/ui/site/css/team/_show.scss
@@ -125,7 +125,7 @@ $section-margin-more: 5vh;
   img {
     max-width: 100%;
   }
-  
+
   .userlist > li,
   .userlist > div.paginated {
     padding: 5px 0 5px 25px;


### PR DESCRIPTION
Make the toggle greyed out, remove the hover effect and change the cursor when it's disabled. Mainly for the token creation page since I don't think disabled toggles appear much elsewhere.

Also reverts a small margin change made in #8834