### PR TITLE
Fix rematch behavior in correspondence and unlimited games

### DIFF
--- a/ui/round/src/view/button.ts
+++ b/ui/round/src/view/button.ts
@@ -75,7 +75,7 @@ function rematchButtons(ctrl: RoundController): MaybeVNodes {
             } else if (d.opponent.onGame || isAsynchronous) {
               d.player.offeringRematch = true;
               ctrl.socket.send('rematch-yes');
-              if (isAsynchronous) ctrl.challengeRematch();
+              if (!d.opponent.onGame) ctrl.challengeRematch();
             } else if (!(e.currentTarget as HTMLElement).classList.contains('disabled')) ctrl.challengeRematch();
           },
           ctrl.redraw

--- a/ui/round/src/view/button.ts
+++ b/ui/round/src/view/button.ts
@@ -66,14 +66,16 @@ function rematchButtons(ctrl: RoundController): MaybeVNodes {
         hook: util.bind(
           'click',
           e => {
-            const d = ctrl.data;
+            const d = ctrl.data,
+              isAsynchronous = d.game.speed === 'correspondence' || d.game.speed === 'unlimited';
             if (d.game.rematch) location.href = gameRoute(d.game.rematch, d.opponent.color);
             else if (d.player.offeringRematch) {
               d.player.offeringRematch = false;
               ctrl.socket.send('rematch-no');
-            } else if (d.opponent.onGame) {
+            } else if (d.opponent.onGame || isAsynchronous) {
               d.player.offeringRematch = true;
               ctrl.socket.send('rematch-yes');
+              if (isAsynchronous) ctrl.challengeRematch();
             } else if (!(e.currentTarget as HTMLElement).classList.contains('disabled')) ctrl.challengeRematch();
           },
           ctrl.redraw


### PR DESCRIPTION
Fixes #3889. Fixes #9187.

**Current behavior:** When your opponent is away from the game, the rematch button will send a challenge instead of initiating or accepting a rematch request.

For normal games, this is desirable behavior because both players should be online to play. But for correspondence and unlimited games, this feels bad. If your opponent has already challenged you to a rematch, accepting should launch the game right away as they don't need to be around for the game to start.

**New behavior in correspondence and unlimited games:**
- When initiating a rematch:
  - If your opponent is still at the game, no challenge is sent. Instead, a rematch is offered.
  - If they are away, a challenge is sent,\* and in addition, a rematch is offered.
- When accpeting a rematch:
  - Instead of sending a challenge, the rematch is accepted and the game screen appears, even if your opponent is away.

Testing this involved a lot of resigning and apparent boosting/sandbagging. 🙂 (on my local instance, to be clear)

---

\* At first, I worried challenges might stick around if the user accepted the rematch instead of the challenge. But in my observations, once you navigate to the game page, the challenges expire very quickly.