### PR TITLE
add index to cache collection in mongodb

### DIFF
--- a/bin/mongodb/indexes.js
+++ b/bin/mongodb/indexes.js
@@ -9,3 +9,5 @@ db.simul.createIndex({ hostSeenAt: -1 }, { partialFilterExpression: { status: 10
 db.oauth2_access_token.createIndex({ userId: 1 });
 db.oauth2_access_token.createIndex({ expires: 1 }, { expireAfterSeconds: 0 });
 db.oauth2_authorization.createIndex({ expires: 1 }, { expireAfterSeconds: 0 });
+
+db.cache.createIndex({ e: 1 }, { expireAfterSeconds: 0 });


### PR DESCRIPTION
Adding record to mongodb script to add index for cache collection. Should be useful for new installations of lila as number of features rely on it.