### PR TITLE
Learn: Fix double sound when clicking 'next level' at stage end

### DIFF
--- a/ui/learn/src/run/runCtrl.js
+++ b/ui/learn/src/run/runCtrl.js
@@ -27,6 +27,7 @@ module.exports = function (opts, trans) {
     onComplete: function () {
       opts.storage.saveScore(stage, level.blueprint, level.vm.score);
       if (level.blueprint.id < stage.levels.length) m.route('/' + stage.id + '/' + (level.blueprint.id + 1));
+      else if (vm.stageCompleted()) return;
       else {
         vm.stageCompleted(true);
         sound.stageEnd();


### PR DESCRIPTION
i.e. when clicking the big green area on the right quickly after completing the last level of a stage