### PR TITLE
Fix nvui analysis commands

### DIFF
--- a/ui/analyse/src/plugins/nvui.ts
+++ b/ui/analyse/src/plugins/nvui.ts
@@ -23,6 +23,7 @@ import {
   positionJumpHandler,
   pieceJumpingHandler,
   Style,
+  lastCapturedCommandHandler,
 } from 'nvui/chess';
 import { renderSetting } from 'nvui/setting';
 import { Notify } from 'nvui/notify';
@@ -137,8 +138,11 @@ lichess.AnalyseNVUI = function (redraw: Redraw) {
                   const $board = $(el.elm as HTMLElement);
                   $board.on('keypress', boardCommandsHandler());
                   const $buttons = $board.find('button');
+                  const steps = () => ctrl.tree.getNodeList(ctrl.path);
+                  const fenSteps = () => steps().map(step => step.fen);
                   $buttons.on('click', selectionHandler(ctrl.data.opponent.color, selectSound));
                   $buttons.on('keydown', arrowKeyHandler(ctrl.data.player.color, borderSound));
+                  $buttons.on('keypress', lastCapturedCommandHandler(fenSteps, pieceStyle.get(), prefixStyle.get()));
                   $buttons.on('keypress', positionJumpHandler());
                   $buttons.on('keypress', pieceJumpingHandler(wrapSound, errorSound));
                 },

--- a/ui/analyse/src/plugins/nvui.ts
+++ b/ui/analyse/src/plugins/nvui.ts
@@ -86,7 +86,7 @@ lichess.AnalyseNVUI = function (redraw: Redraw) {
           h('div.pieces', renderPieces(ctrl.chessground.state.pieces, style)),
           h('h2', 'Current position'),
           h(
-            'p.position',
+            'p.position.lastMove',
             {
               attrs: {
                 'aria-live': 'assertive',

--- a/ui/analyse/src/plugins/nvui.ts
+++ b/ui/analyse/src/plugins/nvui.ts
@@ -153,6 +153,16 @@ lichess.AnalyseNVUI = function (redraw: Redraw) {
               boardStyle.get()
             )
           ),
+          h(
+            'div.boardstatus',
+            {
+              attrs: {
+                'aria-live': 'polite',
+                'aria-atomic': 'true',
+              },
+            },
+            ''
+          ),
           h('div.content', {
             hook: {
               insert: vnode => {


### PR DESCRIPTION
Fixes three things:

- Last move board command doesn't work because the relevant element has className `position` instead of `lastMove`
- Board commands produce no output because `div.boardstatus` does not exist
- "c: announce last move's captured piece." This documentation exists, but c does nothing, since `lastCapturedCommandHandler` isn't used.