### PR TITLE
Update stockfish-nnue.wasm 1.0.0

### DIFF
--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -232,7 +232,7 @@ export default function (opts: CevalOpts): CevalCtrl {
             downloadProgress(mb);
             opts.redraw();
           }),
-          version: '85a969',
+          version: 'b6939d',
           wasmMemory: sharedWasmMemory(2048, growableSharedMem ? 32768 : 2048),
           cache: new Cache('ceval-wasm-cache'),
         });

--- a/ui/ceval/src/view.ts
+++ b/ui/ceval/src/view.ts
@@ -83,7 +83,7 @@ function engineName(ctrl: CevalCtrl): VNode[] {
     h(
       'span',
       { attrs: { title: version || '' } },
-      ctrl.technology == 'nnue' ? 'Stockfish 13+' : ctrl.technology == 'hce' ? 'Stockfish 11+' : 'Stockfish 10+'
+      ctrl.technology == 'nnue' ? 'Stockfish 14+' : ctrl.technology == 'hce' ? 'Stockfish 11+' : 'Stockfish 10+'
     ),
     ctrl.technology == 'nnue'
       ? h(

--- a/ui/site/package.json
+++ b/ui/site/package.json
@@ -23,7 +23,7 @@
     "highcharts": "=4.2.5",
     "hopscotch": "^0.3.1",
     "stockfish-mv.wasm": "^0.6.1",
-    "stockfish-nnue.wasm": "0.0.2",
+    "stockfish-nnue.wasm": "1.0.0-1946a675.smolnet",
     "stockfish.js": "^10.0.2",
     "stockfish.wasm": "^0.10.0",
     "tablesort": "^5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4825,10 +4825,10 @@ stockfish-mv.wasm@^0.6.1:
   resolved "https://registry.yarnpkg.com/stockfish-mv.wasm/-/stockfish-mv.wasm-0.6.1.tgz#cd160b01b25ff64794cb44fe55b6791c3fb297f8"
   integrity sha512-6QE1LeWbv9NNMABHCjDGyjgob+1CfMpIszxUKCUcCH0znreWPXz48G09rhKTUpRzC8YsOTHPQL/s74gDcqXJGw==
 
-stockfish-nnue.wasm@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/stockfish-nnue.wasm/-/stockfish-nnue.wasm-0.0.2.tgz#388128b17a22215222ad87cf3f29e71822e7ff5f"
-  integrity sha512-PPbYo0hbPihPVj7j1DWsJq4idifKXf0jfsavXIIuoHE/XG+7nfbrah91DnliDo7s3PsXM0y+ZgOC++Xszv3JyQ==
+stockfish-nnue.wasm@1.0.0-1946a675.smolnet:
+  version "1.0.0-1946a675.smolnet"
+  resolved "https://registry.yarnpkg.com/stockfish-nnue.wasm/-/stockfish-nnue.wasm-1.0.0-1946a675.smolnet.tgz#af422e3e2870d0b0fee2ea28eec89b813fe90040"
+  integrity sha512-ofHHGb60dsMuz1SFurbkUBStMz6zmSLEculHUYdryX3782dys785hWgY9HJVgxMZQW+uhAARFcwPtPlyeW/nZg==
 
 stockfish.js@^10.0.2:
   version "10.0.2"


### PR DESCRIPTION
Hi guys, it's been a while since the last contribution, but recently I got back to wasm simd stockfish port and updated the package, which now includes features from Stockfish 14.

This means that the size of `stockfish.wasm` increased quite a lot due to the new neural network (47MB originally and 27.6MB after compression), so I'm not sure how easy it is for Lichess to actually deploy this one as it is.
For this version of my port, I added a feature to load .nnue file separately from .wasm file itself, so this might help in some way.

Please let me know if you guys have any considerations about this and feel free to ask me any questions about the new version (as before, you can find my repo here https://github.com/hi-ogawa/Stockfish).
Thanks!