### PR TITLE
Fix date disappearance (insights)

### DIFF
--- a/ui/insight/src/chart.ts
+++ b/ui/insight/src/chart.ts
@@ -141,7 +141,7 @@ function makeChart(el: HTMLElement, data: Chart) {
     xAxis: {
       type: data.xAxis.dataType === 'date' ? 'datetime' : 'linear',
       categories: data.xAxis.categories.map(function (v) {
-        return `${data.xAxis.dataType === 'date' ? v * 1000 : v}`;
+        return (data.xAxis.dataType === 'date' ? v * 1000 : v) as any;
       }),
       crosshair: true,
       labels: {


### PR DESCRIPTION
The type annotation for categories is wrong; dates should be numbers, not strings.

This fixes the format of dates in tooltips, and it fixes the issue of dates not showing up beneath the x-axis. Address part of #9567.