### PR TITLE
Ignore msg security for Challenge API messages

### DIFF
--- a/modules/challenge/src/main/ChallengeMsg.scala
+++ b/modules/challenge/src/main/ChallengeMsg.scala
@@ -28,7 +28,7 @@ final class ChallengeMsg(msgApi: lila.msg.MsgApi, lightUserApi: LightUserApi)(im
           .replace("{player}", s"@${u1.name}")
           .replace("{opponent}", s"@${u2.name}")
           .replace("{game}", s"#${gameId}")
-        msgApi.post(managedById, u1.id, msg, multi = true)
+        msgApi.post(managedById, u1.id, msg, multi = true, ignoreSecurity = true)
       }
       .sequenceFu
       .void


### PR DESCRIPTION
It also skips the empty message check but at least for the API messages, that's checked before anyway.

And besides the bulk API it also applies to challenge accepts via the API but that seems equally unproblematic.