### PR TITLE
Add zen mode to puzzle racer

### DIFF
--- a/app/views/racer.scala
+++ b/app/views/racer.scala
@@ -50,6 +50,7 @@ object racer {
       ),
       title = "Puzzle Racer",
       zoomable = true,
+      playing = true,
       chessground = false
     ) {
       main(

--- a/ui/racer/css/_race.scss
+++ b/ui/racer/css/_race.scss
@@ -81,6 +81,7 @@ $c-bg-position-y: 2px;
 
   &__player {
     @extend %flex-center-nowrap;
+    @extend %zen;
 
     height: 100%;
     transition: transform 4s;

--- a/ui/racer/css/_racer.scss
+++ b/ui/racer/css/_racer.scss
@@ -1,6 +1,7 @@
 @import 'car-font';
 @import 'race';
 @import 'countdown';
+@import 'zen';
 
 .racer {
   &__race {

--- a/ui/racer/css/_zen.scss
+++ b/ui/racer/css/_zen.scss
@@ -1,0 +1,12 @@
+%zen {
+  body.playing.zen & {
+    display: none;
+  }
+}
+
+#friend_box,
+.puz-side__table,
+.site-title-nav,
+.site-buttons {
+  @extend %zen;
+}

--- a/ui/racer/css/build/_racer.scss
+++ b/ui/racer/css/build/_racer.scss
@@ -1,6 +1,8 @@
 @import '../../../common/css/plugin';
 @import '../../../common/css/layout/uniboard';
 @import '../../../common/css/component/board-resize';
+@import '../../../common/css/component/zen-toggle';
+@import '../../../common/css/component/fbt';
 @import '../../../common/css/vendor/chessground/_coords';
 @import '../../../chess/css/promotion';
 @import '../../../puz/css/puz';


### PR DESCRIPTION
There are [some people requesting for this](https://lichess.org/forum/lichess-feedback/feature-request-zen-mode-in-puzzle-racer) but I'm not sure if it is necessary. I thought I'd make a PR anyway to let you decide.

Hiding all elements on racer kinda defeats the purpose of a race. So I've only hidden the cars and the combo/controls area.
The tracks being visible is probably not very elegant but I've left it visible so users can see other people's scores.
![zen racer](https://i.ibb.co/H4qb2DP/zenracer.png)