### PR TITLE
Fix 'Learn from mistakes' being cut off on small screens

### DIFF
--- a/ui/analyse/css/_training.scss
+++ b/ui/analyse/css/_training.scss
@@ -8,6 +8,12 @@
     display: flex;
     flex-flow: column;
     justify-content: center;
+
+    .find,
+    .fail {
+      padding-top: 5px;
+      padding-bottom: 8px;
+    }
   }
 
   .progress {


### PR DESCRIPTION
Fixes #5196

|Before|After
|:--:|:--:|
|![before](https://user-images.githubusercontent.com/19309705/120056125-9972b600-c03a-11eb-9bd6-6ae989185cc6.png)|![after](https://user-images.githubusercontent.com/19309705/120056126-9c6da680-c03a-11eb-9772-c054c9547d8d.png)|