### PR TITLE
Add flip board for normal puzzles, streak and racer

### DIFF
--- a/app/views/puzzle/bits.scala
+++ b/app/views/puzzle/bits.scala
@@ -94,7 +94,8 @@ object bits {
       trans.showThreat,
       trans.gameOver,
       trans.inLocalBrowser,
-      trans.toggleLocalEvaluation
+      trans.toggleLocalEvaluation,
+      trans.flipBoard
     ).map(_.key)
 
   private val trainingI18nKeys: List[MessageKey] =

--- a/app/views/racer.scala
+++ b/app/views/racer.scala
@@ -80,7 +80,8 @@ object racer {
       trans.toInviteSomeoneToPlayGiveThisUrl,
       s.skip,
       s.skipHelp,
-      s.skipExplanation
+      s.skipExplanation,
+      trans.flipBoard
     ).map(_.key)
   }
 }

--- a/ui/puzzle/css/_side.scss
+++ b/ui/puzzle/css/_side.scss
@@ -126,6 +126,11 @@
       display: inline-block;
       margin-top: 2vmin;
     }
+
+    &__flip {
+      float: right;
+      margin-top: 2vmin;
+    }
   }
 
   &__replay {

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -17,7 +17,7 @@ import { defer } from 'common/defer';
 import { defined, prop, Prop } from 'common';
 import { makeSanAndPlay } from 'chessops/san';
 import { parseFen, makeFen } from 'chessops/fen';
-import { parseSquare, parseUci, makeSquare, makeUci } from 'chessops/util';
+import { parseSquare, parseUci, makeSquare, makeUci, opposite } from 'chessops/util';
 import { pgnToTree, mergeSolution } from './moveTree';
 import { Redraw, Vm, Controller, PuzzleOpts, PuzzleData, PuzzleResult, MoveTest, ThemeKey } from './interfaces';
 import { Role, Move, Outcome } from 'chessops/types';
@@ -59,6 +59,8 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
     good: loadSound('lisp/PuzzleStormGood', 0.7, 500),
     end: loadSound('lisp/PuzzleStormEnd', 1, 1000),
   };
+
+  let flipped = false;
 
   function setPath(path: Tree.Path): void {
     vm.path = path;
@@ -130,7 +132,7 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
         };
     const config = {
       fen: node.fen,
-      orientation: vm.pov,
+      orientation: flipped ? opposite(vm.pov) : vm.pov,
       turnColor: color,
       movable: movable,
       premovable: {
@@ -443,6 +445,12 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
     playBestMove();
   };
 
+  const flip = () => {
+    flipped = !flipped;
+    withGround(g => g.toggleOrientation());
+    redraw();
+  };
+
   const vote = (v: boolean) => {
     if (!vm.voteDisabled) {
       xhr.vote(data.puzzle.id, v);
@@ -482,6 +490,7 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
     toggleThreatMode,
     redraw,
     playBestMove,
+    flip,
   });
 
   // If the page loads while being hidden (like when changing settings),
@@ -552,5 +561,6 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
     },
     streak,
     skip,
+    flip,
   };
 }

--- a/ui/puzzle/src/interfaces.ts
+++ b/ui/puzzle/src/interfaces.ts
@@ -24,6 +24,7 @@ export interface KeyboardController {
   toggleCeval(): void;
   toggleThreatMode(): void;
   playBestMove(): void;
+  flip(): void;
 }
 
 export type ThemeKey = string;

--- a/ui/puzzle/src/keyboard.ts
+++ b/ui/puzzle/src/keyboard.ts
@@ -26,5 +26,6 @@ export default function (ctrl: KeyboardController): void {
         else ctrl.toggleCeval();
       }
     })
-    .bind('z', () => lichess.pubsub.emit('zen'));
+    .bind('z', () => lichess.pubsub.emit('zen'))
+    .bind('f', ctrl.flip);
 }

--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -243,7 +243,7 @@ export function config(ctrl: Controller): MaybeVNode {
         )
       : null,
     h(
-      'a.puzzle__side__config__zen',
+      'a.puzzle__side__config__zen.button.button-empty',
       {
         hook: bind('click', () => lichess.pubsub.emit('zen')),
         attrs: {
@@ -251,6 +251,16 @@ export function config(ctrl: Controller): MaybeVNode {
         },
       },
       ctrl.trans.noarg('zenMode')
+    ),
+    h(
+      'a.puzzle__side__config__flip.button.button-empty',
+      {
+        hook: bind('click', ctrl.flip),
+        attrs: {
+          title: 'Keyboard: f',
+        },
+      },
+      ctrl.trans.noarg('flipBoard')
     ),
   ]);
 }

--- a/ui/racer/src/ctrl.ts
+++ b/ui/racer/src/ctrl.ts
@@ -32,6 +32,7 @@ export default class StormCtrl {
   skipAvailable = true;
   knowsSkip = storedProp('racer.skip', false);
   ground = prop<CgApi | false>(false) as Prop<CgApi | false>;
+  flipped = false;
 
   constructor(opts: RacerOpts, redraw: (data: RacerData) => void) {
     this.data = opts.data;
@@ -68,6 +69,7 @@ export default class StormCtrl {
     });
     lichess.socket.sign(this.sign);
     setInterval(this.redraw, 1000);
+    setTimeout(this.hotkeys, 1000);
     // this.simulate();
   }
 
@@ -182,7 +184,7 @@ export default class StormCtrl {
 
   private cgOpts = () =>
     this.isPlayer()
-      ? makeCgOpts(this.run, this.isRacing())
+      ? makeCgOpts(this.run, this.isRacing(), this.flipped)
       : {
           orientation: this.run.pov,
         };
@@ -203,5 +205,13 @@ export default class StormCtrl {
     return g && f(g);
   };
 
+  flip = () => {
+    this.flipped = !this.flipped;
+    this.withGround(g => g.toggleOrientation());
+    this.redraw();
+  };
+
   private socketSend = (tpe: string, data?: any) => lichess.socket.send(tpe, data, { sign: this.sign });
+
+  private hotkeys = () => window.Mousetrap.bind('f', this.flip);
 }

--- a/ui/racer/src/view/main.ts
+++ b/ui/racer/src/view/main.ts
@@ -107,7 +107,20 @@ const spectating = (noarg: TransNoArg) =>
 
 const renderBonus = (bonus: number) => `+${bonus}`;
 
-const comboZone = (ctrl: RacerCtrl) => h('div.puz-side__table', [renderCombo(config, renderBonus)(ctrl.run)]);
+const renderControls = (ctrl: RacerCtrl): VNode =>
+  h(
+    'div.puz-side__control',
+    h('a.puz-side__control__flip.button.button-empty', {
+      attrs: {
+        'data-icon': 'B',
+        title: ctrl.trans.noarg('flipBoard'),
+      },
+      hook: bind('click', ctrl.flip),
+    })
+  );
+
+const comboZone = (ctrl: RacerCtrl) =>
+  h('div.puz-side__table', [renderControls(ctrl), renderCombo(config, renderBonus)(ctrl.run)]);
 
 const playerScore = (ctrl: RacerCtrl): VNode =>
   h('div.puz-side__top.puz-side__solved', [h('div.puz-side__solved__text', ctrl.myScore() || 0)]);


### PR DESCRIPTION
Added flip board + `f` hotkey for puzzles, streak and racer.
Wasn't sure where to put the button for puzzles + streak so I went with this in the end:
[![flip.png](https://i.postimg.cc/rF7NKg9Z/flip.png)](https://postimg.cc/mtNHnYJ7)
(also changed zen mode link from simple text to a button)