### PR TITLE
fix `edit` button color in forum posts

### DIFF
--- a/ui/site/css/forum/_post.scss
+++ b/ui/site/css/forum/_post.scss
@@ -46,7 +46,8 @@
     &:hover {
       color: $c-bad;
 
-      &.quote {
+      &.quote,
+      &.edit {
         color: $c-primary;
       }
     }


### PR DESCRIPTION
before 
<img width="424" alt="Screenshot 2021-08-22 at 15 54 43" src="https://user-images.githubusercontent.com/56031107/130358344-d696e327-6aba-4407-9963-3ae3967e1b5e.png">
after
<img width="416" alt="Screenshot 2021-08-22 at 16 12 13" src="https://user-images.githubusercontent.com/56031107/130358345-b6c04ddf-64e2-4f59-9baf-efe93b8cc202.png">
