### PR TITLE
Prevent safari from zooming in on double-tap

### DIFF
--- a/ui/chess/css/_control.scss
+++ b/ui/chess/css/_control.scss
@@ -1,4 +1,5 @@
 .analyse-controls {
+  @extend %double-tap;
   display: flex;
   justify-content: space-between;
   align-items: stretch;

--- a/ui/common/css/abstract/_extends.scss
+++ b/ui/common/css/abstract/_extends.scss
@@ -248,3 +248,8 @@
   width: 100%;
   height: 100%;
 }
+
+%double-tap {
+  // prevent iPad safari from zooming in on double tap
+  touch-action: manipulation;
+}

--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -1,4 +1,5 @@
 .cmn-toggle {
+  @extend %double-tap;
   position: absolute;
   margin-left: -99999px;
 }

--- a/ui/round/css/_moves.scss
+++ b/ui/round/css/_moves.scss
@@ -11,7 +11,7 @@
 }
 
 #{$rmoves-tag} {
-  @extend %flex-column;
+  @extend %flex-column, %double-tap;
 
   .buttons {
     @extend %box-shadow;


### PR DESCRIPTION
Closes https://github.com/ornicar/lila/issues/8857 (which is driving me insane :)

This is nearly identical to ornicar's initial fix (https://github.com/ornicar/lila/commit/3d010e47e1d6faf76a9e78d5a3617acf9c4f3da0) which was reverted since it stopped drag/drops on the board itself.

This PR applies the fix to the control elements other than the board itself.  Tested on an iPad.