### PR TITLE
Fix coordinate positions in WebKit

### DIFF
--- a/app/ui/scalatags.scala
+++ b/app/ui/scalatags.scala
@@ -57,7 +57,8 @@ trait ScalatagsSnippets extends Cap {
   val timeTag                                = tag("time")
   val dialog                                 = tag("dialog")
   val svgTag                                 = tag("svg")
-  val textTag                                = tag("text")
+  val svgGroupTag                            = tag("g")
+  val svgTextTag                             = tag("text")
 
   def userTitleTag(t: Title) =
     span(

--- a/app/views/coordinate.scala
+++ b/app/views/coordinate.scala
@@ -75,10 +75,10 @@ object coordinate {
         ),
         div(cls := "coord-trainer__board main-board")(
           svgTag(cls := "coords-svg", viewBoxAttr := "0 0 100 100")(
-            textTag(cls := "coord coord--resolved"),
-            textTag(cls := "coord coord--current"),
-            textTag(cls := "coord coord--next"),
-            textTag(cls := "coord coord--new")
+            svgGroupTag(cls := "coord coord--resolved")(svgTextTag),
+            svgGroupTag(cls := "coord coord--current")(svgTextTag),
+            svgGroupTag(cls := "coord coord--next")(svgTextTag),
+            svgGroupTag(cls := "coord coord--new")(svgTextTag)
           ),
           chessgroundBoard
         ),

--- a/ui/site/css/_coordinate.scss
+++ b/ui/site/css/_coordinate.scss
@@ -132,14 +132,20 @@ $mq-col3: $mq-x-large;
 
     .coord {
       @include transition;
-      font-weight: bold;
-      text-shadow: 0 10px 10px #444;
+      text {
+        @include transition;
+        font-weight: bold;
+        text-shadow: 0 10px 10px #444;
+      }
 
       @mixin coord($fill, $opacity, $font-size, $translate-x, $translate-y) {
-        fill: $fill;
-        opacity: $opacity;
-        font-size: $font-size;
         transform: translate($translate-x, $translate-y);
+
+        text {
+          fill: $fill;
+          opacity: $opacity;
+          font-size: $font-size;
+        }
       }
 
       &--resolved {
@@ -190,7 +196,7 @@ $mq-col3: $mq-x-large;
       color: $c-wrong !important;
     }
 
-    .coord--current {
+    .coord--current text {
       fill: $c-wrong !important;
     }
   }


### PR DESCRIPTION
Fixes #9337

There is a known issue with the `translate` CSS function in WebKit. 

A working fix is to wrap a `<text>` element in a `<g>` element and apply transform style there.

[183237 – Nested CSS transforms on SVG elements not updated after page load](https://bugs.webkit.org/show_bug.cgi?id=183237)

[CSS transform on SVG text element not working in Safari - Stack Overflow](https://stackoverflow.com/questions/58230668/css-transform-on-svg-text-element-not-working-in-safari)