### PR TITLE
Add option to flip the board in puzzle storm

### DIFF
--- a/app/views/storm.scala
+++ b/app/views/storm.scala
@@ -137,6 +137,7 @@ object storm {
     )
 
   private val i18nKeys = {
+    import lila.i18n.{ I18nKeys => trans }
     import lila.i18n.I18nKeys.{ storm => s }
     List(
       s.moveToStart,
@@ -158,7 +159,8 @@ object storm {
       s.newRun,
       s.endRun,
       s.youPlayTheWhitePiecesInAllPuzzles,
-      s.youPlayTheBlackPiecesInAllPuzzles
+      s.youPlayTheBlackPiecesInAllPuzzles,
+      trans.flipBoard
     ).map(_.key)
   }
 }

--- a/ui/puz/src/run.ts
+++ b/ui/puz/src/run.ts
@@ -1,15 +1,16 @@
 import { Run } from './interfaces';
 import { Config as CgConfig } from 'chessground/config';
+import { opposite } from 'chessground/util';
 import { uciToLastMove } from './util';
 import { makeFen } from 'chessops/fen';
 import { chessgroundDests } from 'chessops/compat';
 
-export const makeCgOpts = (run: Run, canMove: boolean): CgConfig => {
+export const makeCgOpts = (run: Run, canMove: boolean, flipped?: boolean): CgConfig => {
   const cur = run.current;
   const pos = cur.position();
   return {
     fen: makeFen(pos.toSetup()),
-    orientation: run.pov,
+    orientation: flipped ? opposite(run.pov) : run.pov,
     turnColor: pos.turn,
     movable: {
       color: run.pov,

--- a/ui/storm/src/ctrl.ts
+++ b/ui/storm/src/ctrl.ts
@@ -203,5 +203,8 @@ export default class StormCtrl {
     });
   };
 
-  private hotkeys = () => window.Mousetrap.bind('space', () => location.reload()).bind('return', this.end);
+  private hotkeys = () =>
+    window.Mousetrap.bind('space', () => location.reload())
+      .bind('return', this.end)
+      .bind('f', this.flip);
 }

--- a/ui/storm/src/ctrl.ts
+++ b/ui/storm/src/ctrl.ts
@@ -23,6 +23,7 @@ export default class StormCtrl {
   trans: Trans;
   promotion: Promotion;
   ground = prop<CgApi | false>(false) as Prop<CgApi | false>;
+  flipped = false;
 
   constructor(opts: StormOpts, redraw: (data: StormData) => void) {
     this.data = opts.data;
@@ -47,7 +48,11 @@ export default class StormCtrl {
       filterFailed: false,
       filterSlow: false,
     };
-    this.promotion = makePromotion(this.withGround, () => makeCgOpts(this.run, !this.run.endAt), this.redraw);
+    this.promotion = makePromotion(
+      this.withGround,
+      () => makeCgOpts(this.run, !this.run.endAt, this.flipped),
+      this.redraw
+    );
     this.checkDupTab();
     setTimeout(this.hotkeys, 1000);
     if (this.data.key) setTimeout(() => sign(this.data.key!).then(this.vm.signed), 1000 * 40);
@@ -130,7 +135,7 @@ export default class StormCtrl {
       this.redrawQuick();
       this.redrawSlow();
     }
-    this.withGround(g => g.set(makeCgOpts(this.run, !this.run.endAt)));
+    this.withGround(g => g.set(makeCgOpts(this.run, !this.run.endAt, this.flipped)));
     lichess.pubsub.emit('ply', this.run.moves);
   };
 
@@ -178,6 +183,12 @@ export default class StormCtrl {
 
   toggleFilterFailed = () => {
     this.vm.filterFailed = !this.vm.filterFailed;
+    this.redraw();
+  };
+
+  flip = () => {
+    this.flipped = !this.flipped;
+    this.withGround(g => g.toggleOrientation());
     this.redraw();
   };
 

--- a/ui/storm/src/view/main.ts
+++ b/ui/storm/src/view/main.ts
@@ -63,7 +63,7 @@ const renderSolved = (ctrl: StormCtrl): VNode =>
 
 const renderControls = (ctrl: StormCtrl): VNode =>
   h('div.puz-side__control', [
-    h('a.puz-side__control__end.button.button-empty', {
+    h('a.puz-side__control__flip.button.button-empty', {
       attrs: {
         'data-icon': 'B',
         title: ctrl.trans.noarg('flipBoard'),

--- a/ui/storm/src/view/main.ts
+++ b/ui/storm/src/view/main.ts
@@ -63,10 +63,17 @@ const renderSolved = (ctrl: StormCtrl): VNode =>
 
 const renderControls = (ctrl: StormCtrl): VNode =>
   h('div.puz-side__control', [
+    h('a.puz-side__control__end.button.button-empty', {
+      attrs: {
+        'data-icon': 'B',
+        title: ctrl.trans.noarg('flipBoard'),
+      },
+      hook: onInsert(el => el.addEventListener('click', ctrl.flip)),
+    }),
     h('a.puz-side__control__reload.button.button-empty', {
       attrs: {
         href: '/storm',
-        'data-icon': 'B',
+        'data-icon': 'P',
         title: ctrl.trans('newRun'),
       },
     }),

--- a/ui/storm/src/view/main.ts
+++ b/ui/storm/src/view/main.ts
@@ -73,7 +73,7 @@ const renderControls = (ctrl: StormCtrl): VNode =>
     h('a.puz-side__control__reload.button.button-empty', {
       attrs: {
         href: '/storm',
-        'data-icon': 'P',
+        'data-icon': 'q',
         title: ctrl.trans('newRun'),
       },
     }),


### PR DESCRIPTION
Resolves #8906. 
I've added the option to flip the board in puzzle storms but I'm not sure if it's the best implementation though. Let me know what you think.