### PR TITLE
Render move confirmation below the board in 1-column view 

### DIFF
--- a/ui/round/css/_app-layout.scss
+++ b/ui/round/css/_app-layout.scss
@@ -74,15 +74,6 @@
     &__table {
       display: none;
     }
-
-    &.move-confirm {
-      // replace move list with move confirmation
-      grid-template-areas: 'controls' 'pocket-top' 'mat-top' 'user-top' 'board' 'expi-bot' 'user-bot' 'mat-bot' 'pocket-bot' 'kb-move';
-
-      #{$rmoves-tag} {
-        display: none;
-      }
-    }
   }
 
   @include breakpoint($mq-col2) {

--- a/ui/round/src/view/main.ts
+++ b/ui/round/src/view/main.ts
@@ -58,24 +58,21 @@ export function main(ctrl: RoundController): VNode {
 
   return ctrl.nvui
     ? ctrl.nvui.render(ctrl)
-    : h(
-        'div.round__app.variant-' + d.game.variant.key,
-        [
-          h(
-            'div.round__app__board.main-board' + (ctrl.data.pref.blindfold ? '.blindfold' : ''),
-            {
-              hook:
-                'ontouchstart' in window
-                  ? undefined
-                  : util.bind('wheel', (e: WheelEvent) => wheel(ctrl, e), undefined, false),
-            },
-            [renderGround(ctrl), promotion.view(ctrl)]
-          ),
-          crazyView(ctrl, topColor, 'top') || renderMaterial(material[topColor], -score, 'top', checks[topColor]),
-          ...renderTable(ctrl),
-          crazyView(ctrl, bottomColor, 'bottom') ||
-            renderMaterial(material[bottomColor], score, 'bottom', checks[bottomColor]),
-          ctrl.keyboardMove ? keyboardMove(ctrl.keyboardMove) : null,
-        ]
-      );
+    : h('div.round__app.variant-' + d.game.variant.key, [
+        h(
+          'div.round__app__board.main-board' + (ctrl.data.pref.blindfold ? '.blindfold' : ''),
+          {
+            hook:
+              'ontouchstart' in window
+                ? undefined
+                : util.bind('wheel', (e: WheelEvent) => wheel(ctrl, e), undefined, false),
+          },
+          [renderGround(ctrl), promotion.view(ctrl)]
+        ),
+        crazyView(ctrl, topColor, 'top') || renderMaterial(material[topColor], -score, 'top', checks[topColor]),
+        ...renderTable(ctrl),
+        crazyView(ctrl, bottomColor, 'bottom') ||
+          renderMaterial(material[bottomColor], score, 'bottom', checks[bottomColor]),
+        ctrl.keyboardMove ? keyboardMove(ctrl.keyboardMove) : null,
+      ]);
 }

--- a/ui/round/src/view/main.ts
+++ b/ui/round/src/view/main.ts
@@ -60,9 +60,6 @@ export function main(ctrl: RoundController): VNode {
     ? ctrl.nvui.render(ctrl)
     : h(
         'div.round__app.variant-' + d.game.variant.key,
-        {
-          class: { 'move-confirm': !!(ctrl.moveToSubmit || ctrl.dropToSubmit) },
-        },
         [
           h(
             'div.round__app__board.main-board' + (ctrl.data.pref.blindfold ? '.blindfold' : ''),


### PR DESCRIPTION
It is now rendered at the same location as other negotiation controls (e.g., takeback and draw offers). It is also more consistent with the way lichobile renders move confirmation. This also prevents a vertical shift down of the board when the move confirmation was shown before this commit.

It is [unclear](https://github.com/ornicar/lila/commit/24ce308845c604380bce3c5a7b2ef3447a062701#commitcomment-51007078) why the move confirmation was put at the top of the screen in the first place. The only reason I can see why putting it below the board might hurt, is when using a screen with a very low height. This could cause the move confirmation to not be visible (as would be the case with the other types of negotiations today). I guess the only way to make sure it will always be visible, is to render it with `display: fixed; bottom: 0;` or something like that.

A note on the second commit: this is to make `prettier` happy. Since it is quite a big diff (a large section of code needed to be unindented), I decided to put it in a separate commit. The first commit actually only removes code and thus makes everything a bit simpler.

And here are some screen shots:

| Current | PR | Other negotiations |
| --- | --- | --- |
| ![old](https://user-images.githubusercontent.com/1546739/118790532-2331bf00-b896-11eb-9774-08a14b543a4d.png) | ![new](https://user-images.githubusercontent.com/1546739/118790550-29c03680-b896-11eb-9997-a7cb4201eeb8.png) | ![takeback](https://user-images.githubusercontent.com/1546739/118790563-2e84ea80-b896-11eb-9692-c8e85576bd99.png) |

Note that in the current situation, the whole board shifts a bit down when showing a move confirmation but this is not really visible in the screen shot.
