### PR TITLE
Search for players by rank in tournaments

### DIFF
--- a/ui/tournament/src/ctrl.ts
+++ b/ui/tournament/src/ctrl.ts
@@ -1,6 +1,6 @@
 import makeSocket from './socket';
 import * as xhr from './xhr';
-import { myPage, players } from './pagination';
+import { maxPerPage, myPage, players } from './pagination';
 import * as sound from './sound';
 import * as tour from './tournament';
 import { TournamentData, TournamentOpts, Pages, PlayerInfo, TeamInfo, Standing, Player } from './interfaces';
@@ -108,6 +108,19 @@ export default class TournamentController {
       this.focusOnMe = false;
       this.pages[this.page].filter(p => p.name.toLowerCase() == userId).forEach(this.showPlayerInfo);
       this.redraw();
+    });
+  };
+
+  jumpToRank = (rank: number) => {
+    if (!Number.isInteger(rank) || rank < 1) return;
+    const page = 1 + Math.floor((rank - 1) / maxPerPage);
+    const row = (rank - 1) % maxPerPage;
+    xhr.loadPage(this, page, () => {
+      if (!this.pages[page] || row >= this.pages[page].length) return;
+      this.page = page;
+      this.searching = false;
+      this.focusOnMe = false;
+      this.showPlayerInfo(this.pages[page][row]);
     });
   };
 

--- a/ui/tournament/src/pagination.ts
+++ b/ui/tournament/src/pagination.ts
@@ -4,7 +4,7 @@ import { MaybeVNodes, Pagination } from './interfaces';
 import { bind } from './view/util';
 import * as search from './search';
 
-const maxPerPage = 10;
+export const maxPerPage = 10;
 
 function button(text: string, icon: string, click: () => void, enable: boolean, ctrl: TournamentController): VNode {
   return h('button.fbt.is', {

--- a/ui/tournament/src/search.ts
+++ b/ui/tournament/src/search.ts
@@ -17,7 +17,7 @@ export function input(ctrl: TournamentController): VNode {
   return h(
     'div.search',
     h('input', {
-      hook: onInsert((el: HTMLInputElement) =>
+      hook: onInsert((el: HTMLInputElement) => {
         lichess.userComplete().then(uac => {
           uac({
             input: el,
@@ -30,8 +30,17 @@ export function input(ctrl: TournamentController): VNode {
             },
           });
           el.focus();
-        })
-      ),
+        });
+        $(el).on('keydown', e => {
+          if (e.code === 'Enter' && el.value.startsWith('#')) {
+            ctrl.jumpToRank(Number(el.value.slice(1)));
+          }
+          if (e.code === 'Escape') {
+            ctrl.toggleSearch();
+            ctrl.redraw();
+          }
+        });
+      }),
     })
   );
 }

--- a/ui/tournament/src/xhr.ts
+++ b/ui/tournament/src/xhr.ts
@@ -32,9 +32,10 @@ export const withdraw = throttle(1000, (ctrl: TournamentController) =>
     .catch(onFail)
 );
 
-export const loadPage = throttle(1000, (ctrl: TournamentController, p: number) =>
+export const loadPage = throttle(1000, (ctrl: TournamentController, p: number, callback?: () => void) =>
   xhr.json(`/tournament/${ctrl.data.id}/standing/${p}`).then(data => {
     ctrl.loadPage(data);
+    callback?.();
     ctrl.redraw();
   }, onFail)
 );


### PR DESCRIPTION
> [It would be useful to be able to search a player by their rank in a tournament, especially when there are a lot of players like in this 2021 Summer Marathon (20,000+ players). For example, I would just need to write #500 and I can see the top 500 player instead of scrolling down and pressing on the "next" button many times.](https://lichess.org/forum/lichess-feedback/feature-request-search-players-by-their-rank-in-a-tournament)

The \#number syntax is nice. It avoids sending user autocomplete xhr because of the existing [regex](https://github.com/ornicar/lila/blob/322dea6eb34e2a4880f155941dbec756fa319e88/ui/site/src/userComplete.ts#L67).

I also made escape dismiss the search input.

In the code, pages and ranks are 1-indexed. Rows within a page are 0-indexed.