### PR TITLE
Fix patron levelup

### DIFF
--- a/app/controllers/Mod.scala
+++ b/app/controllers/Mod.scala
@@ -427,8 +427,8 @@ final class Mod(
               modApi.setPermissions(me, user.username, Permission(permissions)) >> {
                 newPermissions(Permission.Coach) ?? env.security.automaticEmail.onBecomeCoach(user)
               } >> {
-                Permission(permissions).exists(_ is Permission.SeeReport) ?? (env.plan.api
-                  .setLifetime(user) >> !user.isPatron ?? env.activity.write.plan(user.username, 1))
+                Permission(permissions).exists(_ is Permission.SeeReport) ?? env.plan.api
+                  .setLifetime(user)
               } inject Redirect(routes.Mod.permissions(username)).flashSuccess
             }
           )

--- a/app/controllers/Mod.scala
+++ b/app/controllers/Mod.scala
@@ -427,8 +427,7 @@ final class Mod(
               modApi.setPermissions(me, user.username, Permission(permissions)) >> {
                 newPermissions(Permission.Coach) ?? env.security.automaticEmail.onBecomeCoach(user)
               } >> {
-                Permission(permissions).exists(_ is Permission.SeeReport) ?? env.plan.api
-                  .setLifetime(user)
+                Permission(permissions).exists(_ is Permission.SeeReport) ?? env.plan.api.setLifetime(user)
               } inject Redirect(routes.Mod.permissions(username)).flashSuccess
             }
           )

--- a/app/views/simul/form.scala
+++ b/app/views/simul/form.scala
@@ -132,7 +132,7 @@ object form {
         form("estimatedStartAt"),
         frag("Estimated start time"),
         half = true
-        )(form3.flatpickr(_)),
+      )(form3.flatpickr(_)),
       form3.group(
         form("text"),
         raw("Simul description"),

--- a/app/views/user/perfStat.scala
+++ b/app/views/user/perfStat.scala
@@ -119,7 +119,11 @@ object perfStat {
         ". ",
         ratingDeviation(
           strong(
-            title := ratingDeviationTooltip.txt(lila.rating.Glicko.provisionalDeviation, lila.rating.Glicko.standardRankableDeviation, lila.rating.Glicko.variantRankableDeviation)
+            title := ratingDeviationTooltip.txt(
+              lila.rating.Glicko.provisionalDeviation,
+              lila.rating.Glicko.standardRankableDeviation,
+              lila.rating.Glicko.variantRankableDeviation
+            )
           )(decimal(perf.glicko.deviation).toString)
         )
       )

--- a/modules/plan/src/main/Patron.scala
+++ b/modules/plan/src/main/Patron.scala
@@ -20,7 +20,7 @@ case class Patron(
 
   def levelUpIfPossible =
     copy(
-      lastLevelUp = if (canLevelUp) Some(DateTime.now) else lastLevelUp orElse Some(DataTime.now)
+      lastLevelUp = if (canLevelUp) Some(DateTime.now) else lastLevelUp orElse Some(DateTime.now)
     )
 
   def expireInOneMonth: Patron =

--- a/modules/plan/src/main/Patron.scala
+++ b/modules/plan/src/main/Patron.scala
@@ -18,14 +18,9 @@ case class Patron(
 
   def canLevelUp = lastLevelUp.exists(_.isBefore(DateTime.now.minusDays(25)))
 
-  def levelUpNow =
-    copy(
-      lastLevelUp = Some(DateTime.now)
-    )
-
   def levelUpIfPossible =
     copy(
-      lastLevelUp = if (canLevelUp) Some(DateTime.now) else lastLevelUp
+      lastLevelUp = if (canLevelUp) Some(DateTime.now) else lastLevelUp orElse Some(DataTime.now)
     )
 
   def expireInOneMonth: Patron =

--- a/modules/plan/src/main/PlanApi.scala
+++ b/modules/plan/src/main/PlanApi.scala
@@ -253,6 +253,7 @@ final class PlanApi(
     }
 
   def setLifetime(user: User): Funit =
+    if (user.plan.isEmpty) Bus.publish(lila.hub.actorApi.plan.MonthInc(user.id, 0), "plan")
     userRepo.setPlan(
       user,
       user.plan.enable

--- a/modules/plan/src/main/PlanApi.scala
+++ b/modules/plan/src/main/PlanApi.scala
@@ -252,7 +252,7 @@ final class PlanApi(
       _.exists(_.isLifetime)
     }
 
-  def setLifetime(user: User): Funit =
+  def setLifetime(user: User): Funit = {
     if (user.plan.isEmpty) Bus.publish(lila.hub.actorApi.plan.MonthInc(user.id, 0), "plan")
     userRepo.setPlan(
       user,
@@ -268,6 +268,7 @@ final class PlanApi(
         upsert = true
       )
       .void >>- lightUserApi.invalidate(user.id)
+  }
 
   def giveMonth(user: User): Funit =
     patronColl.update

--- a/modules/simul/src/main/SimulForm.scala
+++ b/modules/simul/src/main/SimulForm.scala
@@ -108,12 +108,12 @@ object SimulForm {
             ) contains _
           )
         }.verifying("At least one variant", _.nonEmpty),
-        "position" -> optional(lila.common.Form.fen.playableStrict),
-        "color"    -> stringIn(colorChoices),
-        "text"     -> cleanText,
+        "position"         -> optional(lila.common.Form.fen.playableStrict),
+        "color"            -> stringIn(colorChoices),
+        "text"             -> cleanText,
         "estimatedStartAt" -> optional(inTheFuture(ISODateTimeOrTimestamp.isoDateTimeOrTimestamp)),
-        "team"     -> optional(nonEmptyText.verifying(id => teams.exists(_.id == id))),
-        "featured" -> optional(boolean)
+        "team"             -> optional(nonEmptyText.verifying(id => teams.exists(_.id == id))),
+        "featured"         -> optional(boolean)
       )(Setup.apply)(Setup.unapply)
     )
 

--- a/modules/simul/src/main/SimulRepo.scala
+++ b/modules/simul/src/main/SimulRepo.scala
@@ -131,7 +131,7 @@ final private[simul] class SimulRepo(val coll: Coll)(implicit ec: scala.concurre
       .one(
         $id(simul.id),
         $set(SimulBSONHandler writeTry simul get) ++
-          simul.estimatedStartAt.isEmpty??($unset("estimatedStartAt"))
+          simul.estimatedStartAt.isEmpty ?? ($unset("estimatedStartAt"))
       )
       .void
 

--- a/modules/user/src/main/Plan.scala
+++ b/modules/user/src/main/Plan.scala
@@ -20,7 +20,7 @@ case class Plan(
   def enable =
     copy(
       active = true,
-      months = months max 1,
+      months = months atLeast 1,
       since = since orElse DateTime.now.some
     )
 

--- a/translation/source/activity.xml
+++ b/translation/source/activity.xml
@@ -3,6 +3,7 @@
   <string name="activity">Activity</string>
   <string name="hostedALiveStream">Hosted a live stream</string>
   <plurals name="supportedNbMonths">
+    <item quantity="zero">Started supporting lichess.org as a %2$s</item>
     <item quantity="one">Supported lichess.org for %1$s month as a %2$s</item>
     <item quantity="other">Supported lichess.org for %1$s months as a %2$s</item>
   </plurals>


### PR DESCRIPTION
Fixes #8244
Fixes #7584
Fixes #5010
Closes #5297

Currently, the month never increases because it always first updates the `lastLevelUp` and then checks again whether a level up is possible to decide whether to update the months.

Rest is mostly scalafmt, some cleanup, and making the activity entry more consistent, i.e. also show it for first-time patrons and use the correct month count.