### PR TITLE
Show material difference in analysis even when there are no clocks

### DIFF
--- a/ui/analyse/css/_analyse.base.scss
+++ b/ui/analyse/css/_analyse.base.scss
@@ -17,5 +17,6 @@
 @import 'fork';
 @import 'side';
 @import 'context-menu';
+@import 'player-clock';
 
 // @import 'side-clock';

--- a/ui/analyse/css/_analyse.round.scss
+++ b/ui/analyse/css/_analyse.round.scss
@@ -3,4 +3,3 @@
 @import 'retro';
 @import 'acpl';
 @import 'round-underboard';
-@import 'player-clock';

--- a/ui/analyse/css/_layout.scss
+++ b/ui/analyse/css/_layout.scss
@@ -96,7 +96,7 @@ body {
     }
 
     &__underboard {
-      margin-top: $block-gap;
+      margin-top: 1.5 * $block-gap;
     }
 
     .eval-gauge {

--- a/ui/analyse/src/view.ts
+++ b/ui/analyse/src/view.ts
@@ -336,11 +336,8 @@ function renderPlayerStrip(cls: string, materialDiff: VNode, clock?: VNode): VNo
 function renderPlayerStrips(ctrl: AnalyseCtrl): [VNode, VNode] | undefined {
   if (ctrl.embed) return;
 
-  const clocks = renderClocks(ctrl);
-
-  if (!clocks) return;
-
-  const whitePov = ctrl.bottomIsWhite(),
+  const clocks = renderClocks(ctrl),
+    whitePov = ctrl.bottomIsWhite(),
     materialDiffs = renderMaterialDiffs(ctrl);
 
   return [


### PR DESCRIPTION
Since #9481 the material difference is shown in analysis mode. However, when there are no clocks, the material difference disappears. This is unfortunate as there is no material difference as soon as you move a way from the mainline.

This PR simply reverts 18633dde5a81a63fd871fc12529ebac4aedff129 which disables material difference when there are no clocks. This seems to work perfectly but since I don't understand the purpose of that commit, I might be missing something.