### PR TITLE
Fix rating graph not showing

### DIFF
--- a/ui/site/src/user.ts
+++ b/ui/site/src/user.ts
@@ -51,6 +51,7 @@ lichess.load.then(() => {
           window.InfiniteScroll('.infinite-scroll');
         });
     $angles.on('click', 'a', function (this: HTMLAnchorElement) {
+      if ($('#games .to-search').hasClass('active')) return true;
       $angles.find('.active').removeClass('active');
       $(this).addClass('active');
       browseTo(this.href);


### PR DESCRIPTION
Reload profile when switching to activity tab after clicking on `Advanced search`

Match behavior with all the games button (all, rated, etc.)

screen of the bug
![Screen Shot 2021-06-25 at 13 25 36](https://user-images.githubusercontent.com/56031107/123418064-e2297a80-d5b8-11eb-90e5-e7e9601a9ee4.png)
