### PR TITLE
Fix no-FEN imports

### DIFF
--- a/modules/game/src/main/GameRepo.scala
+++ b/modules/game/src/main/GameRepo.scala
@@ -390,7 +390,7 @@ final class GameRepo(val coll: Coll)(implicit ec: scala.concurrent.ExecutionCont
       else g
     val userIds = g2.userIds.distinct
     val fen: Option[FEN] = initialFen orElse {
-      (!g2.variant.standardInitialPosition)
+      g2.variant.fromPosition
         .option(Forsyth >> g2.chess)
         .filterNot(_.initial)
     }

--- a/modules/game/src/main/GameRepo.scala
+++ b/modules/game/src/main/GameRepo.scala
@@ -390,7 +390,7 @@ final class GameRepo(val coll: Coll)(implicit ec: scala.concurrent.ExecutionCont
       else g
     val userIds = g2.userIds.distinct
     val fen: Option[FEN] = initialFen orElse {
-      g2.variant.fromPosition
+      (g2.variant.fromPosition || g2.variant.chess960)
         .option(Forsyth >> g2.chess)
         .filterNot(_.initial)
     }

--- a/modules/importer/src/main/Chess960.scala
+++ b/modules/importer/src/main/Chess960.scala
@@ -30,11 +30,4 @@ private object Chess960 {
         case _                                                         => false
       }(Rank.Eighth)
     }
-
-  def fixVariantName(v: String) =
-    v.toLowerCase match {
-      case "chess 960"   => "chess960"
-      case "fisherandom" => "chess960" // I swear, sometimes...
-      case _             => v
-    }
 }

--- a/modules/importer/src/main/ImporterForm.scala
+++ b/modules/importer/src/main/ImporterForm.scala
@@ -57,7 +57,7 @@ case class ImportData(pgn: String, analyse: Option[String]) {
   def preprocess(user: Option[String]): Validated[String, Preprocessed] = ImporterForm.catchOverflow { () =>
     Parser.full(pgn) flatMap { parsed =>
       Reader.fullWithSans(
-        pgn,
+        parsed,
         sans => sans.copy(value = sans.value take maxPlies),
         Tags.empty
       ) map evenIncomplete map { case replay @ Replay(setup, _, state) =>

--- a/modules/importer/src/main/ImporterForm.scala
+++ b/modules/importer/src/main/ImporterForm.scala
@@ -55,12 +55,11 @@ case class ImportData(pgn: String, analyse: Option[String]) {
     }
 
   def preprocess(user: Option[String]): Validated[String, Preprocessed] = ImporterForm.catchOverflow { () =>
-    Parser.full(pgn) flatMap { parsed =>
+    Parser.full(pgn) map { parsed =>
       Reader.fullWithSans(
         parsed,
-        sans => sans.copy(value = sans.value take maxPlies),
-        Tags.empty
-      ) map evenIncomplete map { case replay @ Replay(setup, _, state) =>
+        sans => sans.copy(value = sans.value take maxPlies)
+      ) pipe evenIncomplete pipe { case replay @ Replay(setup, _, state) =>
         val initBoard    = parsed.tags.fen flatMap Forsyth.<< map (_.board)
         val fromPosition = initBoard.nonEmpty && !parsed.tags.fen.exists(_.initial)
         val variant = {


### PR DESCRIPTION
Fixes #8485

And also more generally a bug where any PGN import for a variant with a non-standard starting position gets messed up because the final board position is used as the initial FEN.

That piece of code generally seems a bit sketchy but it seems to be necessary to get the initial FEN for FromPosition games in a few places. In those cases they are all new games though so it doesn't matter that it takes the final position.

I don't think it's ever needed for non-FromPosition games though and importing those without a FEN at least doesn't make sense anyway. But if I'm missing something, I guess the alternative would be to add something like  `initialFen | game.variant.initialFen` [here](https://github.com/ornicar/lila/blob/master/modules/importer/src/main/Importer.scala#L18).