### PR TITLE
Fix uniboard max size on vertical screens

### DIFF
--- a/ui/common/css/abstract/_uniboard.scss
+++ b/ui/common/css/abstract/_uniboard.scss
@@ -8,27 +8,38 @@ $mq-col3-uniboard: $mq-x-large;
 /* when the width is appropriate for col1, but landscape prevents it */
 $mq-col2-uniboard-squeeze: $mq-not-small $mq-landscape;
 
-$col3-uniboard-side: minmax(230px, 20vw);
-$col3-uniboard-table: minmax(240px, 400px);
+$col3-uniboard-side-min: 230px;
+$col3-uniboard-side: Minmax(#{$col3-uniboard-side-min}, 20vw);
+$col3-uniboard-table-min: 240px;
+$col3-uniboard-table: Minmax(#{$col3-uniboard-table-min}, 400px);
 $col3-uniboard-controls: 3rem;
 
-$col3-uniboard-min-width: calc(70vmin * var(--board-scale));
-$col3-uniboard-max-width: calc(100vh * var(--board-scale) - #{$site-header-outer-height} - #{$col3-uniboard-controls});
-$col3-uniboard-width: minmax($col3-uniboard-min-width, $col3-uniboard-max-width);
+$col3-uniboard-min-size: 200px;
+$col3-uniboard-max-width: calc(
+  100vw - #{$col3-uniboard-side-min} - #{$block-gap} - var(--gauge-gap, 0) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0)
+);
+$col3-uniboard-max-height: calc(100vh - #{$site-header-outer-height} - #{$col3-uniboard-controls});
+$col3-uniboard-max-size: Min(#{$col3-uniboard-max-width}, #{$col3-uniboard-max-height});
+$col3-uniboard-preferred-size: calc(#{$col3-uniboard-max-size} * var(--board-scale));
+$col3-uniboard-width: Max(#{$col3-uniboard-min-size}, #{$col3-uniboard-preferred-size});
 
-$col3-uniboard-default-scale: 0.9;
+$uniboard-default-scale: 0.9;
 
 // zoom: 85%
-$col3-uniboard-default-min-width: 500px;
-$col3-uniboard-default-max-width: calc(
-  100vh * #{$col3-uniboard-default-scale} - #{$site-header-outer-height} - #{$col3-uniboard-controls}
-);
-$col3-uniboard-default-width: minmax(#{$col3-uniboard-default-min-width}, #{$col3-uniboard-default-max-width});
+$col3-uniboard-default-preferred-size: calc(#{$col3-uniboard-max-size} * #{$uniboard-default-scale});
+$col3-uniboard-default-width: Max(#{$col3-uniboard-min-size}, #{$col3-uniboard-default-preferred-size});
 
 $col2-uniboard-table: $col3-uniboard-table;
 $col2-uniboard-controls: $col3-uniboard-controls;
-$col2-uniboard-width: $col3-uniboard-width;
-$col2-uniboard-default-width: $col3-uniboard-default-width;
+$col2-uniboard-min-size: $col3-uniboard-min-size;
+$col2-uniboard-max-width: calc(100vw - var(--gauge-gap, 0) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0));
+$col2-uniboard-max-height: $col3-uniboard-max-height;
+$col2-uniboard-max-size: Min(#{$col2-uniboard-max-width}, #{$col2-uniboard-max-height});
+$col2-uniboard-preferred-size: calc(#{$col2-uniboard-max-size} * var(--board-scale));
+$col2-uniboard-width: Max(#{$col2-uniboard-min-size}, #{$col2-uniboard-preferred-size});
+
+$col2-uniboard-default-preferred-size: calc(#{$col2-uniboard-max-size} * #{$uniboard-default-scale});
+$col2-uniboard-default-width: Max(#{$col2-uniboard-min-size}, #{$col2-uniboard-default-preferred-size});
 
 $col2-uniboard-squeeze-table: minmax(200px, 240px);
 $col2-uniboard-squeeze-width: minmax(calc(55vmin), calc(100vh - #{$site-header-outer-height} - #{$block-gap}));

--- a/ui/common/css/abstract/_uniboard.scss
+++ b/ui/common/css/abstract/_uniboard.scss
@@ -14,8 +14,11 @@ $col3-uniboard-table-min: 240px;
 $col3-uniboard-table: Minmax(#{$col3-uniboard-table-min}, 400px);
 $col3-uniboard-controls: 3rem;
 
+$scrollbar-width: 20px;
+
 $col3-uniboard-max-width: calc(
-  100vw - #{$col3-uniboard-side-min} - #{$block-gap} - var(--gauge-gap, #{$block-gap}) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0px)
+  100vw - #{$col3-uniboard-side-min} - #{$block-gap} - var(--gauge-gap, #{$block-gap}) - #{$col3-uniboard-table-min} - 2 *
+    var(--main-margin, 0px) - #{$scrollbar-width}
 );
 $col3-uniboard-max-height: calc(100vh - #{$site-header-outer-height} - #{$col3-uniboard-controls});
 $col3-uniboard-max-size: Min(#{$col3-uniboard-max-width}, #{$col3-uniboard-max-height});
@@ -29,7 +32,7 @@ $col3-uniboard-default-width: calc(#{$col3-uniboard-max-size} * #{$uniboard-defa
 $col2-uniboard-table: $col3-uniboard-table;
 $col2-uniboard-controls: $col3-uniboard-controls;
 $col2-uniboard-max-width: calc(
-  100vw - var(--gauge-gap, #{$block-gap}) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0px)
+  100vw - var(--gauge-gap, #{$block-gap}) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0px) - #{$scrollbar-width}
 );
 $col2-uniboard-max-height: $col3-uniboard-max-height;
 $col2-uniboard-max-size: Min(#{$col2-uniboard-max-width}, #{$col2-uniboard-max-height});

--- a/ui/common/css/abstract/_uniboard.scss
+++ b/ui/common/css/abstract/_uniboard.scss
@@ -28,7 +28,9 @@ $col3-uniboard-default-width: calc(#{$col3-uniboard-max-size} * #{$uniboard-defa
 
 $col2-uniboard-table: $col3-uniboard-table;
 $col2-uniboard-controls: $col3-uniboard-controls;
-$col2-uniboard-max-width: calc(100vw - var(--gauge-gap, 0px) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0px));
+$col2-uniboard-max-width: calc(
+  100vw - var(--gauge-gap, 0px) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0px)
+);
 $col2-uniboard-max-height: $col3-uniboard-max-height;
 $col2-uniboard-max-size: Min(#{$col2-uniboard-max-width}, #{$col2-uniboard-max-height});
 $col2-uniboard-width: calc(#{$col2-uniboard-max-size} * var(--board-scale));

--- a/ui/common/css/abstract/_uniboard.scss
+++ b/ui/common/css/abstract/_uniboard.scss
@@ -15,7 +15,7 @@ $col3-uniboard-table: Minmax(#{$col3-uniboard-table-min}, 400px);
 $col3-uniboard-controls: 3rem;
 
 $col3-uniboard-max-width: calc(
-  100vw - #{$col3-uniboard-side-min} - #{$block-gap} - var(--gauge-gap, 0px) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0px)
+  100vw - #{$col3-uniboard-side-min} - #{$block-gap} - var(--gauge-gap, #{$block-gap}) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0px)
 );
 $col3-uniboard-max-height: calc(100vh - #{$site-header-outer-height} - #{$col3-uniboard-controls});
 $col3-uniboard-max-size: Min(#{$col3-uniboard-max-width}, #{$col3-uniboard-max-height});
@@ -29,7 +29,7 @@ $col3-uniboard-default-width: calc(#{$col3-uniboard-max-size} * #{$uniboard-defa
 $col2-uniboard-table: $col3-uniboard-table;
 $col2-uniboard-controls: $col3-uniboard-controls;
 $col2-uniboard-max-width: calc(
-  100vw - var(--gauge-gap, 0px) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0px)
+  100vw - var(--gauge-gap, #{$block-gap}) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0px)
 );
 $col2-uniboard-max-height: $col3-uniboard-max-height;
 $col2-uniboard-max-size: Min(#{$col2-uniboard-max-width}, #{$col2-uniboard-max-height});

--- a/ui/common/css/abstract/_uniboard.scss
+++ b/ui/common/css/abstract/_uniboard.scss
@@ -14,32 +14,26 @@ $col3-uniboard-table-min: 240px;
 $col3-uniboard-table: Minmax(#{$col3-uniboard-table-min}, 400px);
 $col3-uniboard-controls: 3rem;
 
-$col3-uniboard-min-size: 200px;
 $col3-uniboard-max-width: calc(
-  100vw - #{$col3-uniboard-side-min} - #{$block-gap} - var(--gauge-gap, 0) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0)
+  100vw - #{$col3-uniboard-side-min} - #{$block-gap} - var(--gauge-gap, 0px) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0px)
 );
 $col3-uniboard-max-height: calc(100vh - #{$site-header-outer-height} - #{$col3-uniboard-controls});
 $col3-uniboard-max-size: Min(#{$col3-uniboard-max-width}, #{$col3-uniboard-max-height});
-$col3-uniboard-preferred-size: calc(#{$col3-uniboard-max-size} * var(--board-scale));
-$col3-uniboard-width: Max(#{$col3-uniboard-min-size}, #{$col3-uniboard-preferred-size});
+$col3-uniboard-width: calc(#{$col3-uniboard-max-size} * var(--board-scale));
 
 $uniboard-default-scale: 0.9;
 
 // zoom: 85%
-$col3-uniboard-default-preferred-size: calc(#{$col3-uniboard-max-size} * #{$uniboard-default-scale});
-$col3-uniboard-default-width: Max(#{$col3-uniboard-min-size}, #{$col3-uniboard-default-preferred-size});
+$col3-uniboard-default-width: calc(#{$col3-uniboard-max-size} * #{$uniboard-default-scale});
 
 $col2-uniboard-table: $col3-uniboard-table;
 $col2-uniboard-controls: $col3-uniboard-controls;
-$col2-uniboard-min-size: $col3-uniboard-min-size;
-$col2-uniboard-max-width: calc(100vw - var(--gauge-gap, 0) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0));
+$col2-uniboard-max-width: calc(100vw - var(--gauge-gap, 0px) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0px));
 $col2-uniboard-max-height: $col3-uniboard-max-height;
 $col2-uniboard-max-size: Min(#{$col2-uniboard-max-width}, #{$col2-uniboard-max-height});
-$col2-uniboard-preferred-size: calc(#{$col2-uniboard-max-size} * var(--board-scale));
-$col2-uniboard-width: Max(#{$col2-uniboard-min-size}, #{$col2-uniboard-preferred-size});
+$col2-uniboard-width: calc(#{$col2-uniboard-max-size} * var(--board-scale));
 
-$col2-uniboard-default-preferred-size: calc(#{$col2-uniboard-max-size} * #{$uniboard-default-scale});
-$col2-uniboard-default-width: Max(#{$col2-uniboard-min-size}, #{$col2-uniboard-default-preferred-size});
+$col2-uniboard-default-width: calc(#{$col2-uniboard-max-size} * #{$uniboard-default-scale});
 
 $col2-uniboard-squeeze-table: minmax(200px, 240px);
 $col2-uniboard-squeeze-width: minmax(calc(55vmin), calc(100vh - #{$site-header-outer-height} - #{$block-gap}));

--- a/ui/round/css/_app-layout.scss
+++ b/ui/round/css/_app-layout.scss
@@ -110,6 +110,10 @@
     }
   }
 
+  @include breakpoint($mq-col3) {
+    grid-template-columns: $col3-uniboard-width $col3-uniboard-table;
+  }
+
   @include breakpoint($mq-col2-uniboard-squeeze) {
     grid-template-columns: $col2-uniboard-squeeze-width $col2-uniboard-squeeze-table;
     grid-column-gap: #{$block-gap * 3 / 2};


### PR DESCRIPTION
Closes #9522

The idea is pretty simple:

Calculate the maximum available space for the board by calculating the max height (as before) and the max width (100vw - everything left and right of the board if it's as small as possible). The board shouldn't be larger than the smaller of those two. This is our 100% scaling and everything else is just scaled from there. By moving the scaling to the outside, it's not really necessary to have an extra minimum since the scaling is already capped at 30%. Although I guess in theory, an extra minimum could be added.

On most screens (all wide ones) it should look pretty much the same. On 100% scaling it's actually exactly the same but since the scaling is now outside, it's not quite the same on lower scalings.