### PR TITLE
Fix clearing insights filters

### DIFF
--- a/ui/insight/src/filters.ts
+++ b/ui/insight/src/filters.ts
@@ -1,4 +1,4 @@
-import { h, VNode } from 'snabbdom';
+import { h } from 'snabbdom';
 import Ctrl from './ctrl';
 import { Dimension } from './interfaces';
 
@@ -6,28 +6,26 @@ function select(ctrl: Ctrl) {
   return function (dimension: Dimension) {
     if (dimension.key === 'date') return;
     const single = dimension.key === 'period';
-    function multipleSelect(vnode: VNode) {
-      $(vnode.elm).multipleSelect({
-        placeholder: dimension.name,
-        width: '100%',
-        selectAll: false,
-        filter: dimension.key === 'opening',
-        single: single,
-        minimumCountSelected: 10,
-        onClick: function (view) {
-          const values = single ? [view.value] : $(vnode.elm).multipleSelect('getSelects');
-          ctrl.setFilter(dimension.key, values);
-        },
-      });
-    }
     return h(
       'select',
       {
         attrs: { multiple: true },
         hook: {
-          insert: multipleSelect,
-          update: (_oldVnode, vnode) => {
-            if (!ctrl.vm.filters[dimension.key]) multipleSelect(vnode);
+          insert: vnode =>
+            $(vnode.elm).multipleSelect({
+              placeholder: dimension.name,
+              width: '100%',
+              selectAll: false,
+              filter: dimension.key === 'opening',
+              single: single,
+              minimumCountSelected: 10,
+              onClick: function (view) {
+                const values = single ? [view.value] : $(vnode.elm).multipleSelect('getSelects');
+                ctrl.setFilter(dimension.key, values);
+              },
+            }),
+          postpatch: (_oldVnode, vnode) => {
+            if (Object.keys(ctrl.vm.filters).length === 0) $(vnode.elm).multipleSelect('uncheckAll');
           },
         },
       },
@@ -38,7 +36,7 @@ function select(ctrl: Ctrl) {
           {
             attrs: {
               value: value.key,
-              selected: selected && selected.includes(value.key),
+              selected: !!selected && selected.includes(value.key),
             },
           },
           value.name


### PR DESCRIPTION
> Another minor issue I've come across is the clear button on filters. It shows the correct insight upon clearing but the filter itself still says 12 of 14 selected with variant filtering for example.

Closes #9567. 

- Clear filters by calling `multipleSelect('uncheckAll')` instead of reinitializing multipleSelect.
- Only clear filters when `ctrl.vm.filters` is `{}`, which only happens after clicking on the clear button. They used to get cleared on every redraw if a dimension had no active filters. This fixes an issue where deselecting the final checkbox of a dimension recreated the list of checkboxes and made them disappear from underneath your mouse. It also saves a bit of computation.
- Set `selected` to false instead of undefined. This fixes an edge case where all checkboxes of a dimension would get selected after clicking on clear.