### PR TITLE
Fix clipping of 3d pieces at the top

### DIFF
--- a/ui/common/css/vendor/chessground/_board-3d.scss
+++ b/ui/common/css/vendor/chessground/_board-3d.scss
@@ -6,7 +6,7 @@ $td-inner-relative-percent: $td-inner-height-ratio / $td-outer-height-ratio * 10
 @include breakpoint($mq-col1-uniboard) {
   .is3d {
     /* horiz scroll caused by 3d pieces overflowing the board */
-    overflow: hidden;
+    overflow-x: clip;
   }
 }
 

--- a/ui/site/css/_coordinate.scss
+++ b/ui/site/css/_coordinate.scss
@@ -27,9 +27,6 @@ $mq-col3: $mq-x-large;
 .coord-trainer {
   grid-area: main;
   display: grid;
-  overflow: hidden;
-
-  // coords cause mobile to have horiz scrolling
 
   &__side {
     @extend %zen;


### PR DESCRIPTION
Fixes #5049

`overflow-x: hidden` doesn't seem to work but it works with `clip` (and still avoids scrolling on mobile). As far as I understand, `hidden` always automatically applies to both axis.