### PR TITLE
Add opening explorer & tablebase to blind mode

### DIFF
--- a/ui/analyse/css/_explorer.scss
+++ b/ui/analyse/css/_explorer.scss
@@ -293,7 +293,7 @@
     .choices {
       display: flex;
 
-      span {
+      button {
         flex-grow: 1;
         padding: 5px 0;
         text-align: center;
@@ -301,6 +301,7 @@
 
         @include transition;
 
+        background: none;
         border: $border;
         border-width: 1px 0 1px 1px;
         text-transform: capitalize;
@@ -319,7 +320,7 @@
           background: #fff;
         }
 
-        &.selected {
+        &[aria-pressed='true'] {
           background: $c-secondary;
           color: $c-secondary-over;
           text-shadow: 1px 0 0 rgba(0, 0, 0, 0.5);

--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -76,9 +76,11 @@ export function view(ctrl: ExplorerConfigCtrl): VNode[] {
         'div.choices',
         d.db.available.map(function (s) {
           return h(
-            'span',
+            'button',
             {
-              class: { selected: d.db.selected() === s },
+              attrs: {
+                'aria-pressed': `${d.db.selected() === s}`,
+              },
               hook: bind('click', _ => ctrl.toggleDb(s), ctrl.redraw),
             },
             s
@@ -98,9 +100,11 @@ export function view(ctrl: ExplorerConfigCtrl): VNode[] {
               'div.choices',
               d.rating.available.map(function (r) {
                 return h(
-                  'span',
+                  'button',
                   {
-                    class: { selected: d.rating.selected().includes(r) },
+                    attrs: {
+                      'aria-pressed': `${d.rating.selected().includes(r)}`,
+                    },
                     hook: bind('click', _ => ctrl.toggleRating(r), ctrl.redraw),
                   },
                   r.toString()
@@ -114,9 +118,11 @@ export function view(ctrl: ExplorerConfigCtrl): VNode[] {
               'div.choices',
               d.speed.available.map(function (s) {
                 return h(
-                  'span',
+                  'button',
                   {
-                    class: { selected: d.speed.selected().includes(s) },
+                    attrs: {
+                      'aria-pressed': `${d.speed.selected().includes(s)}`,
+                    },
                     hook: bind('click', _ => ctrl.toggleSpeed(s), ctrl.redraw),
                   },
                   s

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -466,8 +466,11 @@ export default function (ctrl: AnalyseCtrl): VNode | undefined {
       content,
       !content || explorer.failing()
         ? null
-        : h('span.toconf', {
-            attrs: dataIcon(configOpened ? '' : ''),
+        : h('button.fbt.toconf', {
+            attrs: {
+              'aria-label': configOpened ? 'Close configuration' : 'Open configuration',
+              ...dataIcon(configOpened ? '' : ''),
+            },
             hook: bind('click', () => ctrl.explorer.config.toggleOpen(), ctrl.redraw),
           }),
     ]

--- a/ui/analyse/src/plugins/nvui.ts
+++ b/ui/analyse/src/plugins/nvui.ts
@@ -35,6 +35,7 @@ import * as moveView from '../moveView';
 import { bind } from '../util';
 import throttle from 'common/throttle';
 import { Role } from 'chessground/types';
+import explorerView from '../explorer/explorerView';
 
 export const throttled = (sound: string) => throttle(100, () => lichess.sound.play(sound));
 
@@ -87,6 +88,21 @@ lichess.AnalyseNVUI = function (redraw: Redraw) {
             },
             renderMainline(ctrl.mainline, ctrl.path, style)
           ),
+          ...(!ctrl.studyPractice
+            ? [
+                h(
+                  'button',
+                  {
+                    attrs: {
+                      'aria-pressed': `${ctrl.explorer.enabled()}`,
+                    },
+                    hook: bind('click', _ => ctrl.explorer.toggle(), redraw),
+                  },
+                  ctrl.trans.noarg('openingExplorerAndTablebase')
+                ),
+                explorerView(ctrl),
+              ]
+            : []),
           h('h2', 'Pieces'),
           h('div.pieces', renderPieces(ctrl.chessground.state.pieces, style)),
           h('h2', 'Current position'),


### PR DESCRIPTION
Years ago, the opening explorer existed in blind mode (#4882). I'm assuming it got removed when the original sidebar got removed. Would it be a welcome (re)addition?

The config span couldn't be detected by screen readers, so I made it a real button along with the other clickable spans.

Caveats:
- Clicking on table rows isn't very discoverable. There are multiple solutions (add hidden buttons, tabindex, keyboard shortcuts, shortcuts + `role="grid"`, or just document clicking behavior), but they all add code, and it isn't clear which is best, so I left the explorer as-is.
- The opening explorer isn't affected by move notation settings because it reuses the existing explorer implementation.