### PR TITLE
ui/analyse: Force-hide zh ui if variant != zh

### DIFF
--- a/ui/analyse/src/crazy/crazyView.ts
+++ b/ui/analyse/src/crazy/crazyView.ts
@@ -10,7 +10,7 @@ const oKeys = ['pawn', 'knight', 'bishop', 'rook', 'queen'];
 type Position = 'top' | 'bottom';
 
 export default function (ctrl: AnalyseCtrl, color: Color, position: Position) {
-  if (!ctrl.node.crazy) return;
+  if (!ctrl.node.crazy || ctrl.data.game.variant.key !== 'crazyhouse') return;
   const pocket = ctrl.node.crazy.pockets[color === 'white' ? 0 : 1];
   const dropped = ctrl.justDropped;
   const captured = ctrl.justCaptured;


### PR DESCRIPTION
Closes #8911

Not sure whether this is actually necessary since there now hopefully shouldn't appear any more standard games with zh pockets anymore in the future after ornicar/scalachess#222 but I guess it still doesn't hurt just in case for the few games that are already in the DB.