### PR TITLE
UI proposal for the explorer's current move stats

### DIFF
--- a/ui/analyse/css/_explorer.scss
+++ b/ui/analyse/css/_explorer.scss
@@ -61,7 +61,7 @@
     }
 
     &:hover {
-      background: mix($c-secondary, $c-bg-box, 20%) !important;
+      background: mix($c-secondary, $c-bg-box, 20%);
     }
   }
 
@@ -88,8 +88,7 @@
   }
 
   .moves tbody tr:last-of-type:not(:first-of-type) {
-    background: mix($c-secondary, $c-bg-box, 20%);
-    color: fade-out($c-font, 0.1);
+    background: mix($c-secondary, $c-bg-box, 30%);
 
     @include breakpoint($mq-col2) {
       @include breakpoint($mq-x-short) {
@@ -101,29 +100,6 @@
     td {
       cursor: default;
     }
-
-    td:last-child {
-      text-align: center;
-    }
-
-    .bar span {
-      box-shadow: none;
-      background-clip: padding-box;
-      border-color: if($theme-light, #0001, #fff1);
-      color: inherit;
-    }
-
-    .white {
-      background-color: if($theme-light, #fff3, #fff2);
-    }
-
-    .draws {
-      background: if($theme-light, #0001, #fff1);
-    }
-
-    .black {
-      background-color: if($theme-light, #0002, #0001);
-    }
   }
 
   .bar span {
@@ -131,7 +107,8 @@
     display: inline-block;
     overflow: hidden;
     vertical-align: middle;
-    border: 0 solid $c-border;
+    background-clip: padding-box;
+    border: 0 solid fade-out($c-font, 0.83);
     border-width: 1px 0;
     height: 16px;
     line-height: 14px;

--- a/ui/analyse/css/_explorer.scss
+++ b/ui/analyse/css/_explorer.scss
@@ -53,16 +53,12 @@
     }
   }
 
-  table.moves tr:nth-child(odd) {
-    background: $c-bg-zebra;
-  }
-
-  table:not(.moves) tr:nth-child(even) {
-    background: $c-bg-zebra;
-  }
-
   tr {
     @include transition;
+
+    &:nth-child(even) {
+      background: $c-bg-zebra;
+    }
 
     &:hover {
       background: mix($c-secondary, $c-bg-box, 20%) !important;
@@ -95,8 +91,14 @@
     background: mix($c-secondary, $c-bg-box, 20%);
     color: fade-out($c-font, 0.1);
 
+    @include breakpoint($mq-col2) {
+      @include breakpoint($mq-x-short) {
+        position: sticky;
+        bottom: 0;
+      }
+    }
+
     td {
-      line-height: 1.9em;
       cursor: default;
     }
 

--- a/ui/analyse/css/_explorer.scss
+++ b/ui/analyse/css/_explorer.scss
@@ -105,14 +105,22 @@
     }
 
     .bar span {
-      background: fade-out($c-bg-box, 0.8);
       box-shadow: none;
-      border-color: fade-out($c-font, 0.8);
+      background-clip: padding-box;
+      border-color: if($theme-light, #0001, #fff1);
       color: inherit;
     }
 
-    .white, .draws {
-      border-right-width: 1px;
+    .white {
+      background-color: if($theme-light, #fff3, #fff2);
+    }
+
+    .draws {
+      background: if($theme-light, #0001, #fff1);
+    }
+
+    .black {
+      background-color: if($theme-light, #0002, #0001);;
     }
   }
 

--- a/ui/analyse/css/_explorer.scss
+++ b/ui/analyse/css/_explorer.scss
@@ -94,7 +94,7 @@
   .moves tbody tr:first-of-type {
     background: mix($c-secondary, $c-bg-box, 20%);
     color: fade-out($c-font, 0.1);
-    
+
     td {
       line-height: 1.9em;
       cursor: default;
@@ -120,7 +120,7 @@
     }
 
     .black {
-      background-color: if($theme-light, #0002, #0001);;
+      background-color: if($theme-light, #0002, #0001);
     }
   }
 

--- a/ui/analyse/css/_explorer.scss
+++ b/ui/analyse/css/_explorer.scss
@@ -87,7 +87,7 @@
     padding-right: 7px;
   }
 
-  .moves tbody tr:first-of-type {
+  .moves tbody tr:last-of-type:not(:first-of-type) {
     background: mix($c-secondary, $c-bg-box, 20%);
     color: fade-out($c-font, 0.1);
 

--- a/ui/analyse/css/_explorer.scss
+++ b/ui/analyse/css/_explorer.scss
@@ -53,15 +53,19 @@
     }
   }
 
+  table.moves tr:nth-child(odd) {
+    background: $c-bg-zebra;
+  }
+
+  table:not(.moves) tr:nth-child(even) {
+    background: $c-bg-zebra;
+  }
+
   tr {
     @include transition;
 
-    &:nth-child(even) {
-      background: $c-bg-zebra;
-    }
-
     &:hover {
-      background: mix($c-secondary, $c-bg-box, 20%);
+      background: mix($c-secondary, $c-bg-box, 20%) !important;
     }
   }
 
@@ -85,6 +89,31 @@
   .moves td:last-child {
     width: 100%;
     padding-right: 7px;
+  }
+
+  .moves tbody tr:first-of-type {
+    background: mix($c-secondary, $c-bg-box, 20%);
+    color: fade-out($c-font, 0.1);
+    
+    td {
+      line-height: 1.9em;
+      cursor: default;
+    }
+
+    td:last-child {
+      text-align: center;
+    }
+
+    .bar span {
+      background: fade-out($c-bg-box, 0.8);
+      box-shadow: none;
+      border-color: fade-out($c-font, 0.8);
+      color: inherit;
+    }
+
+    .white, .draws {
+      border-right-width: 1px;
+    }
   }
 
   .bar span {

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -56,7 +56,7 @@ function moveTableAttributes(ctrl: AnalyseCtrl, fen: Fen) {
           const uci = $(e.target as HTMLElement)
             .parents('tr')
             .attr('data-uci');
-          if (uci) ctrl.explorerMove(uci);
+          if (uci && uci !== 'Current Position') ctrl.explorerMove(uci);
         });
       },
       postpatch(old: VNode) {

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -84,7 +84,7 @@ function showMoveTable(ctrl: AnalyseCtrl, data: OpeningData): VNode | null {
       san: 'All',
     };
 
-    movesWithCurrent = [currentStats, ...data.moves];
+    movesWithCurrent = [...data.moves, currentStats];
   }
 
   return h('table.moves', [

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -81,7 +81,7 @@ function showMoveTable(ctrl: AnalyseCtrl, data: OpeningData): VNode | null {
       draws: data.draws!,
       averageRating: data.averageRating!,
       uci: 'Current Position',
-      san: 'Current',
+      san: 'All',
     };
 
     movesWithCurrent = [currentStats, ...data.moves];

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -74,7 +74,7 @@ function showMoveTable(ctrl: AnalyseCtrl, data: OpeningData): VNode | null {
   const trans = ctrl.trans.noarg;
   let movesWithCurrent: OpeningMoveStats[] = [...data.moves];
 
-  if ([data.white, data.black, data.draws, data.averageRating].every(el => el !== undefined)) {
+  if (data.moves.length > 1 && [data.white, data.black, data.draws, data.averageRating].every(el => el !== undefined)) {
     const currentStats: OpeningMoveStats = {
       white: data.white!,
       black: data.black!,


### PR DESCRIPTION
![Comparison between old and new explorer style](https://user-images.githubusercontent.com/7917791/129339495-b9122c1e-eee9-42e9-85a6-39a94299957d.png)

This is my proposal for a clearer presentation of the opening explorer's awesome new feature.

- Color the background, reduce text contrast, and reduce the row height to associate it more closely with the table header.
- Dim and flatten the White / Draw / Black bar as if it were a disabled button.

Our brains like to gravitate towards the first element of a list, so I wanted to reestablish the top move as the first element of its group of visually similar elements. That helps users click on what they want to click on. The Current/All row still looks similar enough to the others that it's clear what it represents.

- Change "Current" to "All" following lichess.org/@/InfiniteFlash's suggestion. I think this fits better with the other cells in the column. "All" represents all the moves that have been played from this position, whereas "Current" refers to a move played from the _previous_ position. So in a context where rows represent moves from this position, not moves from the last position, "All" feels less out of place.
- Additionally, "All" has connotations of combination/addition, and the user can see that it combines all the games listed in the subsequent rows.

And then a couple miscellaneous changes:

- Show the default cursor instead of a pointer on hover to make it clear that this row isn't clickable.
- Avoid throwing an exception when clicking on the non-clickable row.

Here's what it looks like with an opening listed and in light mode:

<img width="411" alt="New explorer in light mode" src="https://user-images.githubusercontent.com/7917791/129344597-d9a4acab-0a59-443d-b261-884b8cb51888.png">

(Link to [my previous mockup](https://lichess.org/forum/lichess-feedback/opening-explorer-current-suggestion#2) on the forums for completeness)
