### PR TITLE
Study: Fix shape indicator in moveview

### DIFF
--- a/ui/analyse/src/moveView.ts
+++ b/ui/analyse/src/moveView.ts
@@ -34,7 +34,7 @@ export function renderMove(ctx: Ctx, node: Tree.Node): VNode[] {
   const ev = cevalView.getBestEval({ client: node.ceval, server: node.eval });
   const nodes = [h('san', fixCrazySan(node.san!))];
   if (node.glyphs && ctx.showGlyphs) node.glyphs.forEach(g => nodes.push(renderGlyph(g)));
-  if (node.shapes) nodes.push(h('shapes'));
+  if (node.shapes && node.shapes.length) nodes.push(h('shapes'));
   if (ev && ctx.showEval) {
     if (defined(ev.cp)) nodes.push(renderEval(normalizeEval(ev.cp)));
     else if (defined(ev.mate)) nodes.push(renderEval('#' + ev.mate));

--- a/ui/analyse/src/moveView.ts
+++ b/ui/analyse/src/moveView.ts
@@ -34,7 +34,7 @@ export function renderMove(ctx: Ctx, node: Tree.Node): VNode[] {
   const ev = cevalView.getBestEval({ client: node.ceval, server: node.eval });
   const nodes = [h('san', fixCrazySan(node.san!))];
   if (node.glyphs && ctx.showGlyphs) node.glyphs.forEach(g => nodes.push(renderGlyph(g)));
-  if (node.shapes && node.shapes.length) nodes.push(h('shapes'));
+  if (node.shapes?.length) nodes.push(h('shapes'));
   if (ev && ctx.showEval) {
     if (defined(ev.cp)) nodes.push(renderEval(normalizeEval(ev.cp)));
     else if (defined(ev.mate)) nodes.push(renderEval('#' + ev.mate));

--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -522,7 +522,7 @@ export default function (
         who = d.w;
       setMemberActive(who);
       if (d.p.chapterId !== vm.chapterId) return;
-      if (who && who.s === lichess.sri) return;
+      if (who && who.s === lichess.sri) return redraw(); // update shape indicator in column move view
       ctrl.tree.setShapes(d.s, ctrl.path);
       if (ctrl.path === position.path) ctrl.withCg(cg => cg.setShapes(d.s));
       redraw();


### PR DESCRIPTION
Indicator not showing immediately but only afters when going to another move, and deleting the shape would not remove the indicator until page reload.
before
![study_shape_bug](https://user-images.githubusercontent.com/56031107/129450971-2ae38730-21e0-4783-8f8b-b72a3d6cf1b1.gif)
after
![study_shape_bug_fixed](https://user-images.githubusercontent.com/56031107/129450964-61561bb4-a08c-43dd-86b5-d1729a34d2e8.gif)
Didn't find a way to only redraw the move column, or a better place for `redraw`