### PR TITLE
Center reactions

### DIFF
--- a/ui/site/css/forum/_reactions.scss
+++ b/ui/site/css/forum/_reactions.scss
@@ -52,6 +52,10 @@
   button.yes {
     order: 0;
     opacity: 1;
+
+    img {
+      margin-right: 0.4em;
+    }
   }
 
   img {
@@ -59,6 +63,5 @@
     height: 20px;
     transition: transform 0.15s cubic-bezier(0.2, 0, 0.13, 2);
     pointer-events: none;
-    margin-right: 0.4em;
   }
 }


### PR DESCRIPTION
On the forum, reaction images have a right-margin intended to separate them from the number of reactors. When no one has reacted, this margin throws the reaction image off-center, so this PR hides the margin when it is not needed.

Before/after:

<img width="144" alt="Screen Shot 2021-08-16 at 2 05 19 PM" src="https://user-images.githubusercontent.com/7917791/129629446-05eb554b-276e-48c0-9555-3bf721d0f5af.png">
<img width="119" alt="Screen Shot 2021-08-16 at 2 05 29 PM" src="https://user-images.githubusercontent.com/7917791/129629454-5bcae2cb-8968-4113-866f-c2e5f5699834.png">
