### PR TITLE
Show material difference in 1-column view

### DIFF
--- a/ui/round/css/_app-layout.scss
+++ b/ui/round/css/_app-layout.scss
@@ -47,8 +47,8 @@
   display: grid;
 
   @include breakpoint($mq-col1) {
-    grid-template-rows: auto $col1-pocket-height $col1-player-clock-height auto $expiration-height $col1-player-clock-height $col1-pocket-height;
-    grid-template-areas: 'moves' 'mat-top' 'user-top' 'board' 'expi-bot' 'user-bot' 'mat-bot' 'kb-move' 'controls';
+    grid-template-rows: auto $col1-pocket-height $col1-mat-height $col1-user-height auto $expiration-height $col1-user-height $col1-mat-height $col1-pocket-height;
+    grid-template-areas: 'moves' 'pocket-top' 'mat-top' 'user-top' 'board' 'expi-bot' 'user-bot' 'mat-bot' 'pocket-bot' 'kb-move' 'controls';
 
     // Put clocks and players in the same grid cell.
     // This allows having a single cell column, instead of
@@ -56,11 +56,11 @@
     // This is required to display the overflowable horizontal move list,
     // so that it can be contain within the grid parent.
     .rclock-top {
-      grid-area: 3 / 1 / 3 / 2;
+      grid-area: 3 / 1 / 5 / 2;
     }
 
     .rclock-bottom {
-      grid-area: 6 / 1 / 6 / 2;
+      grid-area: 7 / 1 / 9 / 2;
     }
 
     cg-board {
@@ -77,7 +77,7 @@
 
     &.move-confirm {
       // replace move list with move confirmation
-      grid-template-areas: 'controls' 'mat-top' 'user-top' 'board' 'expi-bot' 'user-bot' 'mat-bot' 'kb-move';
+      grid-template-areas: 'controls' 'pocket-top' 'mat-top' 'user-top' 'board' 'expi-bot' 'user-bot' 'mat-bot' 'pocket-bot' 'kb-move';
 
       #{$rmoves-tag} {
         display: none;

--- a/ui/round/css/_constants.scss
+++ b/ui/round/css/_constants.scss
@@ -4,6 +4,8 @@ $mq-col2: $mq-col2-uniboard;
 $mq-col3: $mq-col3-uniboard;
 
 $col1-player-clock-height: 50px;
+$col1-user-height: ($col1-player-clock-height / 2);
+$col1-mat-height: ($col1-player-clock-height / 2);
 $col1-moves-height: 2.5em;
 $move-tag: 'u8t';
 $rmoves-tag: 'rm6';

--- a/ui/round/css/_material.scss
+++ b/ui/round/css/_material.scss
@@ -1,59 +1,69 @@
 .material {
   align-self: center;
-  display: none;
+  display: flex;
+  align-items: center;
   height: 40px;
+  line-height: 0;
+  white-space: nowrap;
 
-  @include breakpoint($mq-col2) {
-    display: flex;
-    align-items: center;
-    line-height: 0;
-    white-space: nowrap;
+  div {
+    display: inline-block;
+    margin-left: 10px;
+  }
+
+  mpiece {
+    margin-left: -10px;
+    width: 32px;
+    height: 32px;
+    background-size: cover;
+    display: inline-block;
+
+    &.pawn {
+      background-image: url(../piece/mono/P.svg);
+    }
+
+    &.bishop {
+      background-image: url(../piece/mono/B.svg);
+    }
+
+    &.knight {
+      background-image: url(../piece/mono/N.svg);
+    }
+
+    &.rook {
+      background-image: url(../piece/mono/R.svg);
+    }
+
+    &.queen {
+      background-image: url(../piece/mono/Q.svg);
+    }
+
+    &.king {
+      background-image: url(../piece/mono/K.svg);
+    }
+
+    @if $theme == 'transp' {
+      filter: brightness(1.3) drop-shadow(0 1px 1px #000);
+    }
+  }
+
+  score {
+    font-family: 'Roboto';
+    line-height: 32px;
+    vertical-align: top;
+  }
+
+  @include breakpoint($mq-col1) {
+    height: $col1-mat-height;
 
     div {
-      display: inline-block;
-      margin-left: 10px;
+      margin-left: 8px;
     }
 
     mpiece {
-      margin-left: -10px;
-      width: 32px;
-      height: 32px;
-      background-size: cover;
-      display: inline-block;
-
-      &.pawn {
-        background-image: url(../piece/mono/P.svg);
-      }
-
-      &.bishop {
-        background-image: url(../piece/mono/B.svg);
-      }
-
-      &.knight {
-        background-image: url(../piece/mono/N.svg);
-      }
-
-      &.rook {
-        background-image: url(../piece/mono/R.svg);
-      }
-
-      &.queen {
-        background-image: url(../piece/mono/Q.svg);
-      }
-
-      &.king {
-        background-image: url(../piece/mono/K.svg);
-      }
-
-      @if $theme == 'transp' {
-        filter: brightness(1.3) drop-shadow(0 1px 1px #000);
-      }
-    }
-
-    score {
-      font-family: 'Roboto';
-      line-height: 32px;
-      vertical-align: top;
+      width: $col1-mat-height * 3/4;
+      height: $col1-mat-height * 3/4;
+      margin-left: -8px;
     }
   }
 }

--- a/ui/round/css/_user.scss
+++ b/ui/round/css/_user.scss
@@ -5,7 +5,7 @@
   justify-content: left;
   font-size: 1.2em;
   padding: 0 0.3em;
-  line-height: $col1-player-clock-height;
+  line-height: $col1-user-height;
 
   &:hover {
     color: $c-font;

--- a/ui/round/css/_zh.scss
+++ b/ui/round/css/_zh.scss
@@ -9,6 +9,16 @@
     margin-top: -0.5em;
   }
 
+  @include breakpoint($mq-col1) {
+    &-top {
+      grid-area: pocket-top;
+    }
+
+    &-bottom {
+      grid-area: pocket-bot;
+    }
+  }
+
   @include breakpoint($mq-col2-uniboard) {
     &-top {
       margin-bottom: $block-gap;


### PR DESCRIPTION
To avoid losing vertical space, the material difference is shown below the user name next to the clock in the same way as in lichobile. The downside of this is that it may look a bit awkward when there is no material difference to show as the user name isn't vertically centered then. It would probably look better if the user name was shown in exactly the same way as it is now when there is no material difference. I haven't found a way to do this using only CSS, however. If there are ideas/pointer on how to do this, I would gladly implement this in this PR.

Since the pocket for Crazy House was using the same grid-area as the material difference, and this grid-area is now moved below the user name, this commit adds new grid-areas just for the pockets in 1-column mode. The mobile view for Crazy House should therefore be unchanged by this commit, except for the user name alignment issue mentioned above.

This fixes #5059.

And here are some screen shots:

| Current | PR | PR without material difference |
|------------|------|---|
| <img src="https://user-images.githubusercontent.com/1546739/118309555-b2815000-b4ed-11eb-98b5-3525fc81bad2.png" width="250"> | <img src="https://user-images.githubusercontent.com/1546739/118309905-35a2a600-b4ee-11eb-84db-da6fa2a6752f.png" width="250"> | <img src="https://user-images.githubusercontent.com/1546739/118310251-a3e76880-b4ee-11eb-96c1-961f2dd6e477.png" width="250"> |



