### PR TITLE
Add missing puzzle translations, closes #9060

### DIFF
--- a/app/views/puzzle/bits.scala
+++ b/app/views/puzzle/bits.scala
@@ -57,7 +57,7 @@ object bits {
         trans.puzzle.history()
       ),
       a(cls := active.active("player"), href := routes.Puzzle.ofPlayer())(
-        "From my games"
+        trans.puzzle.fromMyGames()
       )
     )
 

--- a/app/views/puzzle/ofPlayer.scala
+++ b/app/views/puzzle/ofPlayer.scala
@@ -14,7 +14,7 @@ object ofPlayer {
 
   def apply(query: String, user: Option[User], puzzles: Option[Paginator[Puzzle]])(implicit ctx: Context) =
     views.html.base.layout(
-      title = user.fold("Lookup puzzles from a player's games")(u => s"Puzzles from ${u.username}' games"),
+      title = user.fold(trans.puzzle.lookupOfPlayer.txt())(u => trans.puzzle.fromXGames.txt(u.username)),
       moreCss = cssTag("puzzle.page"),
       moreJs = infiniteScrollTag
     )(
@@ -30,25 +30,23 @@ object ofPlayer {
               name := "name",
               value := query,
               cls := "form-control user-autocomplete",
-              placeholder := "Lichess username",
+              placeholder := trans.clas.lichessUsername.txt(),
               autocomplete := "off",
               dataTag := "span",
               autofocus
             ),
-            submitButton(cls := "button")("Search puzzles")
+            submitButton(cls := "button")(trans.puzzle.searchPuzzles.txt())
           ),
           div(cls := "puzzle-of-player__results")(
             (user, puzzles) match {
               case (Some(u), Some(pager)) =>
                 if (pager.nbResults == 0 && ctx.is(u))
-                  p(
-                    "You have no puzzles in the database, but Lichess still loves you very much.",
-                    br,
-                    "Play rapid and classical games to increase your chances of having a puzzle of yours added!"
-                  )
+                  p(trans.puzzle.fromMyGamesNone())
                 else
                   frag(
-                    p(strong(pager.nbResults), " puzzles found in ", userLink(u), " games."),
+                    p(strong 
+                    (trans.puzzle.fromXGamesFound((pager.nbResults), userLink(u)))
+                    ),
                     div(cls := "puzzle-of-player__pager infinite-scroll")(
                       pager.currentPageResults.map { puzzle =>
                         div(cls := "puzzle-of-player__puzzle")(

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1896,6 +1896,12 @@ val `newStreak` = new I18nKey("puzzle:newStreak")
 val `playedXTimes` = new I18nKey("puzzle:playedXTimes")
 val `nbPointsBelowYourPuzzleRating` = new I18nKey("puzzle:nbPointsBelowYourPuzzleRating")
 val `nbPointsAboveYourPuzzleRating` = new I18nKey("puzzle:nbPointsAboveYourPuzzleRating")
+val `fromMyGames` = new I18nKey("puzzle:fromMyGames")
+val `lookupOfPlayer` = new I18nKey("puzzle:lookupOfPlayer")
+val `fromXGames` = new I18nKey("puzzle:fromXGames")
+val `searchPuzzles` = new I18nKey("puzzle:searchPuzzles")
+val `fromMyGamesNone` = new I18nKey("puzzle:fromMyGamesNone")
+val `fromXGamesFound` = new I18nKey("puzzle:fromXGamesFound")
 }
 
 object puzzleTheme {

--- a/translation/source/puzzle.xml
+++ b/translation/source/puzzle.xml
@@ -63,4 +63,11 @@
   <string name="streakSkipExplanation">Skip this move to preserve your streak! Only works once per run.</string>
   <string name="continueTheStreak">Continue the streak</string>
   <string name="newStreak">New streak</string>
+  <string name="fromMyGames">From my games</string>
+  <string name="lookupOfPlayer">Lookup puzzles from a player's games</string>
+  <string name="fromXGames">Puzzles from %s' games</string>
+  <string name="searchPuzzles">Search puzzles</string>
+  <string name="fromMyGamesNone">You have no puzzles in the database, but Lichess still loves you very much.
+Play rapid and classical games to increase your chances of having a puzzle of yours added!</string>
+  <string name="fromXGamesFound">%1$s puzzles found in %2$s games</string>    
 </resources>


### PR DESCRIPTION
Adding missing translations related to /training/of-player. At some point in the future it may be good to move `class:lichessUsername` translation key to `site` but I will leave this to someone who has done it before.