### PR TITLE
Fix resign command in nvui

### DIFF
--- a/ui/round/src/plugins/nvui.ts
+++ b/ui/round/src/plugins/nvui.ts
@@ -318,7 +318,7 @@ function onCommand(ctrl: RoundController, notify: (txt: string) => void, c: stri
   if (lowered == 'c' || lowered == 'clock') notify($('.nvui .botc').text() + ', ' + $('.nvui .topc').text());
   else if (lowered == 'l' || lowered == 'last') notify($('.lastMove').text());
   else if (lowered == 'abort') $('.nvui button.abort').trigger('click');
-  else if (lowered == 'resign') $('.nvui button.resign-confirm').trigger('click');
+  else if (lowered == 'resign') $('.nvui button.resign').trigger('click');
   else if (lowered == 'draw') $('.nvui button.draw-yes').trigger('click');
   else if (lowered == 'takeback') $('.nvui button.takeback-yes').trigger('click');
   else if (lowered == 'o' || lowered == 'opponent') notify(playerText(ctrl, ctrl.data.opponent));


### PR DESCRIPTION
The resign text command in nvui searches for an older class which no longer exists.

The "resign-confirm" class comes from 2015 in db9d559. 84216b0 is the commit that removed "resign-confirm" and began using "act-confirm" instead. The nvui command for resigning comes from 420c9a9.

The current button for resigning is "button.resign", and it doesn't need confirmation when in nvui mode, so triggering a click on it correctly resigns.

Related #9529.