### PR TITLE
Fix rollup build import

### DIFF
--- a/ui/@build/rollupProject/index.js
+++ b/ui/@build/rollupProject/index.js
@@ -3,7 +3,7 @@ const commonjs = require('@rollup/plugin-commonjs');
 const typescript = require('@rollup/plugin-typescript');
 const terser = require('rollup-plugin-terser').terser;
 
-exports.rollupProject = targets => {
+module.exports = targets => {
   return args => {
     const prod = args['config-prod'];
     const target = targets[args['config-plugin'] || 'main'];

--- a/ui/analyse/rollup.config.mjs
+++ b/ui/analyse/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/challenge/rollup.config.mjs
+++ b/ui/challenge/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/chat/rollup.config.mjs
+++ b/ui/chat/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/cli/rollup.config.mjs
+++ b/ui/cli/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/dasher/rollup.config.mjs
+++ b/ui/dasher/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/dgt/rollup.config.mjs
+++ b/ui/dgt/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/editor/rollup.config.mjs
+++ b/ui/editor/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/insight/rollup.config.mjs
+++ b/ui/insight/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/learn/rollup.config.mjs
+++ b/ui/learn/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/lobby/rollup.config.mjs
+++ b/ui/lobby/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/msg/rollup.config.mjs
+++ b/ui/msg/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/notify/rollup.config.mjs
+++ b/ui/notify/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/palantir/rollup.config.mjs
+++ b/ui/palantir/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/puzzle/rollup.config.mjs
+++ b/ui/puzzle/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/racer/rollup.config.mjs
+++ b/ui/racer/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/round/rollup.config.mjs
+++ b/ui/round/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/serviceWorker/rollup.config.mjs
+++ b/ui/serviceWorker/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/simul/rollup.config.mjs
+++ b/ui/simul/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/site/rollup.config.js
+++ b/ui/site/rollup.config.js
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process';
 import { dirname } from 'path';
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 import copy from 'rollup-plugin-copy';
 import replace from '@rollup/plugin-replace';
 

--- a/ui/speech/rollup.config.mjs
+++ b/ui/speech/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/storm/rollup.config.mjs
+++ b/ui/storm/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/swiss/rollup.config.mjs
+++ b/ui/swiss/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/tournament/rollup.config.mjs
+++ b/ui/tournament/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/tournamentCalendar/rollup.config.mjs
+++ b/ui/tournamentCalendar/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {

--- a/ui/tournamentSchedule/rollup.config.mjs
+++ b/ui/tournamentSchedule/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { rollupProject } from '@build/rollupProject';
+import rollupProject from '@build/rollupProject';
 
 export default rollupProject({
   main: {


### PR DESCRIPTION
Caused by d523aeff8b59aae8df7e51f391b9f2982b0c1e9c

ES rollup config modules on Node 13+ can only import the default export from commonJS modules it seems. See also: https://rollupjs.org/guide/en/#using-untranspiled-config-files

And bc `ui/site` is still a commonJS module we also can't switch `@build/rollupProject` to an ES module.