### PR TITLE
Remove unused UserRepo.isEngine

### DIFF
--- a/modules/user/src/main/UserRepo.scala
+++ b/modules/user/src/main/UserRepo.scala
@@ -391,8 +391,6 @@ final class UserRepo(val coll: Coll)(implicit ec: scala.concurrent.ExecutionCont
 
   def updateTroll(user: User) = setTroll(user.id, user.marks.troll)
 
-  def isEngine(id: ID): Fu[Boolean] = coll.exists($id(id) ++ engineSelect(true))
-
   def filterEngine(ids: Seq[ID]): Fu[Set[ID]] =
     coll.distinct[ID, Set]("_id", Some($inIds(ids) ++ engineSelect(true)))
 


### PR DESCRIPTION
btw, should `filterEngine` (used for striking swiss top3s) be changed to also check for other ToS marks since that's what most other things on Lichess do now? Seems a bit weird for this case but on the other hand, it's one of the remaining ways to identify that a mark is for cheating.