### PR TITLE
Missing dasher translations

### DIFF
--- a/app/controllers/Dasher.scala
+++ b/app/controllers/Dasher.scala
@@ -34,6 +34,8 @@ final class Dasher(env: Env) extends LilaController(env) {
     trans.profile,
     trans.inbox,
     trans.preferences.preferences,
+    trans.coachManager,
+    trans.streamerManager,
     trans.logOut
   ).map(_.key) ::: translationsBase
 

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -751,6 +751,8 @@ val `availableInNbLanguages` = new I18nKey("availableInNbLanguages")
 val `nbSecondsToPlayTheFirstMove` = new I18nKey("nbSecondsToPlayTheFirstMove")
 val `nbSeconds` = new I18nKey("nbSeconds")
 val `andSaveNbPremoveLines` = new I18nKey("andSaveNbPremoveLines")
+val `coachManager` = new I18nKey("coachManager")
+val `streamerManager` = new I18nKey("streamerManager")
 
 object arena {
 val `arenaTournaments` = new I18nKey("arena:arenaTournaments")

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -869,4 +869,6 @@ computer analysis, game chat and shareable URL.</string>
   <string name="welcome">Welcome!</string>
   <string name="lichessPatronInfo">Lichess is a charity and entirely free/libre open source software.
 All operating costs, development, and content are funded solely by user donations.</string>
+  <string name="coachManager">Coach manager</string>
+  <string name="streamerManager">Streamer manager</string>
 </resources>

--- a/ui/dasher/src/links.ts
+++ b/ui/dasher/src/links.ts
@@ -1,5 +1,7 @@
 import { h, VNode } from 'snabbdom';
 
+import { h, VNode } from 'snabbdom';
+
 import { DasherCtrl, Mode } from './dasher';
 import { view as pingView } from './ping';
 import { bind } from './util';
@@ -30,9 +32,9 @@ export default function (ctrl: DasherCtrl): VNode {
             noarg('preferences')
           ),
 
-          !d.coach ? null : h('a.text', linkCfg('/coach/edit', ':'), 'Coach manager'),
+          !d.coach ? null : h('a.text', linkCfg('/coach/edit', ':'), noarg('coachManager')),
 
-          !d.streamer ? null : h('a.text', linkCfg('/streamer/edit', ''), 'Streamer manager'),
+          !d.streamer ? null : h('a.text', linkCfg('/streamer/edit', ''), noarg('streamerManager')),
 
           h(
             'form.logout',

--- a/ui/dasher/src/links.ts
+++ b/ui/dasher/src/links.ts
@@ -1,7 +1,5 @@
 import { h, VNode } from 'snabbdom';
 
-import { h, VNode } from 'snabbdom';
-
 import { DasherCtrl, Mode } from './dasher';
 import { view as pingView } from './ping';
 import { bind } from './util';


### PR DESCRIPTION
Making "coach manager" and "streamer manager" translateable. 