### PR TITLE
Explorer: Fix stuck move-arrow after changing db

### DIFF
--- a/ui/analyse/src/explorer/explorerCtrl.ts
+++ b/ui/analyse/src/explorer/explorerCtrl.ts
@@ -62,9 +62,9 @@ export default function (root: AnalyseCtrl, opts: ExplorerOpts, allow: boolean):
 
   let cache: Dictionary<ExplorerData> = {};
   function onConfigClose() {
-    root.redraw();
     cache = {};
     setNode();
+    root.redraw();
   }
   const data = root.data,
     withGames = root.synthetic || gameUtil.replayable(data) || !!data.opponent.ai,


### PR DESCRIPTION
Fixes #8903

Setting `loading(true)` before redrawing avoids creating a move-arrow on hover. The old entries still flash for a moment but avoiding that without creating move-jank e.g. by simply resetting `lastShown` every time seems way too annoying.