### PR TITLE
Adjust coordinate size and position according to board size

### DIFF
--- a/app/ui/scalatags.scala
+++ b/app/ui/scalatags.scala
@@ -25,6 +25,7 @@ trait ScalatagsAttrs {
   val dataBotAttr    = attr("data-bot").empty
   val deferAttr      = attr("defer").empty
   val downloadAttr   = attr("download").empty
+  val viewBoxAttr    = attr("viewBox")
 
   object frame {
     val scrolling       = attr("scrolling")
@@ -54,7 +55,8 @@ trait ScalatagsSnippets extends Cap {
   val goodTag                                = tag("good")
   val badTag                                 = tag("bad")
   val timeTag                                = tag("time")
-  val dialog                                 = tag("dialog")
+  val svgTag                                 = tag("svg")
+  val textTag                                = tag("text")
 
   def userTitleTag(t: Title) =
     span(

--- a/app/ui/scalatags.scala
+++ b/app/ui/scalatags.scala
@@ -55,6 +55,7 @@ trait ScalatagsSnippets extends Cap {
   val goodTag                                = tag("good")
   val badTag                                 = tag("bad")
   val timeTag                                = tag("time")
+  val dialog                                 = tag("dialog")
   val svgTag                                 = tag("svg")
   val textTag                                = tag("text")
 

--- a/app/views/coordinate.scala
+++ b/app/views/coordinate.scala
@@ -69,8 +69,9 @@ object coordinate {
           )
         ),
         div(cls := "coord-trainer__board main-board")(
-          div(cls := "next_coord", id := "next_coord0"),
-          div(cls := "next_coord", id := "next_coord1"),
+          raw(
+            """<svg class="coords-svg" viewBox="0 0 100 100"><text class="coord current-coord"/><text class="coord next-coord"/></svg>"""
+          ),
           chessgroundBoard
         ),
         div(cls := "coord-trainer__table")(

--- a/app/views/coordinate.scala
+++ b/app/views/coordinate.scala
@@ -69,8 +69,9 @@ object coordinate {
           )
         ),
         div(cls := "coord-trainer__board main-board")(
-          raw(
-            """<svg class="coords-svg" viewBox="0 0 100 100"><text class="coord current-coord"/><text class="coord next-coord"/></svg>"""
+          svgTag(cls := "coords-svg", viewBoxAttr := "0 0 100 100")(
+            textTag(cls := "coord current-coord"),
+            textTag(cls := "coord next-coord")
           ),
           chessgroundBoard
         ),

--- a/ui/site/css/_coordinate.scss
+++ b/ui/site/css/_coordinate.scss
@@ -122,41 +122,33 @@ $mq-col3: $mq-x-large;
     }
   }
 
-  .next_coord {
-    @extend %flex-center;
-
-    z-index: 2;
-    justify-content: center;
+  svg.coords-svg {
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 90%;
+    z-index: 3;
+    width: 100%;
     height: 100%;
-    font-size: 180px;
-    font-weight: bold;
-    opacity: 1;
     pointer-events: none;
-    color: #eee;
-    text-shadow: 0 10px 10px #444;
-    opacity: 0.8;
-
-    @include transition;
-  }
-
-  #next_coord0 {
-    color: #fff;
-  }
-
-  #next_coord1 {
-    left: 26%;
-    top: 10%;
-    font-size: 75px;
-    opacity: 0.7;
-  }
-
-  #next_coord1,
-  #next_coord0 {
     user-select: none;
+
+    .coord {
+      @include transition;
+      font-weight: bold;
+      text-shadow: 0 10px 10px #444;
+
+      &.current-coord {
+        fill: #fff;
+        opacity: 0.8;
+        font-size: 30px;
+        transform: translate(22px, 60px);
+      }
+
+      &.next-coord {
+        fill: #eee;
+        opacity: 0.7;
+        font-size: 12px;
+        transform: translate(64px, 64px);
+      }
+    }
   }
 
   .progress_bar {
@@ -178,23 +170,25 @@ $mq-col3: $mq-x-large;
     }
   }
 
-  &.wrong .progress_bar {
-    background-color: $c-bad;
-  }
+  &.wrong {
+    $c-wrong: $c-bad;
 
-  &.wrong .coord-trainer__score,
-  &.wrong #next_coord0 {
-    color: $c-bad !important;
+    .progress_bar {
+      background-color: $c-wrong;
+    }
+
+    .coord-trainer__score {
+      color: $c-wrong !important;
+    }
+
+    .current-coord {
+      fill: $c-wrong !important;
+    }
   }
 
   &.play .start,
-  #next_coord,
   &.play form.color {
     display: none;
-  }
-
-  &.play #next_coord {
-    display: block;
   }
 
   &.init {

--- a/ui/site/src/coordinate.ts
+++ b/ui/site/src/coordinate.ts
@@ -8,11 +8,12 @@ lichess.load.then(() => {
   $('#trainer').each(function (this: HTMLElement) {
     const $trainer = $(this);
     const $board = $('.coord-trainer__board .cg-wrap');
+    const $coordsSvg = $('.coords-svg');
+    const $coords = $coordsSvg.find('.coord');
     let ground;
     const $side = $('.coord-trainer__side');
     const $right = $('.coord-trainer__table');
     const $bar = $trainer.find('.progress_bar');
-    const $coords = [$('#next_coord0'), $('#next_coord1')];
     const $start = $right.find('.start');
     const $explanation = $right.find('.explanation');
     const $score = $('.coord-trainer__score');
@@ -121,9 +122,7 @@ lichess.load.then(() => {
     centerRight();
 
     const clearCoords = function () {
-      $.each($coords, function (_, e) {
-        e.text('');
-      });
+      $coords.text('');
     };
 
     const newCoord = function (prevCoord) {
@@ -141,15 +140,18 @@ lichess.load.then(() => {
       );
     };
 
+    const currentCoordEl = function () {
+      return $coordsSvg.find('.current-coord');
+    };
+
+    const nextCoordEl = function () {
+      return $coordsSvg.find('.next-coord');
+    };
+
     const advanceCoords = function () {
-      $('#next_coord0').removeClass('nope');
-      const lastElement = $coords.shift()!;
-      $.each($coords, function (i, e) {
-        e.attr('id', 'next_coord' + i);
-      });
-      lastElement.attr('id', 'next_coord' + $coords.length);
-      lastElement.text(newCoord($coords[$coords.length - 1].text()));
-      $coords.push(lastElement);
+      $coords.toggleClass('current-coord').toggleClass('next-coord');
+      const currentCoordValue = currentCoordEl().text();
+      nextCoordEl().text(newCoord(currentCoordValue));
     };
 
     const stop = function () {
@@ -204,7 +206,7 @@ lichess.load.then(() => {
         ground.set({
           events: {
             select(key) {
-              const hit = key == $coords[0].text();
+              const hit = key == currentCoordEl().text();
               if (hit) {
                 score++;
                 $score.text(score);
@@ -220,9 +222,10 @@ lichess.load.then(() => {
             },
           },
         });
-        $coords[0].text(newCoord('a1'));
-        let i;
-        for (i = 1; i < $coords.length; i++) $coords[i].text(newCoord($coords[i - 1].text()));
+
+        const initialCoordValue = newCoord('a1');
+        currentCoordEl().text(initialCoordValue);
+        nextCoordEl().text(newCoord(initialCoordValue));
         tick();
       }, 1000);
     });


### PR DESCRIPTION
Fixes #9065

The issue isn't just relevant to very small board. Since currently coordinate font-sizes and positions are constant - coordinates are relatively small on bigger board and enormous (and overlapping) on smaller board.
I've reworked it with SVG so that font sizes and positions are scaled based on the board size.

| Board size | Before | After |
| -------------- | --------- | ------ |
| 200px      | ![200-before](https://user-images.githubusercontent.com/66057996/121790182-6e18cb00-cbe5-11eb-9a84-992da18c214f.png) | ![200-after](https://user-images.githubusercontent.com/66057996/121790183-707b2500-cbe5-11eb-8eaa-664bfa97688c.png) |
| 440px      | ![440-before](https://user-images.githubusercontent.com/66057996/121790185-72dd7f00-cbe5-11eb-9974-1d2ec96cf7cd.png) | ![440-after](https://user-images.githubusercontent.com/66057996/121790188-75d86f80-cbe5-11eb-9835-420f1f344b55.png) |
| 760px      | ![760-before](https://user-images.githubusercontent.com/66057996/121790193-7f61d780-cbe5-11eb-9460-275ce865263f.png) | ![760-after](https://user-images.githubusercontent.com/66057996/121790194-812b9b00-cbe5-11eb-9979-f256fbf41c58.png) |
