### PR TITLE
Reset coordinate color preference after reload in Firefox

### DIFF
--- a/app/views/coordinate.scala
+++ b/app/views/coordinate.scala
@@ -43,7 +43,12 @@ object coordinate {
               div(cls := "scores")(scoreCharts(score))
             }
           ),
-          form(cls := "color buttons", action := routes.Coordinate.color, method := "post")(
+          form(
+            cls := "color buttons",
+            action := routes.Coordinate.color,
+            method := "post",
+            autocomplete := "off"
+          )(
             st.group(cls := "radio")(
               List(Color.BLACK, Color.RANDOM, Color.WHITE).map { id =>
                 div(


### PR DESCRIPTION
Fixes #9063 

This is indeed a "feature" of Firefox. Firefox remembers form input values after reloading the page.
The solution is to set the `autocomplete` attribute to `off`.

Note from MDN:

> Note: The autocomplete attribute also controls whether Firefox will — unlike other browsers — persist the dynamic disabled state and (if applicable) dynamic checkedness of an `<input>` element, `<textarea>` element, or entire `<form>` across page loads. The persistence feature is enabled by default. Setting the value of the autocomplete attribute to off disables this feature. This works even when the autocomplete attribute would normally not apply by virtue of its type. See bug 654072.

[The HTML autocomplete attribute - HTML: HyperText Markup Language | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)

[firefox - Why does the checkbox stay checked when reloading the page? - Stack Overflow](https://stackoverflow.com/questions/299811/why-does-the-checkbox-stay-checked-when-reloading-the-page)