### PR TITLE
fixing issue where material imbalance is displayed on the opposite side when a study chapter's orientation is set as black.

### DIFF
--- a/modules/tournament/src/main/ColorHistory.scala
+++ b/modules/tournament/src/main/ColorHistory.scala
@@ -7,7 +7,7 @@ import lila.memo.CacheApi
 
 // positive strike -> user played straight strike games by white pieces
 // negative strike -> black pieces
-private case class ColorHistory(strike: Int, balance: Int) extends Ordered[ColorHistory] {
+case class ColorHistory(strike: Int, balance: Int) extends Ordered[ColorHistory] {
 
   override def compare(that: ColorHistory): Int = {
     if (strike < that.strike) -1

--- a/ui/analyse/src/view.ts
+++ b/ui/analyse/src/view.ts
@@ -320,7 +320,7 @@ export function renderMaterialDiffs(ctrl: AnalyseCtrl): [VNode, VNode] {
 
   return materialView.renderMaterialDiffs(
     true, // showCaptured
-    ctrl.flipped,
+    ctrl.getOrientation() === 'black' ? !ctrl.flipped : ctrl.flipped,
     ctrl.data.player,
     ctrl.data.opponent,
     pieces,

--- a/ui/analyse/src/view.ts
+++ b/ui/analyse/src/view.ts
@@ -320,7 +320,7 @@ export function renderMaterialDiffs(ctrl: AnalyseCtrl): [VNode, VNode] {
 
   return materialView.renderMaterialDiffs(
     true, // showCaptured
-    ctrl.getOrientation() === 'black' ? true : false,
+    ctrl.getOrientation() === 'black',
     ctrl.data.player,
     ctrl.data.opponent,
     pieces,

--- a/ui/analyse/src/view.ts
+++ b/ui/analyse/src/view.ts
@@ -320,7 +320,7 @@ export function renderMaterialDiffs(ctrl: AnalyseCtrl): [VNode, VNode] {
 
   return materialView.renderMaterialDiffs(
     true, // showCaptured
-    ctrl.getOrientation() === 'black' ? !ctrl.flipped : ctrl.flipped,
+    ctrl.getOrientation() === 'black' ? true : false,
     ctrl.data.player,
     ctrl.data.opponent,
     pieces,


### PR DESCRIPTION
Fixing issue with commit https://github.com/ornicar/lila/pull/9481/commits/1b1d0964488feaa6fb01c18602b8ac248ae6bb21 where material imbalance is displayed on the opposite side when a study chapter's orientation is set as black.