### PR TITLE
Make movetime chart tooltip unshared again

### DIFF
--- a/public/javascripts/chart/movetime.js
+++ b/public/javascripts/chart/movetime.js
@@ -156,7 +156,6 @@ lichess.movetimeChart = function (data, trans, hunter) {
                 animation: false,
               },
               tooltip: {
-                shared: true,
                 formatter: function () {
                   let seconds = data.game.moveCentis[this.x] / 100;
                   if (seconds) seconds = seconds.toFixed(seconds >= 2 ? 1 : 2);


### PR DESCRIPTION
To avoid tooltips flipping back and forth between black and white. I thought this makes sense to make both the line and bar highlight at once but it hardly makes a difference and the flipping back and forth is really annoying.