### PR TITLE
hide report score < 5

### DIFF
--- a/app/views/report/list.scala
+++ b/app/views/report/list.scala
@@ -121,7 +121,7 @@ object list {
                     )
                   )(
                     room.name,
-                    scores.get(room).filter(20 <).map(scoreTag(_))
+                    scores.get(room).filter(5 <).map(scoreTag(_))
                   )
                 }
               },


### PR DESCRIPTION
The default report score is 20, 19-5 the amount of reports aren't that much (except one queue) < 5 reports can just be hidden