### PR TITLE
Handle en passant client-side

### DIFF
--- a/modules/game/src/main/Event.scala
+++ b/modules/game/src/main/Event.scala
@@ -78,7 +78,6 @@ object Event {
       check: Boolean,
       threefold: Boolean,
       promotion: Option[Promotion],
-      enpassant: Option[Enpassant],
       castle: Option[Castling],
       state: State,
       clock: Option[ClockEvent],
@@ -95,7 +94,6 @@ object Event {
             "san" -> san
           )
           .add("promotion" -> promotion.map(_.data))
-          .add("enpassant" -> enpassant.map(_.data))
           .add("castle" -> castle.map(_.data))
       }
     override def moveBy = Some(!state.color)
@@ -116,9 +114,6 @@ object Event {
         check = situation.check,
         threefold = situation.threefoldRepetition,
         promotion = move.promotion.map { Promotion(_, move.dest) },
-        enpassant = (move.capture ifTrue move.enpassant).map {
-          Event.Enpassant(_, !move.color)
-        },
         castle = move.castle.map { case (king, rook) =>
           Castling(king, rook, move.color)
         },
@@ -203,15 +198,6 @@ object Event {
         moves.foldLeft(JsObject(Nil)) { case (res, (o, d)) =>
           res + (o.key -> JsString(d map (_.key) mkString))
         }
-  }
-
-  case class Enpassant(pos: Pos, color: Color) extends Event {
-    def typ = "enpassant"
-    def data =
-      Json.obj(
-        "key"   -> pos.key,
-        "color" -> color
-      )
   }
 
   case class Castling(king: (Pos, Pos), rook: (Pos, Pos), color: Color) extends Event {

--- a/ui/round/src/atomic.ts
+++ b/ui/round/src/atomic.ts
@@ -23,10 +23,3 @@ export function capture(ctrl: RoundController, key: cg.Key) {
   ctrl.chessground.setPieces(diff);
   ctrl.chessground.explode(exploding);
 }
-
-// needs to explicitly destroy the capturing pawn
-export function enpassant(ctrl: RoundController, key: cg.Key, color: cg.Color) {
-  const pos = util.key2pos(key),
-    pawnPos: cg.Pos = [pos[0], pos[1] + (color === 'white' ? -1 : 1)];
-  capture(ctrl, util.pos2key(pawnPos));
-}

--- a/ui/round/src/interfaces.ts
+++ b/ui/round/src/interfaces.ts
@@ -133,10 +133,6 @@ export interface ApiMove extends Step {
     key: cg.Key;
     pieceClass: cg.Role;
   };
-  enpassant?: {
-    key: cg.Key;
-    color: Color;
-  };
   castle?: {
     king: [cg.Key, cg.Key];
     rook: [cg.Key, cg.Key];


### PR DESCRIPTION
Fixes #8559

Tested in Stanard, Atomic, and Crazyhouse with and without move confirmation.

I'm a bit unsure about removing the server-side event but I searched the whole repo and `lila-ws` for "enpassant" and didn't find anything else using it so I guess it should be removed.