### PR TITLE
Two random small fixes

### DIFF
--- a/ui/common/package.json
+++ b/ui/common/package.json
@@ -17,6 +17,9 @@
     "dev": "yarn run compile",
     "prod": "yarn run compile"
   },
+  "dependencies": {
+    "snabbdom": "^3.0.1"
+  },
   "devDependencies": {
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",

--- a/ui/game/src/interfaces.ts
+++ b/ui/game/src/interfaces.ts
@@ -55,7 +55,7 @@ export type StatusId = number;
 
 export interface Player {
   id: string;
-  name: string;
+  name: string | null;
   user?: PlayerUser;
   spectator?: boolean;
   color: Color;


### PR DESCRIPTION
`ui/common/richText` already uses `snabbdom` so it should be listed as a dependency. Not sure why it even worked without it.