### PR TITLE
add filter of an opponent by lag/ping

### DIFF
--- a/ui/site/src/puzzleEmbed.ts
+++ b/ui/site/src/puzzleEmbed.ts
@@ -4,7 +4,6 @@ window.onload = () => {
   const el = document.querySelector('#daily-puzzle') as HTMLElement,
     board = el.querySelector('.mini-board') as HTMLAnchorElement,
     [fen, orientation, lm] = board.getAttribute('data-state')!.split(',');
-  board.innerHTML = '<div class="cg-wrap">';
 
   Chessground(board.firstChild as HTMLElement, {
     coordinates: false,


### PR DESCRIPTION
hello, lichess. i'm player flaggedyourlaguslow, play virtually only ultra, stream too. as my name insinuates i have issues regarding lag, or more accurately lag comp. i'm almost sure i don't have to fully explain what the deal is as i guess you already know that lag comp's implementation is not really ok and it yields advantage by compensating more than it should be doin. then it even is exploited on purpose too by some, while proving it isn't even that easy, there's no way you can be certain if one's lag is genuine or if he has just no other option (and there's no malice along). there's lots of players with same concerns, we have asked for its fixing numerous times, especially i. apparently while it seems that it stays as is more cause of there's no technical solution found i think it's also so overlooked and not digged much cause you def don't want make anyone feel oppressed as it literally goes against your ideology and philosophy - so i see why even though current comp gives an advantage to bad net player you really prefer this not be other way around. 

every time i genuinely ask for its fixing there are lots of players who just pull apathy card, calling names like you don't care about others, you wanna oppress players who don't have nice net like you, you are selfish, etc, except it's not case, i try to explain it as much as i can and i don't just throw my opinions, yet even when i don't even ask for direct disabling of lag comp but fixing its implementation or making different pools it's still same story.

now i went down to what i gonna ask - while obviously fixing is always better since i think it not gonna be easy i come up with this practical idea - please add filter of lag so that you can select the range you want your opponents lag be - either by number of bars or very number of ping. this way, aside arenas, we will be able to filter so that we get to play and enjoy as much as we can - same way we choose range or rating, control, format, etc, so that it fits our preferences.

while it gonna obviously make the play more fair (which's best point), and that it gonna make the experience more enjoyable where i'm coming from the most is this way i don't have to just abort all the games i randomly get (which gonna not only make it worse for their experience as well it gonna literally ban me), only way you can both avoid playin vs lag and aborting is you shouldn't sit in pool but wait for others' to check their bars number (or recall how he did before vs u), which's not favorable.

furthermore, not only does this address the issue in an unfairness sense it also makes the experience better in a sense that you get to play the style you want - ultra with say 90 lag on both ends is almost completely different game and feel than say 90-180, it feels so different and game strategy drastically differs - in the former you gonna play mostly on time and flag, not much caring about finding mates and etc and vice versa.

please consider this, add filter at least in ultrabullet, i know on surface this may still sound oppresive as it seems like players get classified by their net, but i think everyone gonna find it right as long as you yourself introduce an idea, explaining logic behind it, instead of flaggedyourlaguslow. furthermore, it's not even like it directly correlates to social status of player, even good net can lag in distance. i hope i explained this so that i don't come off arrogant or selfish this time, but genuinely asking this cause it's so excruciatingly painful to lose cause of opponent's bad net, even though you aren't apathetic. 

that's it.