### PR TITLE
Show opening name even after move 25

### DIFF
--- a/ui/analyse/src/explorer/explorerCtrl.ts
+++ b/ui/analyse/src/explorer/explorerCtrl.ts
@@ -104,10 +104,11 @@ export default function (root: AnalyseCtrl, opts: ExplorerOpts, allow: boolean):
     true
   );
 
-  const empty: ExplorerData = {
+  const empty: OpeningData = {
     isOpening: true,
     moves: [],
     fen: '',
+    opening: root.data.game.opening,
   };
 
   function setNode() {


### PR DESCRIPTION
**Description:**

`OpeningData` is not fetched for moves after 25 as games are not indexed beyond this point.
As a side-effect, the opening name was also not displayed for all moves after 25.
So adding the additional opening info for all such moves.

**Before:**
![OpeningNotShown](https://user-images.githubusercontent.com/25326979/120116258-f38f8a80-c1a4-11eb-9713-4d41f65547c5.png)

**After:**
![OpeningShown](https://user-images.githubusercontent.com/25326979/120116270-05712d80-c1a5-11eb-91ff-7482676d0503.png)

Closes #8989