### PR TITLE
Expose swiss ID in game API

### DIFF
--- a/modules/api/src/main/GameApiV2.scala
+++ b/modules/api/src/main/GameApiV2.scala
@@ -310,6 +310,7 @@ final class GameApiV2(
       .add("daysPerTurn" -> g.daysPerTurn)
       .add("analysis" -> analysisOption.ifTrue(withFlags.evals).map(analysisJson.moves(_, withGlyph = false)))
       .add("tournament" -> g.tournamentId)
+      .add("swiss" -> g.swissId)
       .add("clock" -> g.clock.map { clock =>
         Json.obj(
           "initial"   -> clock.limitSeconds,


### PR DESCRIPTION
See https://github.com/ornicar/lila/pull/5466
Swiss tournaments were added since the pull request above, and they would also be convenient in game JSON for determining performance in Atomic World Championship.