### PR TITLE
add `maxRating` and `minRating` to `api/tournament`

### DIFF
--- a/modules/tournament/src/main/ApiJsonView.scala
+++ b/modules/tournament/src/main/ApiJsonView.scala
@@ -56,7 +56,9 @@ final class ApiJsonView(lightUserApi: LightUserApi)(implicit ec: scala.concurren
         "perf"       -> perfJson(tour.perfType)
       )
       .add("secondsToStart", tour.secondsToStart.some.filter(0 <))
-      .add("hasMaxRating", tour.conditions.maxRating.isDefined)
+      .add("hasMaxRating", tour.conditions.maxRating.isDefined) // BC
+      .add("maxRating", tour.conditions.maxRating)
+      .add("minRating", tour.conditions.minRating)
       .add("private", tour.isPrivate)
       .add("position", tour.position.map(positionJson))
       .add("schedule", tour.schedule map scheduleJson)


### PR DESCRIPTION
`hasMaxRating` is now useless since `maxRating` is only added when there is a limitation. I've left it for now for BC but should it be removed? Edit: since this endpoint is used internally it will need some frontend changes.

PR to update docs incoming