### PR TITLE
Make moves user-selectable again

### DIFF
--- a/ui/tree/css/_tree.scss
+++ b/ui/tree/css/_tree.scss
@@ -18,8 +18,6 @@ $c-blunder: #df5353;
   move {
     @extend %move;
 
-    user-select: none;
-
     &.inaccuracy {
       color: $c-inaccuracy;
     }


### PR DESCRIPTION
Since some people were complaining about not being able to select and copy variations anymore.

I originally changed this because `clearSelection()` wasn't enough to always prevent all selections on touch long-presses but it looks like the remaining `user-select: none` on the context menu is enough to handle those cases.