### PR TITLE
fix ui build on windows

### DIFF
--- a/ui/ceval/package.json
+++ b/ui/ceval/package.json
@@ -15,7 +15,7 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "compile": "../../node_modules/typescript/bin/tsc --incremental",
+    "compile": "tsc --incremental",
     "dev": "yarn run compile",
     "prod": "yarn run compile"
   },

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -9,7 +9,7 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "compile": "../../node_modules/typescript/bin/tsc --incremental --outDir ./dist --declaration --inlineSourceMap",
+    "compile": "tsc --incremental --outDir ./dist --declaration --inlineSourceMap",
     "dev": "yarn run compile && rollup --config",
     "prod": "yarn run compile && rollup --config --config-prod"
   },

--- a/ui/chess/package.json
+++ b/ui/chess/package.json
@@ -13,7 +13,7 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "compile": "../../node_modules/typescript/bin/tsc --incremental",
+    "compile": "tsc --incremental",
     "dev": "yarn run compile",
     "prod": "yarn run compile"
   },

--- a/ui/common/package.json
+++ b/ui/common/package.json
@@ -13,7 +13,7 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "compile": "../../node_modules/typescript/bin/tsc",
+    "compile": "tsc",
     "dev": "yarn run compile",
     "prod": "yarn run compile"
   },

--- a/ui/game/package.json
+++ b/ui/game/package.json
@@ -15,7 +15,7 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "compile": "../../node_modules/typescript/bin/tsc --incremental",
+    "compile": "tsc --incremental",
     "dev": "yarn run compile",
     "prod": "yarn run compile"
   },

--- a/ui/nvui/package.json
+++ b/ui/nvui/package.json
@@ -13,7 +13,7 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "compile": "../../node_modules/typescript/bin/tsc --incremental",
+    "compile": "tsc --incremental",
     "dev": "yarn run compile",
     "prod": "yarn run compile"
   },

--- a/ui/puz/package.json
+++ b/ui/puz/package.json
@@ -9,7 +9,7 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "compile": "../../node_modules/typescript/bin/tsc",
+    "compile": "tsc",
     "dev": "yarn run compile",
     "prod": "yarn run compile"
   },

--- a/ui/tree/package.json
+++ b/ui/tree/package.json
@@ -13,7 +13,7 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "compile": "../../node_modules/typescript/bin/tsc --incremental",
+    "compile": "tsc --incremental",
     "dev": "yarn run compile",
     "prod": "yarn run compile"
   },


### PR DESCRIPTION
As yarn doesn't understand the paths like `../../node_modules/typescript/bin/tsc` on Windows, we have to remove the folder from the path to build on Windows so yarn finds itself `tsc` which is also in the folder `node_modules\.bin`. This should also work on UNIX systems so with this PR we can build the UI in all systems including Windows.