### PR TITLE
Fix voice-over of identical moves in analysis

### DIFF
--- a/ui/analyse/src/plugins/nvui.ts
+++ b/ui/analyse/src/plugins/nvui.ts
@@ -91,7 +91,8 @@ lichess.AnalyseNVUI = function (redraw: Redraw) {
                 'aria-atomic': 'true',
               },
             },
-            renderCurrentNode(ctrl.node, style)
+            // make sure consecutive positions are different so that they get re-read
+            renderCurrentNode(ctrl.node, style) + (ctrl.node.ply % 2 === 0 ? '' : ' ')
           ),
           h('h2', 'Move form'),
           h(
@@ -327,7 +328,9 @@ function renderMainline(nodes: Tree.Node[], currentPath: Tree.Path, style: Style
 
 function renderCurrentNode(node: Tree.Node, style: Style): string {
   if (!node.san || !node.uci) return 'Initial position';
-  return [moveView.plyToTurn(node.ply), renderSan(node.san, node.uci, style), renderComments(node, style)].join(' ');
+  return [moveView.plyToTurn(node.ply), renderSan(node.san, node.uci, style), renderComments(node, style)]
+    .join(' ')
+    .trim();
 }
 
 function renderComments(node: Tree.Node, style: Style): string {


### PR DESCRIPTION
Fixes #9070

Very similar to the fix in #9004, but in analysis mode, the position text often comes with a trailing space already, so there's an added `trim()`. Without it, revoicing doesn't happen (tested on macOS VoiceOver).