### PR TITLE
Make the interface of renderMaterialDiffs less error-prone

### DIFF
--- a/ui/analyse/src/view.ts
+++ b/ui/analyse/src/view.ts
@@ -320,10 +320,9 @@ export function renderMaterialDiffs(ctrl: AnalyseCtrl): [VNode, VNode] {
 
   return materialView.renderMaterialDiffs(
     true, // showCaptured
-    ctrl.getOrientation() === 'black',
-    ctrl.data.player,
-    ctrl.data.opponent,
+    ctrl.bottomColor(),
     pieces,
+    !!(ctrl.data.player.checks || ctrl.data.opponent.checks), // showChecks
     ctrl.nodeList,
     ctrl.node.ply
   );

--- a/ui/game/src/view/material.ts
+++ b/ui/game/src/view/material.ts
@@ -1,7 +1,8 @@
 import * as cg from 'chessground/types';
 import { h, VNode } from 'snabbdom';
-import { CheckCount, CheckState, MaterialDiff, MaterialDiffSide, Player } from '../interfaces';
+import { CheckCount, CheckState, MaterialDiff, MaterialDiffSide } from '../interfaces';
 import { countChecks, getMaterialDiff, getScore, NO_CHECKS } from '../material';
+import { opposite } from 'chessground/util';
 
 function renderMaterialDiff(
   material: MaterialDiffSide,
@@ -30,16 +31,12 @@ const EMPTY_MATERIAL_DIFF: MaterialDiff = {
 
 export function renderMaterialDiffs(
   showCaptured: boolean,
-  flip: boolean,
-  player: Player,
-  opponent: Player,
+  bottomColor: Color,
   pieces: cg.Pieces,
+  showChecks: boolean,
   checkStates: CheckState[],
   ply: Ply
 ): [VNode, VNode] {
-  const topColor = (flip ? player : opponent).color;
-  const bottomColor = (flip ? opponent : player).color;
-
   let material: MaterialDiff,
     score = 0;
   if (showCaptured) {
@@ -47,7 +44,8 @@ export function renderMaterialDiffs(
     score = getScore(pieces) * (bottomColor === 'white' ? 1 : -1);
   } else material = EMPTY_MATERIAL_DIFF;
 
-  const checks: CheckCount = player.checks || opponent.checks ? countChecks(checkStates, ply) : NO_CHECKS;
+  const checks: CheckCount = showChecks ? countChecks(checkStates, ply) : NO_CHECKS;
+  const topColor = opposite(bottomColor);
 
   return [
     renderMaterialDiff(material[topColor], -score, 'top', checks[topColor]),

--- a/ui/round/src/view/main.ts
+++ b/ui/round/src/view/main.ts
@@ -6,7 +6,7 @@ import { h, VNode } from 'snabbdom';
 import { plyStep } from '../round';
 import { read as readFen } from 'chessground/fen';
 import { render as keyboardMove } from '../keyboardMove';
-import { render as renderGround } from '../ground';
+import { render as renderGround, boardOrientation } from '../ground';
 import { renderTable } from './table';
 import { renderMaterialDiffs } from 'game/view/material';
 
@@ -27,10 +27,9 @@ export function main(ctrl: RoundController): VNode {
     pieces = cgState ? cgState.pieces : readFen(plyStep(ctrl.data, ctrl.ply).fen),
     materialDiffs = renderMaterialDiffs(
       ctrl.data.pref.showCaptured,
-      ctrl.flip,
-      ctrl.data.player,
-      ctrl.data.opponent,
+      boardOrientation(ctrl.data, ctrl.flip),
       pieces,
+      !!(ctrl.data.player.checks || ctrl.data.opponent), // showChecks
       ctrl.data.steps,
       ctrl.ply
     );

--- a/ui/round/src/view/main.ts
+++ b/ui/round/src/view/main.ts
@@ -29,7 +29,7 @@ export function main(ctrl: RoundController): VNode {
       ctrl.data.pref.showCaptured,
       boardOrientation(ctrl.data, ctrl.flip),
       pieces,
-      !!(ctrl.data.player.checks || ctrl.data.opponent), // showChecks
+      !!(ctrl.data.player.checks || ctrl.data.opponent.checks), // showChecks
       ctrl.data.steps,
       ctrl.ply
     );


### PR DESCRIPTION
Recently, there have been a few bugs that rendered the material difference on the wrong side of the board. For example, in #9573 the material diff was on the wrong side in studies that started from black's orientation. This was fixed in #9583 but this [introduced the same bug for normal analysis boards](https://github.com/ornicar/lila/pull/9583#issuecomment-900275310).

The interface of `renderMaterialDiffs` was rather confusing and error-prone as it had a `flip` argument and it wasn't entirely clear what this was supposed to do with respect to the `player` and `opponent` arguments, especially in the case of studies (what is the interpretation of player and opponent here?).

Since `renderMaterialDiffs` doesn't care about players and flipping but only cares about which color is shown on which side of the board, this commit tries to simplify its interface. `flip`, `player`, and `opponent` are all replaced with s single `bottomColor` argument. An extra argument `showChecks` is added (for three-check) because this information was previously retrieved from the player/opponent arguments.

I verified that this works during games, game analysis, and studies.