### PR TITLE
Remove overlapping hyper/ultra bullet tournaments

### DIFF
--- a/modules/tournament/src/main/Schedule.scala
+++ b/modules/tournament/src/main/Schedule.scala
@@ -217,9 +217,10 @@ object Schedule {
     def byId(id: Int)            = all find (_.id == id)
     def similar(s1: Speed, s2: Speed) =
       (s1, s2) match {
-        case (a, b) if a == b                              => true
-        case (Bullet, HippoBullet) | (HippoBullet, Bullet) => true
-        case _                                             => false
+        case (a, b) if a == b                                        => true
+        case (Bullet, HippoBullet) | (HippoBullet, Bullet)           => true
+        case (HyperBullet, UltraBullet) | (UltraBullet, HyperBullet) => true
+        case _                                                       => false
       }
     def fromClock(clock: chess.Clock.Config) = {
       val time = clock.estimateTotalSeconds


### PR DESCRIPTION
To avoid this:

![Screenshot 2021-05-12 215713](https://user-images.githubusercontent.com/19309705/118037968-d2d6d080-b36e-11eb-99cd-64dea8972165.png)

Pretty sure there shouldn't be any other change since no such tournaments overlap otherwise.