### PR TITLE
Use real button elements in gamebook

### DIFF
--- a/ui/analyse/css/gamebook/_play.scss
+++ b/ui/analyse/css/gamebook/_play.scss
@@ -86,10 +86,13 @@
       z-index: 2;
     }
 
-    a.hint {
+    button.hint {
+      @extend %button-none;
+
       padding: 0.8em 1em;
       color: $c-primary;
       font-size: 1rem;
+      text-align: unset;
     }
   }
 
@@ -105,7 +108,7 @@
   }
 
   .feedback {
-    @extend %flex-column, %box-radius;
+    @extend %flex-column, %box-radius, %button-none;
 
     flex: 1 1 100%;
     height: 8rem;
@@ -188,8 +191,8 @@
       flex-flow: row;
       font-size: 0.8em;
 
-      a {
-        @extend %flex-column;
+      button {
+        @extend %flex-column, %button-none;
 
         flex: 1 1 100%;
         background: mix($c-primary, $c-bg-box, 80%);

--- a/ui/analyse/css/gamebook/_play.scss
+++ b/ui/analyse/css/gamebook/_play.scss
@@ -76,23 +76,26 @@
       min-height: 2.5em;
     }
 
-    div.hint {
-      padding: 0.8em 1em;
-      background: $c-primary;
-      color: $c-primary-over;
-      border-radius: 0 0 1rem 1rem;
-      cursor: pointer;
-      font-size: 0.9em;
-      z-index: 2;
-    }
-
-    button.hint {
+    button {
       @extend %button-none;
 
-      padding: 0.8em 1em;
-      color: $c-primary;
-      font-size: 1rem;
-      text-align: unset;
+      text-align: start;
+
+      &.hint {
+        padding: 0.8em 1em;
+        color: $c-primary;
+        font-size: 1rem;
+      }
+
+      div.hint {
+        padding: 0.8em 1em;
+        background: $c-primary;
+        color: $c-primary-over;
+        border-radius: 0 0 1rem 1rem;
+        cursor: pointer;
+        font-size: 0.9em;
+        z-index: 2;
+      }
     }
   }
 

--- a/ui/analyse/src/study/gamebook/gamebookButtons.ts
+++ b/ui/analyse/src/study/gamebook/gamebookButtons.ts
@@ -14,7 +14,7 @@ export function playButtons(root: AnalyseCtrl): VNode | undefined {
   return h('div.gamebook-buttons', [
     root.path
       ? h(
-          'a.fbt.text.back',
+          'button.fbt.text.back',
           {
             attrs: dataIcon(''),
             hook: bind('click', () => root.userJump(''), ctrl.redraw),
@@ -24,7 +24,7 @@ export function playButtons(root: AnalyseCtrl): VNode | undefined {
       : null,
     myTurn
       ? h(
-          'a.fbt.text.solution',
+          'button.fbt.text.solution',
           {
             attrs: dataIcon(''),
             hook: bind('click', ctrl.solution, ctrl.redraw),
@@ -41,7 +41,7 @@ export function overrideButton(study: StudyCtrl): VNode | undefined {
     const o = study.vm.gamebookOverride;
     if (study.members.canContribute())
       return h(
-        'a.fbt.text.preview',
+        'button.fbt.text.preview',
         {
           class: { active: o === 'play' },
           attrs: dataIcon(''),

--- a/ui/analyse/src/study/gamebook/gamebookButtons.ts
+++ b/ui/analyse/src/study/gamebook/gamebookButtons.ts
@@ -16,7 +16,10 @@ export function playButtons(root: AnalyseCtrl): VNode | undefined {
       ? h(
           'button.fbt.text.back',
           {
-            attrs: dataIcon(''),
+            attrs: {
+              'data-icon': '',
+              type: 'button',
+            },
             hook: bind('click', () => root.userJump(''), ctrl.redraw),
           },
           'Back'
@@ -26,7 +29,10 @@ export function playButtons(root: AnalyseCtrl): VNode | undefined {
       ? h(
           'button.fbt.text.solution',
           {
-            attrs: dataIcon(''),
+            attrs: {
+              'data-icon': '',
+              type: 'button',
+            },
             hook: bind('click', ctrl.solution, ctrl.redraw),
           },
           'View the solution'
@@ -44,7 +50,10 @@ export function overrideButton(study: StudyCtrl): VNode | undefined {
         'button.fbt.text.preview',
         {
           class: { active: o === 'play' },
-          attrs: dataIcon(''),
+          attrs: {
+            'data-icon': '',
+            type: 'button',
+          },
           hook: bind(
             'click',
             () => {

--- a/ui/analyse/src/study/gamebook/gamebookPlayView.ts
+++ b/ui/analyse/src/study/gamebook/gamebookPlayView.ts
@@ -47,11 +47,12 @@ export function render(ctrl: GamebookPlayCtrl): VNode {
 
 function hintZone(ctrl: GamebookPlayCtrl) {
   const state = ctrl.state,
-    clickHook = () => ({
+    buttonData = () => ({
+      attrs: { type: 'button' },
       hook: bind('click', ctrl.hint, ctrl.redraw),
     });
-  if (state.showHint) return h('button', clickHook(), [h('div.hint', { hook: richHTML(state.hint!) })]);
-  if (state.hint) return h('button.hint', clickHook(), 'Get a hint');
+  if (state.showHint) return h('button', buttonData(), [h('div.hint', { hook: richHTML(state.hint!) })]);
+  if (state.hint) return h('button.hint', buttonData(), 'Get a hint');
   return undefined;
 }
 
@@ -62,6 +63,7 @@ function renderFeedback(ctrl: GamebookPlayCtrl, state: State) {
     return h(
       'button.feedback.act.bad' + (state.comment ? '.com' : ''),
       {
+        attrs: { type: 'button' },
         hook: bind('click', ctrl.retry),
       },
       [iconTag(''), h('span', 'Retry')]
@@ -70,6 +72,7 @@ function renderFeedback(ctrl: GamebookPlayCtrl, state: State) {
     return h(
       'button.feedback.act.good.com',
       {
+        attrs: { type: 'button' },
         hook: bind('click', ctrl.next),
       },
       [h('span.text', { attrs: dataIcon('') }, 'Next'), h('kbd', '<space>')]
@@ -99,7 +102,10 @@ function renderEnd(ctrl: GamebookPlayCtrl) {
       ? h(
           'button.next.text',
           {
-            attrs: dataIcon(''),
+            attrs: {
+              'data-icon': '',
+              type: 'button',
+            },
             hook: bind('click', study.goToNextChapter),
           },
           'Next chapter'
@@ -108,7 +114,10 @@ function renderEnd(ctrl: GamebookPlayCtrl) {
     h(
       'button.retry',
       {
-        attrs: dataIcon(''),
+        attrs: {
+          'data-icon': '',
+          type: 'button',
+        },
         hook: bind('click', () => ctrl.root.userJump(''), ctrl.redraw),
       },
       'Play again'
@@ -116,7 +125,10 @@ function renderEnd(ctrl: GamebookPlayCtrl) {
     h(
       'button.analyse',
       {
-        attrs: dataIcon(''),
+        attrs: {
+          'data-icon': '',
+          type: 'button',
+        },
         hook: bind('click', () => study.setGamebookOverride('analyse'), ctrl.redraw),
       },
       'Analyse'

--- a/ui/analyse/src/study/gamebook/gamebookPlayView.ts
+++ b/ui/analyse/src/study/gamebook/gamebookPlayView.ts
@@ -51,7 +51,7 @@ function hintZone(ctrl: GamebookPlayCtrl) {
       hook: bind('click', ctrl.hint, ctrl.redraw),
     });
   if (state.showHint) return h('div', clickHook(), [h('div.hint', { hook: richHTML(state.hint!) })]);
-  if (state.hint) return h('a.hint', clickHook(), 'Get a hint');
+  if (state.hint) return h('button.hint', clickHook(), 'Get a hint');
   return undefined;
 }
 
@@ -60,7 +60,7 @@ function renderFeedback(ctrl: GamebookPlayCtrl, state: State) {
     color = ctrl.root.turnColor();
   if (fb === 'bad')
     return h(
-      'div.feedback.act.bad' + (state.comment ? '.com' : ''),
+      'button.feedback.act.bad' + (state.comment ? '.com' : ''),
       {
         hook: bind('click', ctrl.retry),
       },
@@ -68,7 +68,7 @@ function renderFeedback(ctrl: GamebookPlayCtrl, state: State) {
     );
   if (fb === 'good' && state.comment)
     return h(
-      'div.feedback.act.good.com',
+      'button.feedback.act.good.com',
       {
         hook: bind('click', ctrl.next),
       },
@@ -97,7 +97,7 @@ function renderEnd(ctrl: GamebookPlayCtrl) {
   return h('div.feedback.end', [
     study.nextChapter()
       ? h(
-          'a.next.text',
+          'button.next.text',
           {
             attrs: dataIcon(''),
             hook: bind('click', study.goToNextChapter),
@@ -106,7 +106,7 @@ function renderEnd(ctrl: GamebookPlayCtrl) {
         )
       : undefined,
     h(
-      'a.retry',
+      'button.retry',
       {
         attrs: dataIcon(''),
         hook: bind('click', () => ctrl.root.userJump(''), ctrl.redraw),
@@ -114,7 +114,7 @@ function renderEnd(ctrl: GamebookPlayCtrl) {
       'Play again'
     ),
     h(
-      'a.analyse',
+      'button.analyse',
       {
         attrs: dataIcon(''),
         hook: bind('click', () => study.setGamebookOverride('analyse'), ctrl.redraw),

--- a/ui/analyse/src/study/gamebook/gamebookPlayView.ts
+++ b/ui/analyse/src/study/gamebook/gamebookPlayView.ts
@@ -50,7 +50,7 @@ function hintZone(ctrl: GamebookPlayCtrl) {
     clickHook = () => ({
       hook: bind('click', ctrl.hint, ctrl.redraw),
     });
-  if (state.showHint) return h('div', clickHook(), [h('div.hint', { hook: richHTML(state.hint!) })]);
+  if (state.showHint) return h('button', clickHook(), [h('div.hint', { hook: richHTML(state.hint!) })]);
   if (state.hint) return h('button.hint', clickHook(), 'Get a hint');
   return undefined;
 }

--- a/ui/common/css/abstract/_extends.scss
+++ b/ui/common/css/abstract/_extends.scss
@@ -114,6 +114,7 @@
   border: none;
   outline: none;
   color: $c-font;
+  align-items: normal;
 }
 
 %checkbox {


### PR DESCRIPTION
Makes progress on #9509. Also one step closer to maybe making fully-featured practice in nvui.

The clickable divs in gamebookEdit.ts were not changed because if I make them buttons, the flash of unstyled content as the css loads can become really unpleasant, particularly in dark themes.

`align-items: normal;` was added to `%button-none` to deal with Chrome's user agent style on buttons.