### PR TITLE
Gives ultrabullet correspondence treatment

### DIFF
--- a/app/controllers/User.scala
+++ b/app/controllers/User.scala
@@ -284,7 +284,6 @@ final class User(
                   "blitz"         -> leaderboards.blitz,
                   "rapid"         -> leaderboards.rapid,
                   "classical"     -> leaderboards.classical,
-                  "ultraBullet"   -> leaderboards.ultraBullet,
                   "crazyhouse"    -> leaderboards.crazyhouse,
                   "chess960"      -> leaderboards.chess960,
                   "kingOfTheHill" -> leaderboards.kingOfTheHill,

--- a/app/views/user/list.scala
+++ b/app/views/user/list.scala
@@ -51,7 +51,6 @@ object list {
               userTopPerf(leaderboards.blitz, PerfType.Blitz),
               userTopPerf(leaderboards.rapid, PerfType.Rapid),
               userTopPerf(leaderboards.classical, PerfType.Classical),
-              userTopPerf(leaderboards.ultraBullet, PerfType.UltraBullet),
               userTopActive(nbAllTime, trans.activePlayers(), icon = 'U'.some),
               tournamentWinners(tourneyWinners),
               userTopPerf(leaderboards.crazyhouse, PerfType.Crazyhouse),

--- a/modules/rating/src/main/PerfType.scala
+++ b/modules/rating/src/main/PerfType.scala
@@ -224,7 +224,6 @@ object PerfType {
     Blitz,
     Rapid,
     Classical,
-    UltraBullet,
     Crazyhouse,
     Chess960,
     KingOfTheHill,

--- a/modules/tournament/src/main/TournamentScheduler.scala
+++ b/modules/tournament/src/main/TournamentScheduler.scala
@@ -137,8 +137,7 @@ Thank you all, you rock!"""
             month.lastWeek.withDayOfWeek(WEDNESDAY) -> Blitz,
             month.lastWeek.withDayOfWeek(THURSDAY)  -> Rapid,
             month.lastWeek.withDayOfWeek(FRIDAY)    -> Classical,
-            month.lastWeek.withDayOfWeek(SATURDAY)  -> HyperBullet,
-            month.lastWeek.withDayOfWeek(SUNDAY)    -> UltraBullet
+            month.lastWeek.withDayOfWeek(SATURDAY)  -> HyperBullet
           ).flatMap { case (day, speed) =>
             at(day, 17) map { date =>
               Schedule(Monthly, speed, Standard, none, date).plan
@@ -169,8 +168,7 @@ Thank you all, you rock!"""
             month.firstWeek.withDayOfWeek(WEDNESDAY) -> Blitz,
             month.firstWeek.withDayOfWeek(THURSDAY)  -> Rapid,
             month.firstWeek.withDayOfWeek(FRIDAY)    -> Classical,
-            month.firstWeek.withDayOfWeek(SATURDAY)  -> HyperBullet,
-            month.firstWeek.withDayOfWeek(SUNDAY)    -> UltraBullet
+            month.firstWeek.withDayOfWeek(SATURDAY)  -> HyperBullet
           ).flatMap { case (day, speed) =>
             at(day, 16) map { date =>
               Schedule(Shield, speed, Standard, none, date) plan {
@@ -257,9 +255,6 @@ Thank you all, you rock!"""
         },
         at(today, 20) map { date =>
           Schedule(Daily, HyperBullet, Standard, none, date pipe orTomorrow).plan
-        },
-        at(today, 21) map { date =>
-          Schedule(Daily, UltraBullet, Standard, none, date pipe orTomorrow).plan
         }
       ).flatten,
       List( // daily variant tournaments!
@@ -341,7 +336,7 @@ Thank you all, you rock!"""
             Schedule(Hourly, HyperBullet, Standard, none, date).plan
           },
           at(date, hour, 30) map { date =>
-            Schedule(Hourly, UltraBullet, Standard, none, date).plan
+            Schedule(Hourly, HyperBullet, Standard, none, date).plan
           },
           at(date, hour) map { date =>
             Schedule(Hourly, Bullet, Standard, none, date).plan

--- a/modules/tournament/src/main/TournamentShield.scala
+++ b/modules/tournament/src/main/TournamentShield.scala
@@ -127,12 +127,6 @@ object TournamentShield {
 
   object Category {
 
-    case object UltraBullet
-        extends Category(
-          of = Left(Schedule.Speed.UltraBullet),
-          iconChar = '{'
-        )
-
     case object HyperBullet
         extends Category(
           of = Left(Schedule.Speed.HyperBullet),
@@ -224,7 +218,6 @@ object TournamentShield {
       Rapid,
       Classical,
       HyperBullet,
-      UltraBullet,
       Crazyhouse,
       Chess960,
       KingOfTheHill,


### PR DESCRIPTION
Due to the current state of ultrabullet being a broken game from factors such as how close a user is to the Lichess servers to different move inputs, many have proposed giving ultrabullet the correspondence treatment of not having leaderboards, trophies and officially scheduled tournaments. 