### PR TITLE
Display overlong names better

### DIFF
--- a/ui/chat/src/util.ts
+++ b/ui/chat/src/util.ts
@@ -1,7 +1,7 @@
 import { h, VNode } from 'snabbdom';
 
 export function userLink(u: string, title?: string, patron?: boolean): VNode {
-  const trunc = u.substring(0, 14);
+  const trunc = u.length > 13 ? u.substring(0, 13) + '…' : u;
   const line = patron
     ? h('line.line.patron', {
         attrs: {

--- a/ui/common/css/component/_mini-game.scss
+++ b/ui/common/css/component/_mini-game.scss
@@ -20,7 +20,14 @@
   }
 
   &__user {
+    display: flex;
+    align-items: baseline;
     overflow: hidden;
+  }
+
+  .name {
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .rating {
@@ -33,7 +40,7 @@
   &__clock {
     @extend %roboto;
 
-    padding: 0 1ch;
+    padding-left: 2ch;
 
     &.clock--run {
       color: $c-accent;


### PR DESCRIPTION
Fixes #9219

| Before | After
|:--:|:--:|
|![after](https://user-images.githubusercontent.com/19309705/123155422-66b8b380-d468-11eb-8ae2-da4cae099699.png)|![before](https://user-images.githubusercontent.com/19309705/123155428-67e9e080-d468-11eb-866e-82af3eeea03e.png)|

Same in the chat where it also now uses "..." instead of just cutting it off.