### PR TITLE
hide coach trophy from chatbanned coaches profiles

### DIFF
--- a/modules/coach/src/main/CoachApi.scala
+++ b/modules/coach/src/main/CoachApi.scala
@@ -41,7 +41,7 @@ final class CoachApi(
     }
 
   def isListedCoach(user: User): Fu[Boolean] =
-    Granter(_.Coach)(user) ?? coachColl.exists($id(user.id) ++ $doc("listed" -> true))
+    Granter(_.Coach)(user) ?? !user.lameOrTroll ?? coachColl.exists($id(user.id) ++ $doc("listed" -> true))
 
   def setSeenAt(user: User): Funit =
     Granter(_.Coach)(user) ?? coachColl.update.one($id(user.id), $set("user.seenAt" -> DateTime.now)).void


### PR DESCRIPTION
Currently the trophy appears on their profile but leads to a 404 page when clicked. With this commit it won't be shown anymore.