### PR TITLE
Replace games in /games even if they load already finished

### DIFF
--- a/app/views/tv/games.scala
+++ b/app/views/tv/games.scala
@@ -24,7 +24,7 @@ object games {
           side.channels(channel, champions, "/games")
         ),
         div(cls := "page-menu__content now-playing")(
-          povs map { pov => div(views.html.game.mini(pov)) }
+          povs map { views.html.game.mini(_) }
         )
       )
     }

--- a/ui/site/src/tvGames.ts
+++ b/ui/site/src/tvGames.ts
@@ -26,7 +26,7 @@ function requestReplacementGame() {
     xhr
       .json(url.toString())
       .then((data: ReplacementResponse) => {
-        main.find(`.mini-game[href^="/${oldId}"]`).parent().html(data.html);
+        main.find(`.mini-game[href^="/${oldId}"]`).replaceWith(data.html);
         if (data.html.includes('mini-game__result')) onFinish(data.id);
         lichess.contentLoaded();
       })


### PR DESCRIPTION
Related: #9646.

Finished games don't have the data-live attribute on initial load, so I took the game id from the href instead.
I also found out about Cash's `replaceWith`, so there's no need for the wrapper div I was originally using.