### PR TITLE
Remove space between movetime chart columns and make them look a bit nicer

### DIFF
--- a/public/javascripts/chart/movetime.js
+++ b/public/javascripts/chart/movetime.js
@@ -204,7 +204,8 @@ lichess.movetimeChart = function (data, trans, hunter) {
                   color: whiteColumnFill,
                   negativeColor: blackColumnFill,
                   grouping: false,
-                  pointPadding: Math.max(0.25 - moveSeries.white.length / 250, -0.2),
+                  groupPadding: 0,
+                  pointPadding: 0,
                   states: {
                     hover: {
                       enabled: false,

--- a/public/javascripts/chart/movetime.js
+++ b/public/javascripts/chart/movetime.js
@@ -114,35 +114,6 @@ lichess.movetimeChart = function (data, trans, hunter) {
                 },
               },
             };
-            const areaLineTypeOptions = {
-              ...sharedTypeOptions,
-              trackByArea: true,
-              fillColor: whiteAreaFill,
-              negativeFillColor: blackAreaFill,
-              threshold: 0,
-              lineWidth: hunter ? 1 : 2,
-              color: highlightColor,
-              states: {
-                hover: {
-                  lineWidth: hunter ? 1 : 2,
-                },
-              },
-              marker: {
-                radius: 1,
-                states: {
-                  hover: {
-                    radius: 3,
-                    lineColor: highlightColor,
-                    fillColor: 'white',
-                  },
-                  select: {
-                    radius: 4,
-                    lineColor: highlightColor,
-                    fillColor: 'white',
-                  },
-                },
-              },
-            };
 
             this.highcharts = Highcharts.chart(this, {
               credits: disabled,
@@ -166,13 +137,13 @@ lichess.movetimeChart = function (data, trans, hunter) {
                   ? [
                       {
                         name: 'White Clock',
-                        type: 'line',
+                        type: 'area',
                         yAxis: 1,
                         data: totalSeries.white,
                       },
                       {
                         name: 'Black Clock',
-                        type: 'line',
+                        type: 'area',
                         yAxis: 1,
                         data: totalSeries.black,
                       },
@@ -199,8 +170,35 @@ lichess.movetimeChart = function (data, trans, hunter) {
                 series: {
                   animation: false,
                 },
-                area: areaLineTypeOptions,
-                line: areaLineTypeOptions,
+                area: {
+                  ...sharedTypeOptions,
+                  trackByArea: true,
+                  fillColor: whiteAreaFill,
+                  negativeFillColor: blackAreaFill,
+                  threshold: 0,
+                  lineWidth: hunter ? 1 : 2,
+                  color: highlightColor,
+                  states: {
+                    hover: {
+                      lineWidth: hunter ? 1 : 2,
+                    },
+                  },
+                  marker: {
+                    radius: 1,
+                    states: {
+                      hover: {
+                        radius: 3,
+                        lineColor: highlightColor,
+                        fillColor: 'white',
+                      },
+                      select: {
+                        radius: 4,
+                        lineColor: highlightColor,
+                        fillColor: 'white',
+                      },
+                    },
+                  },
+                },
                 column: {
                   ...sharedTypeOptions,
                   color: whiteColumnFill,

--- a/public/javascripts/chart/movetime.js
+++ b/public/javascripts/chart/movetime.js
@@ -25,10 +25,10 @@ lichess.movetimeChart = function (data, trans, hunter) {
             const highlightColor = '#3893E8';
             const xAxisColor = '#cccccc99';
             const whiteAreaFill = 'rgba(255, 255, 255, 0.2)';
-            const whiteColumnFill = 'rgba(255, 255, 255, 0.4)';
-            const whiteColumnBorder = '#00000077';
+            const whiteColumnFill = 'rgba(255, 255, 255, 0.9)';
+            const whiteColumnBorder = '#00000044';
             const blackAreaFill = 'rgba(0, 0, 0, 0.4)';
-            const blackColumnFill = 'rgba(0, 0, 0, 0.7)';
+            const blackColumnFill = 'rgba(0, 0, 0, 0.9)';
             const blackColumnBorder = '#ffffff33';
 
             const moveSeries = {
@@ -114,27 +114,40 @@ lichess.movetimeChart = function (data, trans, hunter) {
                 },
               },
             };
+            const areaLineTypeOptions = {
+              ...sharedTypeOptions,
+              trackByArea: true,
+              fillColor: whiteAreaFill,
+              negativeFillColor: blackAreaFill,
+              threshold: 0,
+              lineWidth: hunter ? 1 : 2,
+              color: highlightColor,
+              states: {
+                hover: {
+                  lineWidth: hunter ? 1 : 2,
+                },
+              },
+              marker: {
+                radius: 1,
+                states: {
+                  hover: {
+                    radius: 3,
+                    lineColor: highlightColor,
+                    fillColor: 'white',
+                  },
+                  select: {
+                    radius: 4,
+                    lineColor: highlightColor,
+                    fillColor: 'white',
+                  },
+                },
+              },
+            };
 
             this.highcharts = Highcharts.chart(this, {
               credits: disabled,
               legend: disabled,
               series: [
-                ...(showTotal
-                  ? [
-                      {
-                        name: 'White Clock',
-                        type: 'area',
-                        yAxis: 1,
-                        data: totalSeries.white,
-                      },
-                      {
-                        name: 'Black Clock',
-                        type: 'area',
-                        yAxis: 1,
-                        data: totalSeries.black,
-                      },
-                    ]
-                  : []),
                 {
                   name: 'White',
                   type: hunter ? 'area' : 'column',
@@ -149,6 +162,22 @@ lichess.movetimeChart = function (data, trans, hunter) {
                   data: moveSeries.black,
                   borderColor: blackColumnBorder,
                 },
+                ...(showTotal
+                  ? [
+                      {
+                        name: 'White Clock',
+                        type: 'line',
+                        yAxis: 1,
+                        data: totalSeries.white,
+                      },
+                      {
+                        name: 'Black Clock',
+                        type: 'line',
+                        yAxis: 1,
+                        data: totalSeries.black,
+                      },
+                    ]
+                  : []),
               ],
               chart: {
                 alignTicks: false,
@@ -170,35 +199,8 @@ lichess.movetimeChart = function (data, trans, hunter) {
                 series: {
                   animation: false,
                 },
-                area: {
-                  ...sharedTypeOptions,
-                  trackByArea: true,
-                  fillColor: whiteAreaFill,
-                  negativeFillColor: blackAreaFill,
-                  threshold: 0,
-                  lineWidth: 1,
-                  color: highlightColor,
-                  states: {
-                    hover: {
-                      lineWidth: 1,
-                    },
-                  },
-                  marker: {
-                    radius: 1,
-                    states: {
-                      hover: {
-                        radius: 3,
-                        lineColor: highlightColor,
-                        fillColor: 'white',
-                      },
-                      select: {
-                        radius: 4,
-                        lineColor: highlightColor,
-                        fillColor: 'white',
-                      },
-                    },
-                  },
-                },
+                area: areaLineTypeOptions,
+                line: areaLineTypeOptions,
                 column: {
                   ...sharedTypeOptions,
                   color: whiteColumnFill,


### PR DESCRIPTION
#### Before (but already without space)
![Screenshot 2021-06-12 060816](https://user-images.githubusercontent.com/19309705/121764619-9ea92800-cb45-11eb-8acb-edc7524c66b9.png)

#### After
![Screenshot 2021-06-12 060709](https://user-images.githubusercontent.com/19309705/121764615-9d77fb00-cb45-11eb-8469-3516f7a4e8f6.png)
![Screenshot 2021-06-12 060657](https://user-images.githubusercontent.com/19309705/121764617-9e109180-cb45-11eb-8434-c213b624b853.png)

Feedback appreciated. To see how it looks on the site without spinning up lila, you can use the overrides feature in Chrome to override `movetime.js` with the version from this PR.
