### PR TITLE
Show current position stats in opening explorer

### DIFF
--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -19,6 +19,7 @@ function pieceDrop(key: cg.Key, role: cg.Role, color: Color): DrawShape {
 }
 
 export function makeShapesFromUci(color: Color, uci: Uci, brush: string, modifiers?: DrawModifiers): DrawShape[] {
+  if (uci === 'Current Position') return [];
   const move = parseUci(uci)!;
   const to = makeSquare(move.to);
   if (isDrop(move)) return [{ orig: to, brush }, pieceDrop(to, move.role, color)];

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -72,6 +72,21 @@ function moveTableAttributes(ctrl: AnalyseCtrl, fen: Fen) {
 function showMoveTable(ctrl: AnalyseCtrl, data: OpeningData): VNode | null {
   if (!data.moves.length) return null;
   const trans = ctrl.trans.noarg;
+  let movesWithCurrent: OpeningMoveStats[] = [...data.moves];
+
+  if ([data.white, data.black, data.draws, data.averageRating].every(el => el !== undefined)) {
+    const currentStats: OpeningMoveStats = {
+      white: data.white!,
+      black: data.black!,
+      draws: data.draws!,
+      averageRating: data.averageRating!,
+      uci: 'Current Position',
+      san: 'Current',
+    };
+
+    movesWithCurrent = [currentStats, ...data.moves];
+  }
+
   return h('table.moves', [
     h('thead', [
       h('tr', [h('th.title', trans('move')), h('th.title', trans('games')), h('th.title', trans('whiteDrawBlack'))]),
@@ -79,7 +94,7 @@ function showMoveTable(ctrl: AnalyseCtrl, data: OpeningData): VNode | null {
     h(
       'tbody',
       moveTableAttributes(ctrl, data.fen),
-      data.moves.map(move => {
+      movesWithCurrent.map(move => {
         return h(
           'tr',
           {

--- a/ui/analyse/src/explorer/interfaces.ts
+++ b/ui/analyse/src/explorer/interfaces.ts
@@ -49,7 +49,7 @@ export interface ExplorerData {
   tablebase?: true;
 }
 
-export interface OpeningData extends ExplorerData {
+export interface OpeningData extends ExplorerData, Partial<OpeningMoveStats> {
   moves: OpeningMoveStats[];
   topGames?: OpeningGame[];
   recentGames?: OpeningGame[];


### PR DESCRIPTION
This is my first time contributing to this repo and first PR for an open-source project in general so any feedback is appreciated! These changes resolve #8847 by showing the win rate statistics for the current board position in the opening explorer. The necessary statistics for the current position were already being pulled from the API call that is made to get information for the opening explorer. However, this information was not previously being propagated to the UI functions responsible for showing the opening explorer table. I tested these changes by trying different cases locally.