### PR TITLE
remove whitespace in UserSearch

### DIFF
--- a/modules/mod/src/main/UserSearch.scala
+++ b/modules/mod/src/main/UserSearch.scala
@@ -14,9 +14,9 @@ final class UserSearch(
   def apply(query: UserSearch.Query): Fu[List[User.WithEmails]] =
     (~query.as match {
       case _ => // "exact"
-        EmailAddress.from(query.q).map(searchEmail) orElse
-          IpAddress.from(query.q).map(searchIp) getOrElse
-          searchUsername(query.q)
+        EmailAddress.from(query.q.replaceAll("\\s", "")).map(searchEmail) orElse
+          IpAddress.from(query.q.replaceAll("\\s", "")).map(searchIp) getOrElse
+          searchUsername(query.q.replaceAll("\\s", ""))
     }) flatMap userRepo.withEmailsU
 
   private def searchIp(ip: IpAddress) =


### PR DESCRIPTION
whitespace cannot appear in usernames etc anyway. sometimes one might copy paste searches from elsewhere and accidentally include whitespace, in which case search used to fail.