### PR TITLE
Add material diff to analysis and study pages

### DIFF
--- a/ui/analyse/css/_player-clock.scss
+++ b/ui/analyse/css/_player-clock.scss
@@ -1,26 +1,42 @@
+@import '../../common/css/component/material';
+
 $clock-height: 20px;
+
+.analyse__player_strip {
+  position: absolute;
+  right: 0;
+  display: flex;
+
+  &.top {
+    top: #{-$clock-height};
+  }
+
+  &.bottom {
+    top: var(--cg-height, 100%);
+    z-index: 1; // over the board coords
+  }
+
+  /* Where to put them in col1 layout? It moves the entire board and controls down for little benefit */
+  @include breakpoint($mq-col1) {
+    display: none;
+  }
+}
 
 .analyse__clock {
   @extend %metal, %box-shadow;
 
-  position: absolute;
-  right: 0;
   padding: 0 0.5em;
+  margin-left: 12px;
   height: $clock-height;
   font-weight: bold;
   text-align: center;
 
   &.top {
     @extend %box-radius-top;
-
-    top: #{-$clock-height};
   }
 
   &.bottom {
     @extend %box-radius-bottom;
-
-    top: var(--cg-height, 100%);
-    z-index: 1; // over the board coords
   }
 
   &.active {
@@ -30,9 +46,28 @@ $clock-height: 20px;
   tenths {
     font-size: 80%;
   }
+}
 
-  /* Where to put them in col1 layout? It moves the entire board and controls down for little benefit */
-  @include breakpoint($mq-col1) {
-    display: none;
+.material {
+  padding-right: 1px;
+
+  mpiece {
+    width: 21px;
+    height: 21px;
+
+    &.pawn {
+      margin-left: -10px;
+    }
   }
+  score {
+    margin-top: -2px;
+  }
+}
+
+.material-top {
+  margin-top: -1px;
+}
+
+.material-bottom {
+  margin-top: 1px;
 }

--- a/ui/analyse/css/study/_player.scss
+++ b/ui/analyse/css/study/_player.scss
@@ -1,3 +1,5 @@
+@import '../../../common/css/component/material';
+
 $player-height: 1.6rem;
 
 .analyse.has-players {
@@ -58,7 +60,7 @@ $player-height: 1.6rem;
 
     align-self: stretch;
     font-size: 1.2em;
-    padding: 0 0.8em;
+    padding: 0 0.8em 0 0.4em;
     border-radius: 0 4px 0 0;
   }
 
@@ -94,4 +96,29 @@ $player-height: 1.6rem;
     margin-left: 0.5em;
     font-weight: normal;
   }
+}
+
+.material {
+  padding: 0 6px;
+
+  mpiece {
+    width: 21px;
+    height: 21px;
+
+    &.pawn {
+      margin-left: -10px;
+    }
+  }
+
+  score {
+    color: #777;
+  }
+}
+
+.material-top {
+  margin-top: 0.2em;
+}
+
+.material-bottom {
+  margin-top: 0.15em;
 }

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -35,6 +35,7 @@ import { opposite, parseUci, makeSquare, roleToChar } from 'chessops/util';
 import { COLORS, Outcome, isNormal } from 'chessops/types';
 import { SquareSet } from 'chessops/squareSet';
 import { parseFen } from 'chessops/fen';
+import { read as fenRead } from 'chessground/fen';
 import { Position, PositionError } from 'chessops/chess';
 import { Result } from '@badrap/result';
 import { setupPosition } from 'chessops/variant';
@@ -43,6 +44,7 @@ import { AnaMove, StudyCtrl } from './study/interfaces';
 import { StudyPracticeCtrl } from './study/practice/interfaces';
 import { valid as crazyValid } from './crazy/crazyCtrl';
 import { PromotionCtrl } from 'chess/promotion';
+import { renderMaterialDiffs } from 'game/view/material';
 
 export default class AnalyseCtrl {
   data: AnalyseData;
@@ -919,4 +921,19 @@ export default class AnalyseCtrl {
     if (this.chessground && this.cgVersion.js === this.cgVersion.dom) return f(this.chessground);
     return undefined;
   };
+
+  renderMaterialDiffs() {
+    const cgState = this.chessground && this.chessground.state,
+      pieces = cgState ? cgState.pieces : fenRead(this.node.fen);
+
+    return renderMaterialDiffs(
+      true, // showCaptured
+      this.flipped,
+      this.data.player,
+      this.data.opponent,
+      pieces,
+      this.nodeList,
+      this.node.ply
+    );
+  }
 }

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -35,7 +35,6 @@ import { opposite, parseUci, makeSquare, roleToChar } from 'chessops/util';
 import { COLORS, Outcome, isNormal } from 'chessops/types';
 import { SquareSet } from 'chessops/squareSet';
 import { parseFen } from 'chessops/fen';
-import { read as fenRead } from 'chessground/fen';
 import { Position, PositionError } from 'chessops/chess';
 import { Result } from '@badrap/result';
 import { setupPosition } from 'chessops/variant';
@@ -44,7 +43,6 @@ import { AnaMove, StudyCtrl } from './study/interfaces';
 import { StudyPracticeCtrl } from './study/practice/interfaces';
 import { valid as crazyValid } from './crazy/crazyCtrl';
 import { PromotionCtrl } from 'chess/promotion';
-import { renderMaterialDiffs } from 'game/view/material';
 
 export default class AnalyseCtrl {
   data: AnalyseData;
@@ -921,19 +919,4 @@ export default class AnalyseCtrl {
     if (this.chessground && this.cgVersion.js === this.cgVersion.dom) return f(this.chessground);
     return undefined;
   };
-
-  renderMaterialDiffs() {
-    const cgState = this.chessground && this.chessground.state,
-      pieces = cgState ? cgState.pieces : fenRead(this.node.fen);
-
-    return renderMaterialDiffs(
-      true, // showCaptured
-      this.flipped,
-      this.data.player,
-      this.data.opponent,
-      pieces,
-      this.nodeList,
-      this.node.ply
-    );
-  }
 }

--- a/ui/analyse/src/study/playerBars.ts
+++ b/ui/analyse/src/study/playerBars.ts
@@ -1,9 +1,9 @@
 import { h, VNode } from 'snabbdom';
-import { ops as treeOps } from 'tree';
-import { TagArray } from './interfaces';
 import renderClocks from '../clocks';
 import AnalyseCtrl from '../ctrl';
-import { isFinished, findTag, resultOf } from './studyChapters';
+import { renderMaterialDiffs } from '../view';
+import { TagArray } from './interfaces';
+import { findTag, isFinished, resultOf } from './studyChapters';
 
 interface PlayerNames {
   white: string;
@@ -21,7 +21,7 @@ export default function (ctrl: AnalyseCtrl): VNode[] | undefined {
 
   const clocks = renderClocks(ctrl),
     ticking = !isFinished(study.data.chapter) && ctrl.turnColor(),
-    materialDiffs = ctrl.renderMaterialDiffs();
+    materialDiffs = renderMaterialDiffs(ctrl);
 
   return (['white', 'black'] as Color[]).map(color =>
     renderPlayer(tags, clocks, materialDiffs, playerNames, color, ticking === color, ctrl.bottomColor() !== color)
@@ -31,7 +31,7 @@ export default function (ctrl: AnalyseCtrl): VNode[] | undefined {
 function renderPlayer(
   tags: TagArray[],
   clocks: [VNode, VNode] | undefined,
-  materialDiffs: [VNode, VNode] | undefined,
+  materialDiffs: [VNode, VNode],
   playerNames: PlayerNames,
   color: Color,
   ticking: boolean,
@@ -54,8 +54,8 @@ function renderPlayer(
           elo && h('span.elo', elo),
         ]),
       ]),
-      materialDiffs && materialDiffs[top ? 0 : 1],
-      clocks && clocks[color === 'white' ? 0 : 1],
+      materialDiffs[top ? 0 : 1],
+      clocks?.[color === 'white' ? 0 : 1],
     ]
   );
 }

--- a/ui/analyse/src/study/playerBars.ts
+++ b/ui/analyse/src/study/playerBars.ts
@@ -18,17 +18,20 @@ export default function (ctrl: AnalyseCtrl): VNode[] | undefined {
       white: findTag(tags, 'white')!,
       black: findTag(tags, 'black')!,
     };
-  if (!playerNames.white && !playerNames.black && !treeOps.findInMainline(ctrl.tree.root, n => !!n.clock)) return;
+
   const clocks = renderClocks(ctrl),
-    ticking = !isFinished(study.data.chapter) && ctrl.turnColor();
+    ticking = !isFinished(study.data.chapter) && ctrl.turnColor(),
+    materialDiffs = ctrl.renderMaterialDiffs();
+
   return (['white', 'black'] as Color[]).map(color =>
-    renderPlayer(tags, clocks, playerNames, color, ticking === color, ctrl.bottomColor() !== color)
+    renderPlayer(tags, clocks, materialDiffs, playerNames, color, ticking === color, ctrl.bottomColor() !== color)
   );
 }
 
 function renderPlayer(
   tags: TagArray[],
   clocks: [VNode, VNode] | undefined,
+  materialDiffs: [VNode, VNode] | undefined,
   playerNames: PlayerNames,
   color: Color,
   ticking: boolean,
@@ -51,6 +54,7 @@ function renderPlayer(
           elo && h('span.elo', elo),
         ]),
       ]),
+      materialDiffs && materialDiffs[top ? 0 : 1],
       clocks && clocks[color === 'white' ? 0 : 1],
     ]
   );

--- a/ui/analyse/src/view.ts
+++ b/ui/analyse/src/view.ts
@@ -312,6 +312,23 @@ function analysisDisabled(ctrl: AnalyseCtrl): VNode {
   ]);
 }
 
+function renderPlayerStrip(cls: string, materialDiff: VNode, clock?: VNode): VNode {
+  return h('div.analyse__player_strip.' + cls, {}, [materialDiff, clock]);
+}
+
+function renderPlayerStrips(ctrl: AnalyseCtrl): [VNode, VNode] | undefined {
+  if (ctrl.embed) return;
+
+  const clocks = renderClocks(ctrl),
+    whitePov = ctrl.bottomIsWhite(),
+    materialDiffs = ctrl.renderMaterialDiffs();
+
+  return [
+    renderPlayerStrip('top', materialDiffs[0], clocks?.[whitePov ? 1 : 0]),
+    renderPlayerStrip('bottom', materialDiffs[1], clocks?.[whitePov ? 0 : 1]),
+  ];
+}
+
 export default function (ctrl: AnalyseCtrl): VNode {
   if (ctrl.nvui) return ctrl.nvui.render(ctrl);
   const concealOf = makeConcealOf(ctrl),
@@ -322,10 +339,11 @@ export default function (ctrl: AnalyseCtrl): VNode {
     gamebookPlayView = gamebookPlay && gbPlay.render(gamebookPlay),
     gamebookEditView = gbEdit.running(ctrl) ? gbEdit.render(ctrl) : undefined,
     playerBars = renderPlayerBars(ctrl),
-    clocks = !playerBars && renderClocks(ctrl),
+    playerStrips = !playerBars && renderPlayerStrips(ctrl),
     gaugeOn = ctrl.showEvalGauge(),
     needsInnerCoords = !!gaugeOn || !!playerBars,
     tour = relayTour(ctrl);
+
   return h(
     'main.analyse.variant-' + ctrl.data.game.variant.key,
     {
@@ -352,7 +370,6 @@ export default function (ctrl: AnalyseCtrl): VNode {
         'comp-off': !ctrl.showComputer(),
         'gauge-on': gaugeOn,
         'has-players': !!playerBars,
-        'has-clocks': !!clocks,
         'has-relay-tour': !!tour,
         'analyse-hunter': ctrl.opts.hunter,
       },
@@ -370,7 +387,7 @@ export default function (ctrl: AnalyseCtrl): VNode {
                 : bindNonPassive('wheel', (e: WheelEvent) => wheel(ctrl, e)),
           },
           [
-            ...(clocks || []),
+            ...(playerStrips || []),
             playerBars ? playerBars[ctrl.bottomIsWhite() ? 1 : 0] : null,
             chessground.render(ctrl),
             playerBars ? playerBars[ctrl.bottomIsWhite() ? 0 : 1] : null,

--- a/ui/analyse/src/view.ts
+++ b/ui/analyse/src/view.ts
@@ -1,10 +1,12 @@
 import { view as cevalView } from 'ceval';
+import { read as readFen } from 'chessground/fen';
 import { parseFen } from 'chessops/fen';
 import { defined } from 'common';
 import changeColorHandle from 'common/coordsColor';
 import { bind, bindNonPassive, MaybeVNodes, onInsert } from 'common/snabbdom';
 import { getPlayer, playable } from 'game';
 import * as router from 'game/router';
+import * as materialView from 'game/view/material';
 import statusView from 'game/view/status';
 import { h, VNode } from 'snabbdom';
 import { path as treePath } from 'tree';
@@ -312,8 +314,23 @@ function analysisDisabled(ctrl: AnalyseCtrl): VNode {
   ]);
 }
 
+export function renderMaterialDiffs(ctrl: AnalyseCtrl): [VNode, VNode] {
+  const cgState = ctrl.chessground?.state,
+    pieces = cgState ? cgState.pieces : readFen(ctrl.node.fen);
+
+  return materialView.renderMaterialDiffs(
+    true, // showCaptured
+    ctrl.flipped,
+    ctrl.data.player,
+    ctrl.data.opponent,
+    pieces,
+    ctrl.nodeList,
+    ctrl.node.ply
+  );
+}
+
 function renderPlayerStrip(cls: string, materialDiff: VNode, clock?: VNode): VNode {
-  return h('div.analyse__player_strip.' + cls, {}, [materialDiff, clock]);
+  return h('div.analyse__player_strip.' + cls, [materialDiff, clock]);
 }
 
 function renderPlayerStrips(ctrl: AnalyseCtrl): [VNode, VNode] | undefined {
@@ -321,7 +338,7 @@ function renderPlayerStrips(ctrl: AnalyseCtrl): [VNode, VNode] | undefined {
 
   const clocks = renderClocks(ctrl),
     whitePov = ctrl.bottomIsWhite(),
-    materialDiffs = ctrl.renderMaterialDiffs();
+    materialDiffs = renderMaterialDiffs(ctrl);
 
   return [
     renderPlayerStrip('top', materialDiffs[0], clocks?.[whitePov ? 1 : 0]),

--- a/ui/common/css/component/_material.scss
+++ b/ui/common/css/component/_material.scss
@@ -1,0 +1,46 @@
+.material {
+  @extend %flex-center-nowrap;
+
+  div {
+    display: inline-block;
+    margin-left: 10px;
+  }
+
+  mpiece {
+    margin-left: -10px;
+    background-size: cover;
+    display: inline-block;
+
+    &.pawn {
+      background-image: url(../piece/mono/P.svg);
+    }
+
+    &.bishop {
+      background-image: url(../piece/mono/B.svg);
+    }
+
+    &.knight {
+      background-image: url(../piece/mono/N.svg);
+    }
+
+    &.rook {
+      background-image: url(../piece/mono/R.svg);
+    }
+
+    &.queen {
+      background-image: url(../piece/mono/Q.svg);
+    }
+
+    &.king {
+      background-image: url(../piece/mono/K.svg);
+    }
+
+    @if $theme == 'transp' {
+      filter: brightness(1.3) drop-shadow(0 1px 1px #000);
+    }
+  }
+
+  score {
+    font-family: 'Roboto';
+  }
+}

--- a/ui/game/src/interfaces.ts
+++ b/ui/game/src/interfaces.ts
@@ -176,3 +176,22 @@ export type ContinueMode = 'friend' | 'ai';
 export interface GameView {
   status(ctrl: Ctrl): string;
 }
+
+export interface CheckState {
+  ply: Ply;
+  check?: unknown;
+}
+
+export interface CheckCount {
+  white: number;
+  black: number;
+}
+
+export interface MaterialDiffSide {
+  [role: string]: number;
+}
+
+export interface MaterialDiff {
+  white: MaterialDiffSide;
+  black: MaterialDiffSide;
+}

--- a/ui/game/src/interfaces.ts
+++ b/ui/game/src/interfaces.ts
@@ -1,3 +1,5 @@
+import * as cg from 'chessground/types';
+
 export interface GameData {
   game: Game;
   player: Player;
@@ -179,7 +181,7 @@ export interface GameView {
 
 export interface CheckState {
   ply: Ply;
-  check?: unknown;
+  check?: boolean | Key;
 }
 
 export interface CheckCount {
@@ -187,9 +189,9 @@ export interface CheckCount {
   black: number;
 }
 
-export interface MaterialDiffSide {
-  [role: string]: number;
-}
+export type MaterialDiffSide = {
+  [role in cg.Role]: number;
+};
 
 export interface MaterialDiff {
   white: MaterialDiffSide;

--- a/ui/game/src/material.ts
+++ b/ui/game/src/material.ts
@@ -1,0 +1,51 @@
+import * as cg from 'chessground/types';
+import { opposite } from 'chessground/util';
+import { CheckCount, CheckState, MaterialDiff } from './interfaces';
+
+const pieceScores = {
+  pawn: 1,
+  knight: 3,
+  bishop: 3,
+  rook: 5,
+  queen: 9,
+  king: 0,
+};
+
+// {white: {pawn: 3 queen: 1}, black: {bishop: 2}}
+export function getMaterialDiff(pieces: cg.Pieces): MaterialDiff {
+  const diff: MaterialDiff = {
+    white: { king: 0, queen: 0, rook: 0, bishop: 0, knight: 0, pawn: 0 },
+    black: { king: 0, queen: 0, rook: 0, bishop: 0, knight: 0, pawn: 0 },
+  };
+  for (const p of pieces.values()) {
+    const them = diff[opposite(p.color)];
+    if (them[p.role] > 0) them[p.role]--;
+    else diff[p.color][p.role]++;
+  }
+  return diff;
+}
+
+export function getScore(pieces: cg.Pieces): number {
+  let score = 0;
+  for (const p of pieces.values()) {
+    score += pieceScores[p.role] * (p.color === 'white' ? 1 : -1);
+  }
+  return score;
+}
+
+export const noChecks: CheckCount = {
+  white: 0,
+  black: 0,
+};
+
+export function countChecks(steps: CheckState[], ply: Ply): CheckCount {
+  const checks: CheckCount = { ...noChecks };
+  for (const step of steps) {
+    if (ply < step.ply) break;
+    if (step.check) {
+      if (step.ply % 2 === 1) checks.white++;
+      else checks.black++;
+    }
+  }
+  return checks;
+}

--- a/ui/game/src/material.ts
+++ b/ui/game/src/material.ts
@@ -2,7 +2,7 @@ import * as cg from 'chessground/types';
 import { opposite } from 'chessground/util';
 import { CheckCount, CheckState, MaterialDiff } from './interfaces';
 
-const pieceScores = {
+const PIECE_SCORES = {
   pawn: 1,
   knight: 3,
   bishop: 3,
@@ -11,7 +11,6 @@ const pieceScores = {
   king: 0,
 };
 
-// {white: {pawn: 3 queen: 1}, black: {bishop: 2}}
 export function getMaterialDiff(pieces: cg.Pieces): MaterialDiff {
   const diff: MaterialDiff = {
     white: { king: 0, queen: 0, rook: 0, bishop: 0, knight: 0, pawn: 0 },
@@ -28,18 +27,18 @@ export function getMaterialDiff(pieces: cg.Pieces): MaterialDiff {
 export function getScore(pieces: cg.Pieces): number {
   let score = 0;
   for (const p of pieces.values()) {
-    score += pieceScores[p.role] * (p.color === 'white' ? 1 : -1);
+    score += PIECE_SCORES[p.role] * (p.color === 'white' ? 1 : -1);
   }
   return score;
 }
 
-export const noChecks: CheckCount = {
+export const NO_CHECKS: CheckCount = {
   white: 0,
   black: 0,
 };
 
 export function countChecks(steps: CheckState[], ply: Ply): CheckCount {
-  const checks: CheckCount = { ...noChecks };
+  const checks: CheckCount = { ...NO_CHECKS };
   for (const step of steps) {
     if (ply < step.ply) break;
     if (step.check) {

--- a/ui/game/src/view/material.ts
+++ b/ui/game/src/view/material.ts
@@ -1,0 +1,51 @@
+import { getMaterialDiff, getScore, countChecks, noChecks } from '../material';
+import { h, VNode } from 'snabbdom';
+import { MaterialDiff, MaterialDiffSide, CheckCount, CheckState, Player } from '../interfaces';
+import { Pieces } from 'chessground/types';
+
+function renderMaterialDiff(material: MaterialDiffSide, score: number, position: 'top' | 'bottom', checks?: number) {
+  const children: VNode[] = [];
+  let role: string, i: number;
+  for (role in material) {
+    if (material[role] > 0) {
+      const content: VNode[] = [];
+      for (i = 0; i < material[role]; i++) content.push(h('mpiece.' + role));
+      children.push(h('div', content));
+    }
+  }
+  if (checks) for (i = 0; i < checks; i++) children.push(h('div', h('mpiece.king')));
+  if (score > 0) children.push(h('score', '+' + score));
+  return h('div.material.material-' + position, children);
+}
+
+const emptyMaterialDiff: MaterialDiff = {
+  white: {},
+  black: {},
+};
+
+export function renderMaterialDiffs(
+  showCaptured: boolean,
+  flip: boolean,
+  player: Player,
+  opponent: Player,
+  pieces: Pieces,
+  checkStates: CheckState[],
+  ply: Ply
+): [VNode, VNode] {
+  const topColor = (flip ? player : opponent).color;
+  const bottomColor = (flip ? opponent : player).color;
+
+  let material: MaterialDiff,
+    score = 0;
+  if (showCaptured) {
+    material = getMaterialDiff(pieces);
+    score = getScore(pieces) * (bottomColor === 'white' ? 1 : -1);
+  } else material = emptyMaterialDiff;
+
+  const checks: CheckCount = player.checks || opponent.checks ? countChecks(checkStates, ply) : noChecks;
+
+  return [
+    renderMaterialDiff(material[topColor], -score, 'top', checks[topColor]),
+    renderMaterialDiff(material[bottomColor], score, 'bottom', checks[bottomColor]),
+  ];
+}

--- a/ui/game/src/view/material.ts
+++ b/ui/game/src/view/material.ts
@@ -1,26 +1,31 @@
-import { getMaterialDiff, getScore, countChecks, noChecks } from '../material';
+import * as cg from 'chessground/types';
 import { h, VNode } from 'snabbdom';
-import { MaterialDiff, MaterialDiffSide, CheckCount, CheckState, Player } from '../interfaces';
-import { Pieces } from 'chessground/types';
+import { CheckCount, CheckState, MaterialDiff, MaterialDiffSide, Player } from '../interfaces';
+import { countChecks, getMaterialDiff, getScore, NO_CHECKS } from '../material';
 
-function renderMaterialDiff(material: MaterialDiffSide, score: number, position: 'top' | 'bottom', checks?: number) {
+function renderMaterialDiff(
+  material: MaterialDiffSide,
+  score: number,
+  position: 'top' | 'bottom',
+  checks?: number
+): VNode {
   const children: VNode[] = [];
-  let role: string, i: number;
+  let role: cg.Role;
   for (role in material) {
     if (material[role] > 0) {
       const content: VNode[] = [];
-      for (i = 0; i < material[role]; i++) content.push(h('mpiece.' + role));
+      for (let i = 0; i < material[role]; i++) content.push(h('mpiece.' + role));
       children.push(h('div', content));
     }
   }
-  if (checks) for (i = 0; i < checks; i++) children.push(h('div', h('mpiece.king')));
+  if (checks) for (let i = 0; i < checks; i++) children.push(h('div', h('mpiece.king')));
   if (score > 0) children.push(h('score', '+' + score));
   return h('div.material.material-' + position, children);
 }
 
-const emptyMaterialDiff: MaterialDiff = {
-  white: {},
-  black: {},
+const EMPTY_MATERIAL_DIFF: MaterialDiff = {
+  white: { king: 0, queen: 0, rook: 0, bishop: 0, knight: 0, pawn: 0 },
+  black: { king: 0, queen: 0, rook: 0, bishop: 0, knight: 0, pawn: 0 },
 };
 
 export function renderMaterialDiffs(
@@ -28,7 +33,7 @@ export function renderMaterialDiffs(
   flip: boolean,
   player: Player,
   opponent: Player,
-  pieces: Pieces,
+  pieces: cg.Pieces,
   checkStates: CheckState[],
   ply: Ply
 ): [VNode, VNode] {
@@ -40,9 +45,9 @@ export function renderMaterialDiffs(
   if (showCaptured) {
     material = getMaterialDiff(pieces);
     score = getScore(pieces) * (bottomColor === 'white' ? 1 : -1);
-  } else material = emptyMaterialDiff;
+  } else material = EMPTY_MATERIAL_DIFF;
 
-  const checks: CheckCount = player.checks || opponent.checks ? countChecks(checkStates, ply) : noChecks;
+  const checks: CheckCount = player.checks || opponent.checks ? countChecks(checkStates, ply) : NO_CHECKS;
 
   return [
     renderMaterialDiff(material[topColor], -score, 'top', checks[topColor]),

--- a/ui/round/css/_material.scss
+++ b/ui/round/css/_material.scss
@@ -1,5 +1,6 @@
+@import '../../common/css/component/material';
+
 .material {
-  @extend %flex-center-nowrap;
   align-self: center;
   height: 40px;
   line-height: 0;
@@ -18,32 +19,7 @@
     display: inline-block;
 
     &.pawn {
-      background-image: url(../piece/mono/P.svg);
       margin-left: -15px;
-    }
-
-    &.bishop {
-      background-image: url(../piece/mono/B.svg);
-    }
-
-    &.knight {
-      background-image: url(../piece/mono/N.svg);
-    }
-
-    &.rook {
-      background-image: url(../piece/mono/R.svg);
-    }
-
-    &.queen {
-      background-image: url(../piece/mono/Q.svg);
-    }
-
-    &.king {
-      background-image: url(../piece/mono/K.svg);
-    }
-
-    @if $theme == 'transp' {
-      filter: brightness(1.3) drop-shadow(0 1px 1px #000);
     }
   }
 

--- a/ui/round/src/interfaces.ts
+++ b/ui/round/src/interfaces.ts
@@ -187,15 +187,3 @@ export interface MoveMetadata {
 }
 
 export type Position = 'top' | 'bottom';
-
-export interface MaterialDiffSide {
-  [role: string]: number;
-}
-export interface MaterialDiff {
-  white: MaterialDiffSide;
-  black: MaterialDiffSide;
-}
-export interface CheckCount {
-  white: number;
-  black: number;
-}

--- a/ui/round/src/util.ts
+++ b/ui/round/src/util.ts
@@ -1,18 +1,8 @@
 import * as cg from 'chessground/types';
-import { opposite } from 'chessground/util';
 import { h, VNodeData } from 'snabbdom';
-import { CheckCount, Dests, EncodedDests, MaterialDiff, Step } from './interfaces';
+import { Dests, EncodedDests } from './interfaces';
 
 export { bind, onInsert } from 'common/snabbdom';
-
-const pieceScores = {
-  pawn: 1,
-  knight: 3,
-  bishop: 3,
-  rook: 5,
-  queen: 9,
-  king: 0,
-};
 
 export const justIcon = (icon: string): VNodeData => ({
   attrs: { 'data-icon': icon },
@@ -33,45 +23,6 @@ export function parsePossibleMoves(dests?: EncodedDests): Dests {
     }
   else for (const k in dests) dec.set(k, dests[k].match(/.{2}/g) as cg.Key[]);
   return dec;
-}
-
-// {white: {pawn: 3 queen: 1}, black: {bishop: 2}}
-export function getMaterialDiff(pieces: cg.Pieces): MaterialDiff {
-  const diff: MaterialDiff = {
-    white: { king: 0, queen: 0, rook: 0, bishop: 0, knight: 0, pawn: 0 },
-    black: { king: 0, queen: 0, rook: 0, bishop: 0, knight: 0, pawn: 0 },
-  };
-  for (const p of pieces.values()) {
-    const them = diff[opposite(p.color)];
-    if (them[p.role] > 0) them[p.role]--;
-    else diff[p.color][p.role]++;
-  }
-  return diff;
-}
-
-export function getScore(pieces: cg.Pieces): number {
-  let score = 0;
-  for (const p of pieces.values()) {
-    score += pieceScores[p.role] * (p.color === 'white' ? 1 : -1);
-  }
-  return score;
-}
-
-export const noChecks: CheckCount = {
-  white: 0,
-  black: 0,
-};
-
-export function countChecks(steps: Step[], ply: Ply): CheckCount {
-  const checks: CheckCount = { ...noChecks };
-  for (const step of steps) {
-    if (ply < step.ply) break;
-    if (step.check) {
-      if (step.ply % 2 === 1) checks.white++;
-      else checks.black++;
-    }
-  }
-  return checks;
 }
 
 export const spinner = () =>

--- a/ui/round/src/view/main.ts
+++ b/ui/round/src/view/main.ts
@@ -4,7 +4,7 @@ import crazyView from '../crazy/crazyView';
 import RoundController from '../ctrl';
 import { h, VNode } from 'snabbdom';
 import { plyStep } from '../round';
-import { read as fenRead } from 'chessground/fen';
+import { read as readFen } from 'chessground/fen';
 import { render as keyboardMove } from '../keyboardMove';
 import { render as renderGround } from '../ground';
 import { renderTable } from './table';
@@ -24,7 +24,7 @@ export function main(ctrl: RoundController): VNode {
     cgState = ctrl.chessground && ctrl.chessground.state,
     topColor = d[ctrl.flip ? 'player' : 'opponent'].color,
     bottomColor = d[ctrl.flip ? 'opponent' : 'player'].color,
-    pieces = cgState ? cgState.pieces : fenRead(plyStep(ctrl.data, ctrl.ply).fen),
+    pieces = cgState ? cgState.pieces : readFen(plyStep(ctrl.data, ctrl.ply).fen),
     materialDiffs = renderMaterialDiffs(
       ctrl.data.pref.showCaptured,
       ctrl.flip,

--- a/ui/round/src/view/main.ts
+++ b/ui/round/src/view/main.ts
@@ -4,26 +4,11 @@ import crazyView from '../crazy/crazyView';
 import RoundController from '../ctrl';
 import { h, VNode } from 'snabbdom';
 import { plyStep } from '../round';
-import { Position, MaterialDiff, MaterialDiffSide, CheckCount } from '../interfaces';
 import { read as fenRead } from 'chessground/fen';
 import { render as keyboardMove } from '../keyboardMove';
 import { render as renderGround } from '../ground';
 import { renderTable } from './table';
-
-function renderMaterial(material: MaterialDiffSide, score: number, position: Position, checks?: number) {
-  const children: VNode[] = [];
-  let role: string, i: number;
-  for (role in material) {
-    if (material[role] > 0) {
-      const content: VNode[] = [];
-      for (i = 0; i < material[role]; i++) content.push(h('mpiece.' + role));
-      children.push(h('div', content));
-    }
-  }
-  if (checks) for (i = 0; i < checks; i++) children.push(h('div', h('mpiece.king')));
-  if (score > 0) children.push(h('score', '+' + score));
-  return h('div.material.material-' + position, children);
-}
+import { renderMaterialDiffs } from 'game/view/material';
 
 function wheel(ctrl: RoundController, e: WheelEvent): void {
   if (!ctrl.isPlaying()) {
@@ -34,26 +19,21 @@ function wheel(ctrl: RoundController, e: WheelEvent): void {
   }
 }
 
-const emptyMaterialDiff: MaterialDiff = {
-  white: {},
-  black: {},
-};
-
 export function main(ctrl: RoundController): VNode {
   const d = ctrl.data,
     cgState = ctrl.chessground && ctrl.chessground.state,
     topColor = d[ctrl.flip ? 'player' : 'opponent'].color,
-    bottomColor = d[ctrl.flip ? 'opponent' : 'player'].color;
-  let material: MaterialDiff,
-    score = 0;
-  if (d.pref.showCaptured) {
-    const pieces = cgState ? cgState.pieces : fenRead(plyStep(ctrl.data, ctrl.ply).fen);
-    material = util.getMaterialDiff(pieces);
-    score = util.getScore(pieces) * (bottomColor === 'white' ? 1 : -1);
-  } else material = emptyMaterialDiff;
-
-  const checks: CheckCount =
-    d.player.checks || d.opponent.checks ? util.countChecks(ctrl.data.steps, ctrl.ply) : util.noChecks;
+    bottomColor = d[ctrl.flip ? 'opponent' : 'player'].color,
+    pieces = cgState ? cgState.pieces : fenRead(plyStep(ctrl.data, ctrl.ply).fen),
+    materialDiffs = renderMaterialDiffs(
+      ctrl.data.pref.showCaptured,
+      ctrl.flip,
+      ctrl.data.player,
+      ctrl.data.opponent,
+      pieces,
+      ctrl.data.steps,
+      ctrl.ply
+    );
 
   return ctrl.nvui
     ? ctrl.nvui.render(ctrl)
@@ -68,10 +48,9 @@ export function main(ctrl: RoundController): VNode {
           },
           [renderGround(ctrl), ctrl.promotion.view(ctrl.data.game.variant.key === 'antichess')]
         ),
-        crazyView(ctrl, topColor, 'top') || renderMaterial(material[topColor], -score, 'top', checks[topColor]),
+        crazyView(ctrl, topColor, 'top') || materialDiffs[0],
         ...renderTable(ctrl),
-        crazyView(ctrl, bottomColor, 'bottom') ||
-          renderMaterial(material[bottomColor], score, 'bottom', checks[bottomColor]),
+        crazyView(ctrl, bottomColor, 'bottom') || materialDiffs[1],
         ctrl.keyboardMove ? keyboardMove(ctrl.keyboardMove) : null,
       ]);
 }


### PR DESCRIPTION
Closes #9466, closes #206 

- Tested on games with and without a clock
- Tested in Chrome, Firefox, and Safari

#### Analysis View Screenshot
<img width="653" alt="Screen Shot 2021-07-27 at 3 47 54 PM" src="https://user-images.githubusercontent.com/551404/127237543-761637ab-cb28-4fb3-ab89-7e0c7be4df89.png">


#### Study View Screenshot
<img width="629" alt="Screen Shot 2021-07-27 at 3 48 25 PM" src="https://user-images.githubusercontent.com/551404/127237552-f5888729-a122-4940-9a62-b18a173491c8.png">

