### PR TITLE
Fix arrow keys for navigating the board in puzzles in blind mode

### DIFF
--- a/ui/puzzle/src/plugins/nvui.ts
+++ b/ui/puzzle/src/plugins/nvui.ts
@@ -138,7 +138,7 @@ lichess.PuzzleNVUI = function (redraw: Redraw) {
                 const fenSteps = () => steps().map(step => step.fen);
                 const opponentColor = ctrl.vm.pov === 'white' ? 'black' : 'white';
                 $board.on('click', selectionHandler(opponentColor, selectSound));
-                $board.on('keypress', arrowKeyHandler(ctrl.vm.pov, borderSound));
+                $board.on('keydown', arrowKeyHandler(ctrl.vm.pov, borderSound));
                 $board.on('keypress', boardCommandsHandler());
                 $buttons.on('keypress', lastCapturedCommandHandler(fenSteps, pieceStyle.get(), prefixStyle.get()));
                 $buttons.on(


### PR DESCRIPTION
In blind mode for puzzles, the arrow keys to move around the board don't work because they use keypress instead of keydown, and arrow keys aren't printable. This PR fixes that (my) mistake.