### PR TITLE
support safari 10/11 in terser

### DIFF
--- a/bin/gen/timeago-to-scala.py
+++ b/bin/gen/timeago-to-scala.py
@@ -71,7 +71,7 @@ def main(args):
 
 
 def terser(js):
-    p = subprocess.Popen(["yarn", "run", "--silent", "terser", "--mangle", "--compress"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=sys.stderr)
+    p = subprocess.Popen(["yarn", "run", "--silent", "terser", "--mangle", "--compress", "--safari10"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=sys.stderr)
     stdout, stderr = p.communicate(js.encode("utf-8"))
     if p.returncode != 0:
         sys.exit(p.returncode)

--- a/ui/@build/rollupProject/index.js
+++ b/ui/@build/rollupProject/index.js
@@ -17,6 +17,7 @@ module.exports = targets => {
               name: target.name,
               plugins: [
                 terser({
+                  safari10: true,
                   output: {
                     comments: false,
                   },


### PR DESCRIPTION
Hello, now that you removed the dirty hack for chrome in #9197 which caused a display bug on iOS 10 (issue #7525), do you have any reason left not to enable iOS 10 support?

If no, I prepared this PR which should be enough for lichess to be playable on iOS 10.

If you still don't want to enable this support, you should also say that you don't support safari 11, as from what I saw [there](https://terser.org/docs/api-reference.html), the minified JS bug is also present on safari 11.