### PR TITLE
missing translations, partly address #8492

### DIFF
--- a/app/views/team/tournaments.scala
+++ b/app/views/team/tournaments.scala
@@ -26,13 +26,13 @@ object tournaments {
           ),
           div(cls := "team-events team-tournaments team-tournaments--both")(
             div(cls := "team-tournaments__next")(
-              h2("Upcoming tournaments"),
+              h2(trans.team.upcomingTourns()),
               table(cls := "slist slist-pad slist-invert")(
                 renderList(tours.next)
               )
             ),
             div(cls := "team-tournaments__past")(
-              h2("Completed tournaments"),
+              h2(trans.team.completedTourns()),
               table(cls := "slist slist-pad")(
                 renderList(tours.past)
               )

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1572,6 +1572,8 @@ val `teamAlreadyExists` = new I18nKey("team:teamAlreadyExists")
 val `nbMembers` = new I18nKey("team:nbMembers")
 val `teamLeaders` = new I18nKey("team:teamLeaders")
 val `xJoinRequests` = new I18nKey("team:xJoinRequests")
+val `upcomingTourns` = new I18nKey("team:upcomingTourns")
+val `completedTourns` = new I18nKey("team:completedTourns")
 }
 
 object perfStat {

--- a/translation/source/team.xml
+++ b/translation/source/team.xml
@@ -47,4 +47,6 @@ Players who don't like receiving your messages might leave the team.</string>
   <string name="teamPasswordDescriptionForLeader">(Optional) A password that new members must know to join this team.</string>
   <string name="incorrectTeamPassword">Incorrect team password.</string>
   <string name="teamAlreadyExists">This team already exists.</string>
+  <string name="upcomingTourns">Upcoming tournaments</string>
+  <string name="completedTourns">Completed tournaments</string>
 </resources>


### PR DESCRIPTION
This is partly resolving #8492 by enabling translation for "Upcoming tournaments" and "Completed tournaments" - see screenshot 2.