### PR TITLE
Disallow zen mode when spectating

### DIFF
--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -574,7 +574,7 @@ export default class RoundController {
     if (was !== is) {
       lichess.quietMode = is;
       $('body')
-        .toggleClass('playing', !this.data.spectator)
+        .toggleClass('playing', !this.data.player.spectator)
         .toggleClass('no-select', is && this.clock && this.clock.millisOf(this.data.player.color) <= 3e5);
     }
   };


### PR DESCRIPTION
Related: #9207, #9216, #9217
As per #9207, there should be no zen mode as spectator but people are still able to toggle it using the preferences page.