### PR TITLE
Fix missing first move sounds on mobile devices

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -198,10 +198,8 @@ export default class AnalyseCtrl {
       this.synthetic || this.ongoing ? undefined : treePath.fromNodeList(treeOps.mainlineNodeList(this.tree.root));
     this.fork = makeFork(this);
 
-    // Preload sounds to ensure that they'll be unlocked on mobile deviced
-    lichess.sound.loadStandard("move");
-    lichess.sound.loadStandard("capture");
-    lichess.sound.loadStandard("check");
+    // Preload sounds to ensure that they'll be unlocked on mobile devices
+    ['move', 'capture', 'check'].forEach(lichess.sound.loadStandard);
   }
 
   private setPath = (path: Tree.Path): void => {

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -197,6 +197,11 @@ export default class AnalyseCtrl {
     this.gamePath =
       this.synthetic || this.ongoing ? undefined : treePath.fromNodeList(treeOps.mainlineNodeList(this.tree.root));
     this.fork = makeFork(this);
+
+    // Preload sounds to ensure that they'll be unlocked on mobile deviced
+    lichess.sound.loadStandard("move");
+    lichess.sound.loadStandard("capture");
+    lichess.sound.loadStandard("check");
   }
 
   private setPath = (path: Tree.Path): void => {


### PR DESCRIPTION
Part of a fix for https://github.com/ornicar/lila/issues/8852 (which also needs an updated version of Howler https://github.com/ornicar/howler.js/pull/4).

Currently the first time a sound is played on mobile safari it needs to have been unlocked by a user interaction. In order for Howler to do this it needs to have attached various touch event listeners to the page, and if does this when creating a new Howl for the sound file, which Lila does when loading a sound for the first time.

Note that `lichess.sound.play` calls `loadStandard` the first time a sound is played, but by then it's too late to be part of the interaction, so the first move sound isn't played. We have to preload to solve this.