### PR TITLE
Study: fix chapter number when importing multiple chapters at once.

### DIFF
--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -51,7 +51,7 @@ export function ctrl(
   setTab: () => void,
   root: AnalyseCtrl
 ): StudyChapterNewFormCtrl {
-  const multiPgnMax = 20;
+  const multiPgnMax = 32;
 
   const vm = {
     variants: [],


### PR DESCRIPTION
before
<img width="297" alt="Screenshot 2021-08-14 at 17 47 46" src="https://user-images.githubusercontent.com/56031107/129486390-971e6bdc-3b4c-4140-aa14-a0b6580a9337.png">
after
<img width="298" alt="Screenshot 2021-08-15 at 18 50 19" src="https://user-images.githubusercontent.com/56031107/129486393-7ba0f2a1-6cc3-47b4-b4ad-2a4fded61b8d.png">


The underlying issue was an offset in all chapters `order` created when creating the first chapter of a study.

When a study is created it's populated with an empty (`initial` in the codebase) chapter, but it's hidden by the UI which shows to the user the form to create the first one. When doing so, the `initial` one is removed. However the `order` of the user-created chapter was computed before erasing the initial one, resulting in an offset.