### PR TITLE
fix download page css for light mode

### DIFF
--- a/ui/site/css/_search.scss
+++ b/ui/site/css/_search.scss
@@ -128,7 +128,7 @@
       }
 
       input {
-        color: #fff7;
+        color: $c-font-dim;
       }
     }
 


### PR DESCRIPTION
before
<img width="923" alt="Screenshot 2021-08-06 at 15 06 41" src="https://user-images.githubusercontent.com/56031107/128515639-7530d4a7-e37c-408e-bfb7-b7c0930567b8.png">
after
<img width="929" alt="Screenshot 2021-08-06 at 15 07 00" src="https://user-images.githubusercontent.com/56031107/128515643-f1bff727-9cd6-416e-af62-7bf6be128c67.png">
dark mode look the same (new)
<img width="929" alt="Screenshot 2021-08-06 at 15 11 04" src="https://user-images.githubusercontent.com/56031107/128515646-14f87057-6335-48e2-a0b6-414062f52c44.png">
