### PR TITLE
Fix study .box__top alignment

### DIFF
--- a/ui/analyse/css/study/_index.scss
+++ b/ui/analyse/css/study/_index.scss
@@ -5,7 +5,9 @@ $top-height: 3.2rem;
 
 .study-index {
   .box__top {
-    @extend %flex-center;
+    @extend %flex-wrap;
+
+    align-items: start;
 
     /* flex gutters, waiting for row-gap to be implemented for flexbox.  https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items#Creating_gutters_between_items */
     margin: 0 0 -1em -1em;


### PR DESCRIPTION
In https://lichess.org/study:

![Comparison between misalignment on master and correction on localhost](https://user-images.githubusercontent.com/7917791/129477931-1e063f23-01d4-4ca8-bb1f-5ec0c021126e.gif)

There's some weirdness in the height calculation + inconsistent centering that's causing this misalignment. As it so happens, removing the [flex gutter hack](https://github.com/ornicar/lila/blob/011adde3659561f4fb41b6fc68fe52c0d7b05d2b/ui/analyse/css/study/_index.scss#L10) (370417/lila@ec4ffbd4300dbe58950402980e37b3cba8262865) corrects the misaligment by fixing the height calculation of `.box__top`. But support for column-gap isn't that comfortably widespread yet ([caniuse](https://caniuse.com/mdn-css_properties_column-gap_flex_context)), notably missing one third of iOS users and missing Chrome ten-versions-ago and Firefox 61/62. So this PR is an alternate little fix using `align-items: start`.