### PR TITLE
Fix timeout after takeback on first move

### DIFF
--- a/modules/game/src/main/Game.scala
+++ b/modules/game/src/main/Game.scala
@@ -456,7 +456,7 @@ case class Game(
 
   private def outoftimeClock(withGrace: Boolean): Boolean =
     clock ?? { c =>
-      started && playable && (bothPlayersHaveMoved || isSimul || isSwiss || fromFriend || fromApi) && {
+      started && playable && {
         c.outOfTime(turnColor, withGrace) || {
           !c.isRunning && c.players.exists(_.elapsed.centis > 0)
         }


### PR DESCRIPTION
Fixes #9072

I'm a bit unsure about this but as far as I can tell this check doesn't actually do anything (other than causing this bug)? I tested it and pool games are still aborted and arena tournament games are lost if either player doesn't make their move at the start. And as far as I can tell it shouldn't trigger anyway in basically all other situations.