### PR TITLE
Add optional estimated start time for Simuls

### DIFF
--- a/app/views/simul/form.scala
+++ b/app/views/simul/form.scala
@@ -17,7 +17,8 @@ object form {
   ) =
     views.html.base.layout(
       title = trans.hostANewSimul.txt(),
-      moreCss = cssTag("simul.form")
+      moreCss = cssTag("simul.form"),
+      moreJs = jsModule("flatpickr")
     ) {
       main(cls := "box box-pad page-small simul-form")(
         h1(trans.hostANewSimul()),
@@ -40,7 +41,8 @@ object form {
   ) =
     views.html.base.layout(
       title = s"Edit ${simul.fullName}",
-      moreCss = cssTag("simul.form")
+      moreCss = cssTag("simul.form"),
+      moreJs = jsModule("flatpickr")
     ) {
       main(cls := "box box-pad page-small simul-form")(
         h1(s"Edit ${simul.fullName}"),
@@ -126,6 +128,12 @@ object form {
           help = views.html.tournament.form.positionInputHelp.some
         )(form3.input(_))
       ),
+      form3.group(
+        form("estimatedStartAt"),
+        frag("Estimated start time"),
+        help = frag("Optional estimated start time").some,
+        half = true
+        )(form3.flatpickr(_)),
       form3.group(
         form("text"),
         raw("Simul description"),

--- a/app/views/simul/form.scala
+++ b/app/views/simul/form.scala
@@ -131,7 +131,6 @@ object form {
       form3.group(
         form("estimatedStartAt"),
         frag("Estimated start time"),
-        help = frag("Optional estimated start time").some,
         half = true
         )(form3.flatpickr(_)),
       form3.group(

--- a/app/views/simul/show.scala
+++ b/app/views/simul/show.scala
@@ -92,6 +92,12 @@ object show {
                 br,
                 trans.mustBeInTeam(a(href := routes.Team.show(t.id))(t.name))
               )
+            },
+            sim.estimatedStartAt map { d =>
+              frag(
+                br,
+                absClientDateTime(d)
+              )
             }
           ),
           stream.map { s =>

--- a/modules/simul/src/main/Simul.scala
+++ b/modules/simul/src/main/Simul.scala
@@ -19,6 +19,7 @@ case class Simul(
     variants: List[Variant],
     position: Option[FEN],
     createdAt: DateTime,
+    estimatedStartAt: Option[DateTime] = None,
     hostId: User.ID,
     hostRating: Int,
     hostGameId: Option[String], // game the host is focusing on
@@ -153,6 +154,7 @@ object Simul {
       position: Option[FEN],
       color: String,
       text: String,
+      estimatedStartAt: Option[DateTime],
       team: Option[String],
       featurable: Option[Boolean]
   ): Simul =
@@ -173,6 +175,7 @@ object Simul {
       },
       hostGameId = none,
       createdAt = DateTime.now,
+      estimatedStartAt = estimatedStartAt,
       variants = if (position.isDefined) List(chess.variant.Standard) else variants,
       position = position,
       applicants = Nil,

--- a/modules/simul/src/main/SimulApi.scala
+++ b/modules/simul/src/main/SimulApi.scala
@@ -58,6 +58,7 @@ final class SimulApi(
       host = me,
       color = setup.color,
       text = setup.text,
+      estimatedStartAt = setup.estimatedStartAt,
       team = setup.team,
       featurable = some(~setup.featured && me.canBeFeatured)
     )
@@ -74,9 +75,13 @@ final class SimulApi(
       position = setup.realPosition,
       color = setup.color.some,
       text = setup.text,
+      estimatedStartAt = setup.estimatedStartAt,
       team = setup.team,
       featurable = some(~setup.featured && me.canBeFeatured)
     )
+    if (prev.estimatedStartAt.isDefined && !simul.estimatedStartAt.isDefined) {
+      repo.removeEstimatedStartAt(simul)
+    }
     repo.update(simul) >>- publish() inject simul
   }
 

--- a/modules/simul/src/main/SimulApi.scala
+++ b/modules/simul/src/main/SimulApi.scala
@@ -79,9 +79,6 @@ final class SimulApi(
       team = setup.team,
       featurable = some(~setup.featured && me.canBeFeatured)
     )
-    if (prev.estimatedStartAt.isDefined && !simul.estimatedStartAt.isDefined) {
-      repo.removeEstimatedStartAt(simul)
-    }
     repo.update(simul) >>- publish() inject simul
   }
 

--- a/modules/simul/src/main/SimulForm.scala
+++ b/modules/simul/src/main/SimulForm.scala
@@ -3,6 +3,7 @@ package lila.simul
 import cats.implicits._
 import chess.format.FEN
 import chess.StartingPosition
+import org.joda.time.DateTime
 import play.api.data._
 import play.api.data.Forms._
 import play.api.data.validation.Constraint
@@ -65,6 +66,7 @@ object SimulForm {
       position = none,
       color = colorDefault,
       text = "",
+      estimatedStartAt = none,
       team = none,
       featured = host.hasTitle.some
     )
@@ -79,6 +81,7 @@ object SimulForm {
       position = simul.position,
       color = simul.color | "random",
       text = simul.text,
+      estimatedStartAt = simul.estimatedStartAt,
       team = simul.team,
       featured = simul.featurable
     )
@@ -108,6 +111,7 @@ object SimulForm {
         "position" -> optional(lila.common.Form.fen.playableStrict),
         "color"    -> stringIn(colorChoices),
         "text"     -> cleanText,
+        "estimatedStartAt" -> optional(inTheFuture(ISODateTimeOrTimestamp.isoDateTimeOrTimestamp)),
         "team"     -> optional(nonEmptyText.verifying(id => teams.exists(_.id == id))),
         "featured" -> optional(boolean)
       )(Setup.apply)(Setup.unapply)
@@ -130,6 +134,7 @@ object SimulForm {
       position: Option[FEN],
       color: String,
       text: String,
+      estimatedStartAt: Option[DateTime] = None,
       team: Option[String],
       featured: Option[Boolean]
   ) {

--- a/modules/simul/src/main/SimulRepo.scala
+++ b/modules/simul/src/main/SimulRepo.scala
@@ -153,6 +153,15 @@ final private[simul] class SimulRepo(val coll: Coll)(implicit ec: scala.concurre
       )
       .void
 
+  def removeEstimatedStartAt(simul: Simul) = {
+    coll.update
+      .one(
+        $id(simul.id),
+        $unset("estimatedStartAt")
+      )
+      .void
+  }
+
   def setText(simul: Simul, text: String) =
     coll.update
       .one(

--- a/modules/simul/src/main/SimulRepo.scala
+++ b/modules/simul/src/main/SimulRepo.scala
@@ -130,11 +130,8 @@ final private[simul] class SimulRepo(val coll: Coll)(implicit ec: scala.concurre
     coll.update
       .one(
         $id(simul.id),
-        if (! simul.estimatedStartAt.isDefined) {
-          $unset("estimatedStartAt") ++ $set(SimulBSONHandler writeTry simul get)
-        } else {
-          $set(SimulBSONHandler writeTry simul get)
-        }
+        $set(SimulBSONHandler writeTry simul get) ++
+          simul.estimatedStartAt.isEmpty??($unset("estimatedStartAt"))
       )
       .void
 

--- a/modules/simul/src/main/SimulRepo.scala
+++ b/modules/simul/src/main/SimulRepo.scala
@@ -126,13 +126,21 @@ final private[simul] class SimulRepo(val coll: Coll)(implicit ec: scala.concurre
       SimulBSONHandler.writeTry(simul).get
     } void
 
-  def update(simul: Simul) =
+  def update(simul: Simul) = {
+    if (! simul.estimatedStartAt.isDefined) {
+      coll.update
+        .one(
+          $id(simul.id),
+          $unset("estimatedStartAt")
+        )
+    }
     coll.update
       .one(
         $id(simul.id),
         $set(SimulBSONHandler writeTry simul get)
       )
       .void
+  }
 
   def remove(simul: Simul) =
     coll.delete.one($id(simul.id)).void
@@ -152,15 +160,6 @@ final private[simul] class SimulRepo(val coll: Coll)(implicit ec: scala.concurre
         $set("hostSeenAt" -> DateTime.now)
       )
       .void
-
-  def removeEstimatedStartAt(simul: Simul) = {
-    coll.update
-      .one(
-        $id(simul.id),
-        $unset("estimatedStartAt")
-      )
-      .void
-  }
 
   def setText(simul: Simul, text: String) =
     coll.update

--- a/modules/simul/src/main/SimulRepo.scala
+++ b/modules/simul/src/main/SimulRepo.scala
@@ -126,21 +126,17 @@ final private[simul] class SimulRepo(val coll: Coll)(implicit ec: scala.concurre
       SimulBSONHandler.writeTry(simul).get
     } void
 
-  def update(simul: Simul) = {
-    if (! simul.estimatedStartAt.isDefined) {
-      coll.update
-        .one(
-          $id(simul.id),
-          $unset("estimatedStartAt")
-        )
-    }
+  def update(simul: Simul) =
     coll.update
       .one(
         $id(simul.id),
-        $set(SimulBSONHandler writeTry simul get)
+        if (! simul.estimatedStartAt.isDefined) {
+          $unset("estimatedStartAt") ++ $set(SimulBSONHandler writeTry simul get)
+        } else {
+          $set(SimulBSONHandler writeTry simul get)
+        }
       )
       .void
-  }
 
   def remove(simul: Simul) =
     coll.delete.one($id(simul.id)).void

--- a/ui/simul/css/build/_simul.form.scss
+++ b/ui/simul/css/build/_simul.form.scss
@@ -1,3 +1,4 @@
 @import '../../../common/css/plugin';
 @import '../../../common/css/form/form3';
+@import '../../../common/css/vendor/flatpickr';
 @import '../form';

--- a/ui/simul/src/interfaces.ts
+++ b/ui/simul/src/interfaces.ts
@@ -23,6 +23,7 @@ export interface SimulData {
   isRunning: boolean;
   isFinished: boolean;
   text: string;
+  estimatedStartAt: string;
   host: Host;
   variants: Variant[];
   applicants: Applicant[];

--- a/ui/simul/src/interfaces.ts
+++ b/ui/simul/src/interfaces.ts
@@ -23,7 +23,6 @@ export interface SimulData {
   isRunning: boolean;
   isFinished: boolean;
   text: string;
-  estimatedStartAt: string;
   host: Host;
   variants: Variant[];
   applicants: Applicant[];


### PR DESCRIPTION
Add an optional estimated start time for Simuls, in case the host wants
to create a simul some time in advance.

Previously the only way to indicate start time (unless immediate...) was
to write a start time in the Simul description. One problem with such a
solution is that the start time from the text won't be displayed in
users local time zones.

This commit adds a field, which is optional, which can be used to give
an estimate of at what time the host intends to click the Start button.

![1-edit-simul-form](https://user-images.githubusercontent.com/4084220/117540669-8018b400-b010-11eb-9c51-612cdefdd016.png)
![2-view-simul](https://user-images.githubusercontent.com/4084220/117540668-8018b400-b010-11eb-880b-cefc5248551a.png)

Here's an example "problematic" Simul which was created in advance with a start time in the description,
https://lichess.org/simul/PtXmjQql
The chat was filled with questions about when it would start... :sweat_smile: 


Sidenote,
this Pull Request was a way for me to take a chance to get familiar with the framework.
I have no experience with this framework - so this implementation might not be well thought out...
No hard feelings if you see this as a pile of technical debt. :sweat_smile:

It took quite a while for me while testing, to figure out why I couldn't remove an estimated start time after setting one.
I've implemented that as a separate SimulRepo method - maybe it is possible to get it working somehow with the SimulBSONHandler with some convenient flag during the coll.update call.
Well well, it was fun!