### PR TITLE
More lobby setup fixes

### DIFF
--- a/app/controllers/Setup.scala
+++ b/app/controllers/Setup.scala
@@ -136,7 +136,8 @@ final class Setup(
     Open { implicit ctx =>
       NoBot {
         if (HTTPRequest isXhr ctx.req) NoPlaybanOrCurrent {
-          fuccess(forms.hookFilled(timeModeString = get("time"))) map { html.setup.forms.hook(_) }
+          val timeMode = get("time")
+          fuccess(forms.hookFilled(timeModeString = timeMode)) map { html.setup.forms.hook(_, timeMode.isDefined) }
         }
         else
           fuccess {

--- a/app/views/setup/bits.scala
+++ b/app/views/setup/bits.scala
@@ -149,10 +149,11 @@ private object bits {
   val dataRandomColorVariants =
     attr("data-random-color-variants") := lila.game.Game.variantsWhereWhiteIsBetter.map(_.id).mkString(",")
 
-  val dataAnon        = attr("data-anon")
-  val dataMin         = attr("data-min")
-  val dataMax         = attr("data-max")
-  val dataValidateUrl = attr("data-validate-url")
-  val dataResizable   = attr("data-resizable")
-  val dataType        = attr("data-type")
+  val dataAnon          = attr("data-anon")
+  val dataMin           = attr("data-min")
+  val dataMax           = attr("data-max")
+  val dataValidateUrl   = attr("data-validate-url")
+  val dataResizable     = attr("data-resizable")
+  val dataType          = attr("data-type")
+  val dataForceTimeMode = attr("data-force-time-mode")
 }

--- a/app/views/setup/forms.scala
+++ b/app/views/setup/forms.scala
@@ -13,11 +13,12 @@ object forms {
 
   import bits._
 
-  def hook(form: Form[_])(implicit ctx: Context) =
+  def hook(form: Form[_], forceTimeMode: Boolean = false)(implicit ctx: Context) =
     layout(
       "hook",
       trans.createAGame(),
-      routes.Setup.hook("sri-placeholder")
+      routes.Setup.hook("sri-placeholder"),
+      forceTimeMode = forceTimeMode
     ) {
       frag(
         renderVariant(form, translatedVariantChoicesWithVariants),
@@ -122,7 +123,8 @@ object forms {
       typ: String,
       titleF: Frag,
       route: Call,
-      error: Option[Frag] = None
+      error: Option[Frag] = None,
+      forceTimeMode: Boolean = false,
   )(fields: Frag)(implicit ctx: Context) =
     div(cls := error.isDefined option "error")(
       h2(titleF),
@@ -140,7 +142,8 @@ object forms {
             novalidate,
             dataRandomColorVariants,
             dataType := typ,
-            dataAnon := ctx.isAnon.option("1")
+            dataAnon := ctx.isAnon.option("1"),
+            dataForceTimeMode := forceTimeMode.option("1")
           )(
             fields,
             if (ctx.blind) submitButton("Create the game")

--- a/ui/lobby/css/_setup.scss
+++ b/ui/lobby/css/_setup.scss
@@ -167,12 +167,9 @@ $c-slider: $c-setup;
         }
       }
 
-      &.nope {
-        visibility: hidden;
-      }
-
       &:disabled {
         opacity: 0.3;
+        cursor: not-allowed;
       }
     }
 

--- a/ui/lobby/src/setup.ts
+++ b/ui/lobby/src/setup.ts
@@ -148,29 +148,30 @@ export default class Setup {
       toggleButtons = () => {
         const variantId = $variantSelect.val(),
           timeMode = $timeModeSelect.val(),
-          rated = $rated.prop('checked'),
           limit = parseFloat($timeInput.val() as string),
           inc = parseFloat($incrementInput.val() as string),
           // no rated variants with less than 30s on the clock and no rated unlimited in the lobby
           cantBeRated =
             (typ === 'hook' && timeMode === '0') ||
             (variantId != '1' && (timeMode != '1' || (limit < 0.5 && inc == 0) || (limit == 0 && inc < 2)));
+        let rated = $rated.prop('checked');
         if (cantBeRated && rated) {
-          $casual.trigger('click');
-          return toggleButtons();
+          $casual.prop('checked', true);
+          save();
+          rated = false;
         }
         $rated.prop('disabled', !!cantBeRated).siblings('label').toggleClass('disabled', cantBeRated);
         const timeOk = timeMode != '1' || limit > 0 || inc > 0,
-          ratedOk = typ != 'hook' || !rated || timeMode != '0',
-          aiOk = typ != 'ai' || variantId != '3' || limit >= 1;
-        if (timeOk && ratedOk && aiOk) {
-          $submits.toggleClass('nope', false);
-          $submits.filter(':not(.random)').toggle(!rated || !randomColorVariants.includes(variantId));
-        } else $submits.toggleClass('nope', true);
+          aiOk = typ != 'ai' || variantId != '3' || limit >= 1 || timeMode != '1';
+        const disable = ($e: Cash, d: boolean) => $e.prop('disabled', d).toggleClass('disabled', d);
+        if (timeOk && aiOk) {
+          disable($submits, false);
+          if (rated && randomColorVariants.includes(variantId)) {
+            disable($submits.filter(':not(.random)'), true);
+          }
+        } else disable($submits, true);
       },
-      save = function () {
-        self.save($form[0] as HTMLFormElement);
-      };
+      save = () => this.save($form[0] as HTMLFormElement);
 
     const c = this.stores[typ].get();
     if (c) {

--- a/ui/lobby/src/setup.ts
+++ b/ui/lobby/src/setup.ts
@@ -176,7 +176,7 @@ export default class Setup {
     if (c) {
       Object.keys(c).forEach(k => {
         $form.find(`[name="${k}"]`).each(function (this: HTMLInputElement) {
-          if (k === 'timeMode' && this.value !== '1') return;
+          if (k === 'timeMode' && $form.data('forceTimeMode')) return;
           if (this.type == 'checkbox') this.checked = true;
           else if (this.type == 'radio') this.checked = this.value == c[k];
           else if (k != 'fen' || !this.value) this.value = c[k];


### PR DESCRIPTION
Fixes #8600
Fixes #8886
Fixes #9002

Changes:
- Respect last selected time mode if not forced by setup
- Disable color buttons instead of hiding them to make it a bit clearer it's intentional
- Fix the bug where having 0+0 selected didn't allow FromPosition games after switching to unlimited time