### PR TITLE
raise number of games used in insights

### DIFF
--- a/modules/insight/src/main/AggregationPipeline.scala
+++ b/modules/insight/src/main/AggregationPipeline.scala
@@ -20,8 +20,8 @@ final private class AggregationPipeline(store: Storage)(implicit ec: scala.concu
         import InsightEntry.{ BSONFields => F }
         import Storage._
 
-        val sampleGames    = Sample(10_000)
-        val sampleMoves    = Sample(200_000).some
+        val sampleGames    = Sample(50_000)
+        val sampleMoves    = Sample(1_000_000).some
         val unwindMoves    = UnwindField(F.moves).some
         val sortNb         = Sort(Descending("nb")).some
         def limit(nb: Int) = Limit(nb).some


### PR DESCRIPTION
The current limit for chess insights make it hard to work with long term data and study how people improve as if someone plays 10 games every day, chess insights won't even show a full 3 years of data with the current limit of 10k games. 50k games should show significantly more data while still keeping it capped from having to generate data from hundreds of thousands of games (which will probably become millions with the maia bots very shortly).