### PR TITLE
Center vertically report/timeout icon in chats

### DIFF
--- a/ui/chat/css/_discussion.scss
+++ b/ui/chat/css/_discussion.scss
@@ -75,7 +75,7 @@
       right: 0;
       cursor: pointer;
       margin-right: 3px;
-      padding: 4px 5px;
+      padding: 1px 5px;
       opacity: 0.7;
       color: $c-accent;
 


### PR DESCRIPTION
before:
<img width="687" alt="Screenshot 2021-08-17 at 23 26 49" src="https://user-images.githubusercontent.com/56031107/130357601-60779548-b4b5-4f41-9998-a4e43f50a8d2.png">
<img width="321" alt="image" src="https://user-images.githubusercontent.com/56031107/130357681-14288a3c-07d6-4589-b7d2-733da1231548.png">
after (tested on Safari and FireFox):
<img width="317" alt="Screenshot 2021-08-22 at 15 47 32" src="https://user-images.githubusercontent.com/56031107/130357590-7047aff2-6800-45d8-acb2-a4c3d3f29ec6.png">
<img width="703" alt="Screenshot 2021-08-22 at 15 48 09" src="https://user-images.githubusercontent.com/56031107/130357591-0b05106c-23d1-4b56-8618-26ff7a12085c.png">
