### PR TITLE
fixing undefined variable error from #9435

### DIFF
--- a/ui/puzzle/css/_puzzle.scss
+++ b/ui/puzzle/css/_puzzle.scss
@@ -1,3 +1,4 @@
+$mq-col1: $mq-col1-uniboard;
 $mq-col2-squeeze: $mq-col2-uniboard-squeeze;
 $mq-col2: $mq-col2-uniboard;
 $mq-col3: $mq-col3-uniboard;


### PR DESCRIPTION
while building ui using ./ui/build, the following error occurs:
```
Error in plugin "sass"
Message:
    puzzle/css/_tools.scss
Error: Undefined variable: "$mq-col1".
        on line 139 of puzzle/css/_tools.scss
        from line 7 of puzzle/css/_puzzle.scss
        from line 18 of puzzle/css/build/_puzzle.scss
        from line 2 of puzzle/css/build/puzzle.dark.scss
>>   @include breakpoint($mq-col1) {
```
