### PR TITLE
Fix missing voice-over of identical moves

### DIFF
--- a/ui/analyse/src/plugins/nvui.ts
+++ b/ui/analyse/src/plugins/nvui.ts
@@ -88,7 +88,7 @@ lichess.AnalyseNVUI = function (redraw: Redraw) {
             {
               attrs: {
                 'aria-live': 'assertive',
-                'aria-atomic': true,
+                'aria-atomic': 'true',
               },
             },
             renderCurrentNode(ctrl.node, style)

--- a/ui/chat/src/discussion.ts
+++ b/ui/chat/src/discussion.ts
@@ -29,7 +29,7 @@ export default function (ctrl: Ctrl): Array<VNode | undefined> {
         attrs: {
           role: 'log',
           'aria-live': 'polite',
-          'aria-atomic': false,
+          'aria-atomic': 'false',
         },
         hook: {
           insert(vnode) {

--- a/ui/nvui/src/notify.ts
+++ b/ui/nvui/src/notify.ts
@@ -26,7 +26,7 @@ export class Notify {
       {
         attrs: {
           'aria-live': 'assertive',
-          'aria-atomic': true,
+          'aria-atomic': 'true',
         },
       },
       this.currentText()

--- a/ui/round/src/plugins/nvui.ts
+++ b/ui/round/src/plugins/nvui.ts
@@ -104,7 +104,7 @@ lichess.RoundNVUI = function (redraw: Redraw) {
               attrs: {
                 role: 'status',
                 'aria-live': 'assertive',
-                'aria-atomic': true,
+                'aria-atomic': 'true',
               },
             },
             [ctrl.data.game.status.name === 'started' ? 'Playing' : renderResult(ctrl)]
@@ -115,10 +115,11 @@ lichess.RoundNVUI = function (redraw: Redraw) {
             {
               attrs: {
                 'aria-live': 'assertive',
-                'aria-atomic': true,
+                'aria-atomic': 'true',
               },
             },
-            renderSan(step.san, step.uci, style)
+            // make sure consecutive moves are different so that they get re-read
+            renderSan(step.san, step.uci, style) + (ctrl.ply % 2 === 0 ? '' : ' ')
           ),
           ...(ctrl.isPlaying()
             ? [
@@ -208,7 +209,7 @@ lichess.RoundNVUI = function (redraw: Redraw) {
             {
               attrs: {
                 'aria-live': 'polite',
-                'aria-atomic': true,
+                'aria-atomic': 'true',
               },
             },
             ''


### PR DESCRIPTION
Fixes #8941.

- `aria-atomic` now uses string values instead of boolean values, so the resulting html is correct.
- In div.lastMove, every other ply gets a space added to the end, so consecutive move notations are always different by at least one space. Without this, the voice-over doesn't seem to happen on identical moves.

Tested with macOS 10.14 VoiceOver, Firefox 88, Chrome 90.