### PR TITLE
ceval: Avoid empty pv collapsing (i.e. after checkmate)

### DIFF
--- a/ui/ceval/css/_pv.scss
+++ b/ui/ceval/css/_pv.scss
@@ -10,6 +10,7 @@
     line-height: 2em;
     border-top: $border;
     padding-right: 14px;
+    min-height: 2em;
 
     &.pv--nowrap {
       display: block; // "flex" doesn't support ellipsis so switch back to "block"


### PR DESCRIPTION
When clicking the little arrow.