### PR TITLE
always allow broadcast contributors see chapters tab

### DIFF
--- a/ui/analyse/src/study/studyView.ts
+++ b/ui/analyse/src/study/studyView.ts
@@ -205,7 +205,7 @@ export function side(ctrl: StudyCtrl): VNode {
     );
 
   const chaptersTab =
-    tourShow && ctrl.looksNew()
+    tourShow && ctrl.looksNew() && !ctrl.members.canContribute()
       ? null
       : makeTab('chapters', ctrl.trans.plural(ctrl.relay ? 'nbGames' : 'nbChapters', ctrl.chapters.size()));
 


### PR DESCRIPTION
Accessing chapters tab in an empty round is occasionally useful for broadcasters, like when adding already finished rounds from a downloaded PGN, or in cases like [here](https://lichess.org/broadcast/katara-bullet-2021-finals/round-1/Pu3b4Rqc). It may also be useful under other circumstances I cannot think of right now - on the other hand making it visible for study members seems quite harmless.