### PR TITLE
Hide eval bar after checkmate in puzzles

### DIFF
--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -554,7 +554,7 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
     userMove,
     playUci,
     showEvalGauge() {
-      return vm.showComputer() && ceval.enabled();
+      return vm.showComputer() && ceval.enabled() && !outcome();
     },
     getOrientation() {
       return withGround(g => g.state.orientation)!;


### PR DESCRIPTION
Fixes #7847 making behaviour consistent with the analysis tool