### PR TITLE
When clicking on a specific move in a local analysis pv, skip to that move

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -112,6 +112,7 @@ export default class AnalyseCtrl {
   cgConfig: any; // latest chessground config (useful for revert)
   music?: any;
   nvui?: NvuiPlugin;
+  pvUciQueue: Uci[];
 
   constructor(readonly opts: AnalyseOpts, readonly redraw: Redraw) {
     this.data = opts.data;
@@ -523,7 +524,9 @@ export default class AnalyseCtrl {
     }
     this.jump(newPath);
     this.redraw();
-    this.chessground.playPremove();
+    const queuedUci = this.pvUciQueue.shift();
+    if (queuedUci) this.playUci(queuedUci, this.pvUciQueue);
+    else this.chessground.playPremove();
   }
 
   addDests(dests: string, path: Tree.Path): void {
@@ -799,7 +802,8 @@ export default class AnalyseCtrl {
     this.redraw();
   }
 
-  playUci(uci: Uci): void {
+  playUci(uci: Uci, uciQueue?: Uci[]): void {
+    this.pvUciQueue = uciQueue ?? [];
     const move = parseUci(uci)!;
     const to = makeSquare(move.to);
     if (isNormal(move)) {
@@ -819,6 +823,12 @@ export default class AnalyseCtrl {
         },
         to
       );
+  }
+
+  playUciList(uciList: Uci[]): void {
+    this.pvUciQueue = uciList;
+    const firstUci = this.pvUciQueue.shift();
+    if (firstUci) this.playUci(firstUci, this.pvUciQueue);
   }
 
   explorerMove(uci: Uci) {

--- a/ui/ceval/src/types.ts
+++ b/ui/ceval/src/types.ts
@@ -100,6 +100,7 @@ export interface ParentCtrl {
   currentEvals(): NodeEvals;
   ongoing: boolean;
   playUci(uci: string): void;
+  playUciList(uciList: string[]): void;
   getOrientation(): Color;
   threatMode(): boolean;
   getNode(): Tree.Node;

--- a/ui/ceval/src/view.ts
+++ b/ui/ceval/src/view.ts
@@ -1,5 +1,5 @@
 import * as winningChances from './winningChances';
-import { defined } from 'common';
+import { defined, notNull } from 'common';
 import { Eval, CevalCtrl, ParentCtrl, NodeEvals } from './types';
 import { h, VNode } from 'snabbdom';
 import { Position } from 'chessops/chess';
@@ -262,7 +262,13 @@ function getElUci(e: TouchEvent | MouseEvent): string | undefined {
   );
 }
 
-function getElPvMoves(e: MouseEvent): (string | null)[] {
+function getElUciList(e: TouchEvent | MouseEvent): string[] {
+  return getElPvMoves(e)
+    .filter(notNull)
+    .map(move => move.split('|')[1]);
+}
+
+function getElPvMoves(e: TouchEvent | MouseEvent): (string | null)[] {
   const pvMoves: (string | null)[] = [];
 
   $(e.target as HTMLElement)
@@ -338,9 +344,9 @@ export function renderPvs(ctrl: ParentCtrl): VNode | undefined {
           el.addEventListener('mouseout', () => ctrl.getCeval().setHovering(getElFen(el)));
           for (const event of ['touchstart', 'mousedown']) {
             el.addEventListener(event, (e: TouchEvent | MouseEvent) => {
-              const uci = getElUci(e);
-              if (uci) {
-                ctrl.playUci(uci);
+              const uciList = getElUciList(e);
+              if (uciList.length > (pvIndex ?? 0)) {
+                ctrl.playUciList(uciList.slice(0, (pvIndex ?? 0) + 1));
                 e.preventDefault();
               }
             });

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -174,6 +174,10 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
     sendMove(parseUci(uci)!);
   }
 
+  function playUciList(uciList: Uci[]): void {
+    uciList.forEach(playUci);
+  }
+
   function playUserMove(orig: Key, dest: Key, promotion?: Role): void {
     sendMove({
       from: parseSquare(orig)!,
@@ -553,6 +557,7 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
     nextNodeBest,
     userMove,
     playUci,
+    playUciList,
     showEvalGauge() {
       return vm.showComputer() && ceval.enabled() && !outcome();
     },

--- a/ui/puzzle/src/interfaces.ts
+++ b/ui/puzzle/src/interfaces.ts
@@ -46,6 +46,7 @@ export interface Controller extends KeyboardController {
   currentEvals(): NodeEvals;
   ongoing: boolean;
   playUci(uci: string): void;
+  playUciList(uciList: string[]): void;
   getOrientation(): Color;
   threatMode: Prop<boolean>;
   getNode(): Tree.Node;


### PR DESCRIPTION
Closes #5493. A duplicate issue is linked there, but for completeness, this feature has also been mentioned in #4164 which isn't otherwise linked.

My initial attempt at implementing this was to just call `playUci` in a loop. This works great for puzzles but fails in analysis because the moves sent to the server get interpreted as variations of the same ply instead of sequential moves. To solve this, I stored the moves to be played in a queue and sent the next move after every "node" response from the server.

From a user's perspective, hovering over local analysis lines works the same as before. But now, when they click on the line, instead of playing the first move and discarding the rest of the line, the moves up to and including the move that they clicked will all be played.

Since the implementation uses the existing `pvIndex` variable, the resulting main board will always match the hover board exactly. I think this does a good job of keeping the promise we make to the user when we show them a clickable, highlightable move with a live preview. It should be very intuitive and discoverable.

Shoutout to dboing and https://lichess.org/forum/lichess-feedback/full-pv-dumpdisplay-for-any-engine-analysis. After failing to implement this last week, that gave me renewed motivation to come up with a solution.