### PR TITLE
Remove gap on lobby when no simuls

### DIFF
--- a/app/views/lobby/home.scala
+++ b/app/views/lobby/home.scala
@@ -50,8 +50,9 @@ object home {
     ) {
       main(
         cls := List(
-          "lobby"      -> true,
-          "lobby-nope" -> (playban.isDefined || currentGame.isDefined)
+          "lobby"            -> true,
+          "lobby-nope"       -> (playban.isDefined || currentGame.isDefined),
+          "lobby--no-simuls" -> simuls.isEmpty
         )
       )(
         div(cls := "lobby__table")(

--- a/ui/lobby/css/_layout.scss
+++ b/ui/lobby/css/_layout.scss
@@ -113,6 +113,10 @@ $mq-not-col3: $mq-not-small;
     grid-area: forum;
   }
 
+  &--no-simuls &__forum {
+    grid-area: simuls;
+  }
+
   &__blog {
     grid-area: blog;
   }


### PR DESCRIPTION
Fixes #8730

Would also be possible with only CSS e.g. like this:

```css
:not(lobby__simuls) + lobby__forum {
  grid-area: simuls;
}
```

But that seems a bit too janky since it relies on the element's order.