### PR TITLE
Fix typing for Tagify constructor.

### DIFF
--- a/ui/analyse/src/study/topics.ts
+++ b/ui/analyse/src/study/topics.ts
@@ -81,7 +81,7 @@ export function formView(ctrl: TopicsCtrl, userId?: string): VNode {
           h(
             'textarea',
             {
-              hook: onInsert(elm => setupTagify(elm, userId)),
+              hook: onInsert(elm => setupTagify(elm as HTMLTextAreaElement, userId)),
             },
             ctrl.getTopics().join(', ').replace(/[<>]/g, '')
           ),
@@ -98,7 +98,7 @@ export function formView(ctrl: TopicsCtrl, userId?: string): VNode {
   });
 }
 
-function setupTagify(elm: HTMLElement, userId?: string) {
+function setupTagify(elm: HTMLInputElement | HTMLTextAreaElement, userId?: string) {
   lichess.loadCssPath('tagify');
   lichess.loadScript('vendor/tagify/tagify.min.js').then(() => {
     tagify = new window.Tagify(elm, {


### PR DESCRIPTION
In my editor, if I use the "hover" mode to see the "type" of the `Tagify` object, it returns `any`, but if you look at the real type https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/yaireo__tagify/index.d.ts#L351 it requires as it's first arg a: `input: HTMLInputElement | HTMLTextAreaElement,` but we are suggesting that it can be any `HTMLElement` which is not technically assignable to the above argument without a cast. 

I think we should also try and figure out why typescript wasn't picking this up to begin with, but I don't know why that is.  Regardless, I think this is the correct fix. 