### PR TITLE
Fix promotion overlay and study player alignment

### DIFF
--- a/ui/analyse/css/_player-clock.scss
+++ b/ui/analyse/css/_player-clock.scss
@@ -19,10 +19,8 @@ $clock-height: 20px;
   &.bottom {
     @extend %box-radius-bottom;
 
-    bottom: #{-$clock-height};
-    z-index: 1;
-
-    // over the board coords
+    top: var(--cg-height, 100%);
+    z-index: 1; // over the board coords
   }
 
   &.active {

--- a/ui/analyse/css/study/_player.scss
+++ b/ui/analyse/css/study/_player.scss
@@ -22,9 +22,9 @@ $player-height: 1.6rem;
   @extend %flex-between-nowrap, %metal, %box-shadow;
 
   position: absolute;
-  left: 0;
   right: 0;
   font-weight: bold;
+  width: var(--cg-width, 100%);
   height: $player-height;
   white-space: nowrap;
 
@@ -37,7 +37,7 @@ $player-height: 1.6rem;
   &-bot {
     @extend %box-radius-bottom;
 
-    bottom: #{-$player-height};
+    top: var(--cg-height, 100%);
   }
 
   .left {

--- a/ui/analyse/src/ground.ts
+++ b/ui/analyse/src/ground.ts
@@ -52,6 +52,7 @@ export function makeConfig(ctrl: AnalyseCtrl): CgConfig {
     orientation: ctrl.bottomColor(),
     coordinates: pref.coords !== Prefs.Coords.Hidden && !ctrl.embed,
     addPieceZIndex: pref.is3d,
+    addDimensionsCssVars: true,
     viewOnly: !!ctrl.embed,
     movable: {
       free: false,

--- a/ui/chess/css/_promotion.scss
+++ b/ui/chess/css/_promotion.scss
@@ -1,8 +1,11 @@
 #promotion-choice {
-  @extend %abs-100;
-
   background: fade-out($c-bg-page, 0.3);
   z-index: z('cg__promotion');
+
+  position: absolute;
+  width: var(--cg-width, 100%);
+  height: var(--cg-height, 100%);
+  right: 0;
 
   square {
     cursor: pointer;

--- a/ui/puz/src/view/chessground.ts
+++ b/ui/puz/src/view/chessground.ts
@@ -12,6 +12,7 @@ export function makeConfig(opts: CgConfig, pref: PuzPrefs, userMove: UserMove): 
     lastMove: opts.lastMove,
     coordinates: pref.coords !== Prefs.Coords.Hidden,
     addPieceZIndex: pref.is3d,
+    addDimensionsCssVars: true,
     movable: {
       free: false,
       color: opts.movable!.color,

--- a/ui/puzzle/src/view/chessground.ts
+++ b/ui/puzzle/src/view/chessground.ts
@@ -24,6 +24,7 @@ export function makeConfig(ctrl: Controller): CgConfig {
     lastMove: opts.lastMove,
     coordinates: ctrl.pref.coords !== Prefs.Coords.Hidden,
     addPieceZIndex: ctrl.pref.is3d,
+    addDimensionsCssVars: true,
     movable: {
       free: false,
       color: opts.movable!.color,

--- a/ui/round/src/ground.ts
+++ b/ui/round/src/ground.ts
@@ -23,6 +23,7 @@ export function makeConfig(ctrl: RoundController): Config {
     check: !!step.check,
     coordinates: data.pref.coords !== Prefs.Coords.Hidden,
     addPieceZIndex: ctrl.data.pref.is3d,
+    addDimensionsCssVars: true,
     highlight: {
       lastMove: data.pref.highlight,
       check: data.pref.highlight,


### PR DESCRIPTION
Fixes #6874

It's a bit hacky but not sure if there's a much better way.

Also, I noticed that there's a lot of duplication with the promotion stuff. I didn't look at it too closely but it seems at least some of them could be combined into a shared file?

Is there something preventing that? And if not, what would be a good location for such a file? Just `common`?