### PR TITLE
Make transparent theme more consistent with light & dark themes

### DIFF
--- a/ui/site/css/user/_activity.scss
+++ b/ui/site/css/user/_activity.scss
@@ -16,7 +16,6 @@ $c-contours: mix($c-brag, $c-shade, 80%);
     time {
       font-weight: bold;
       text-transform: uppercase;
-      background: $c-bg-box;
     }
   }
 

--- a/ui/site/css/user/_number-menu.scss
+++ b/ui/site/css/user/_number-menu.scss
@@ -1,5 +1,4 @@
 .number-menu {
-  background: $c-bg-zebra;
   display: flex;
   user-select: none;
 


### PR DESCRIPTION
A couple css issues were reported [on the forums](https://lichess.org/forum/lichess-feedback/transparent-background-issues).

![extra opacity in date](https://i.prntscr.com/yvilOjPcRPCTUlITklqiHg.png)
![extra opacity under username](https://i.prntscr.com/lUsrihBMQ1qSrit6Sn7CpA.png)

In both cases, the elements have the same background color as their containers, but since that color is translucent, extra opacity gets added. This PR removes the background css rule so that the backgrounds are transparent instead.

NB. The section under the username has class `number-menu`. That class shows up in two other places, but in those places, a different rule overrides the background, so the rule is safe to delete.

- [A](https://github.com/ornicar/lila/blob/8b403a6ee2f1e8b7fb1e87f9ed251208f9469d42/app/views/user/show/gamesContent.scala#L23) The `#games` tabs, where the rule is overridden by [`$c-bg-low`](https://github.com/ornicar/lila/blob/6048f3c4e223357ea99ed84ea4f0a82f251eb2fe/ui/site/css/user/_show.scss#L90)
- [B](https://github.com/ornicar/lila/blob/8b403a6ee2f1e8b7fb1e87f9ed251208f9469d42/app/views/user/show/header.scala#L261) The Activity/123 Games tabs, where the rule is overridden by [the metal linear gradient](https://github.com/ornicar/lila/blob/8b403a6ee2f1e8b7fb1e87f9ed251208f9469d42/ui/common/css/component/_crosstable.scss#L27)

Now the transparent theme looks more like the light and dark themes:

<img width="255" alt="Screen Shot 2021-07-30 at 7 21 19 PM" src="https://user-images.githubusercontent.com/7917791/127725858-145cce90-76b0-4977-ad82-01cef8a2eb5e.png">
<img width="310" alt="Screen Shot 2021-07-30 at 7 20 52 PM" src="https://user-images.githubusercontent.com/7917791/127725859-754a7d0e-737e-426d-80b4-e1bf427a49fe.png">
