### PR TITLE
Trim spaces when deleting studies

### DIFF
--- a/ui/analyse/src/study/studyForm.ts
+++ b/ui/analyse/src/study/studyForm.ts
@@ -292,7 +292,7 @@ export function view(ctrl: StudyFormCtrl): VNode {
             },
             hook: bindNonPassive(
               'submit',
-              _ => isNew || prompt(ctrl.trans('confirmDeleteStudy', data.name)) === data.name
+              _ => isNew || prompt(ctrl.trans('confirmDeleteStudy', data.name))?.trim() === data.name.trim()
             ),
           },
           [h(emptyRedButton, ctrl.trans.noarg(isNew ? 'cancel' : 'deleteStudy'))]


### PR DESCRIPTION
Someone [on the forums](https://lichess.org/forum/lichess-feedback/i-delete-a-study-but-it-doesnt-work) had trouble deleting a study on their phone but succeeded on their laptop. There's a decent chance the problem had the same root cause as veloce/lichobile#1806, where phones add trailing spaces to words. Trimming the user input accounts for this extra space.

I also call `trim` on the name of the study because javascript's `trim` removes non-breaking spaces but scala's doesn't seem to. Otherwise, a study with leading or trailing nbsps would be impossible to delete unless you rename it first.