### PR TITLE
provide study pgn api (lichess-org/api#119)

### DIFF
--- a/app/controllers/RelayRound.scala
+++ b/app/controllers/RelayRound.scala
@@ -204,7 +204,7 @@ final class RelayRound(
   private def doShow(rt: RoundModel.WithTour, oldSc: lila.study.Study.WithChapter)(implicit
       ctx: Context
   ): Fu[Result] =
-    studyC.CanViewResult(oldSc.study) {
+    studyC.CanView(oldSc.study, ctx.me) {
       for {
         (sc, studyData) <- studyC.getJsonData(oldSc)
         rounds          <- env.relay.api.byTourOrdered(rt.tour)
@@ -220,7 +220,7 @@ final class RelayRound(
       } yield EnableSharedArrayBuffer(
         Ok(html.relay.show(rt withStudy sc.study, data, chat, sVersion, streamers))
       )
-    }
+    }(studyC.privateUnauthorizedFu(oldSc.study), studyC.privateForbiddenFu(oldSc.study))
 
   implicit private def makeRelayId(id: String): RoundModel.Id           = RoundModel.Id(id)
   implicit private def makeChapterId(id: String): lila.study.Chapter.Id = lila.study.Chapter.Id(id)

--- a/conf/routes
+++ b/conf/routes
@@ -169,6 +169,7 @@ POST  /study/topic                     controllers.Study.setTopics
 GET   /study/topic/:topic/:order       controllers.Study.byTopic(topic: String, order: String, page: Int ?= 1)
 GET   /study/topic/autocomplete        controllers.Study.topicAutocomplete
 GET   /study/glyphs/:lang.json         controllers.Study.glyphs(lang)
+GET   /api/study/$id<\w{8}>.pgn        controllers.Study.apiPgn(id: String)
 
 # Relay
 GET   /broadcast                              controllers.RelayTour.index(page: Int ?= 1)


### PR DESCRIPTION
Unlike `/study/{studyId}.pgn`, this supports CORS and reading private
studies using the `study:read` OAuth scope.