### PR TITLE
Preload sounds when starting a game

### DIFF
--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -151,7 +151,7 @@ export default class RoundController {
     });
 
     lichess.sound.preloadBoardSounds();
-    
+
     if (this.isPlaying()) ab.init(this);
   }
 

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -150,6 +150,8 @@ export default class RoundController {
       }
     });
 
+    lichess.sound.preloadBoardSounds();
+    
     if (this.isPlaying()) ab.init(this);
   }
 

--- a/ui/site/src/component/sound.ts
+++ b/ui/site/src/component/sound.ts
@@ -33,7 +33,7 @@ const sound: SoundI = new (class {
   };
 
   preloadBoardSounds() {
-    if (this.soundSet !== 'music') ['move', 'capture', 'check'].forEach(s => this.loadStandard(s));
+    if (this.soundSet !== 'music') ['move', 'capture', 'check', 'genericNotify'].forEach(s => this.loadStandard(s));
   }
 
   play(name: string, volume?: number) {


### PR DESCRIPTION
Fixes https://github.com/ornicar/lila/issues/8993.

The iPad (along wither other devices) requires an interaction to play a sound.  By preloading the sounds Howler will do it's best to unlock them on an interaction before they're needed.