### PR TITLE
Wrap modals in divs

### DIFF
--- a/ui/analyse/src/serverSideUnderboard.ts
+++ b/ui/analyse/src/serverSideUnderboard.ts
@@ -138,7 +138,7 @@ export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
     const iframe = '<iframe src="' + url + '?theme=auto&bg=auto"\nwidth=600 height=397 frameborder=0></iframe>';
     modal({
       content: $(
-        '<strong style="font-size:1.5em">' +
+        '<div><strong style="font-size:1.5em">' +
           $(this).html() +
           '</strong><br /><br />' +
           '<pre>' +
@@ -146,7 +146,7 @@ export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
           '</pre><br />' +
           iframe +
           '<br /><br />' +
-          '<a class="text" data-icon="" href="/developers#embed-game">Read more about embedding games</a>'
+          '<a class="text" data-icon="" href="/developers#embed-game">Read more about embedding games</a></div>'
       ),
     });
   });

--- a/ui/cli/src/main.ts
+++ b/ui/cli/src/main.ts
@@ -63,7 +63,7 @@ function help() {
   lichess.loadCssPath('clinput.help');
   modal({
     content: $(
-      '<h3>Commands</h3>' +
+      '<div><h3>Commands</h3>' +
         commandHelp('/tv /follow', ' <user>', 'Watch someone play') +
         commandHelp('/play /challenge /match', ' <user>', 'Challenge someone to play') +
         commandHelp('/light /dark /transp', '', 'Change the background theme') +
@@ -72,7 +72,8 @@ function help() {
         commandHelp('s', '', 'Search for a user') +
         commandHelp('/', '', 'Type a command') +
         commandHelp('c', '', 'Focus the chat input') +
-        commandHelp('esc', '', 'Close modals like this one')
+        commandHelp('esc', '', 'Close modals like this one') +
+        '</div>'
     ),
     class: 'clinput-help',
   });

--- a/ui/round/src/socket.ts
+++ b/ui/round/src/socket.ts
@@ -155,8 +155,8 @@ export function make(send: SocketSend, ctrl: RoundController): RoundSocket {
       lichess.loadCssPath('modal');
       modal({
         content: $(
-          '<p>Simul complete!</p><br /><br />' +
-            `<a class="button" href="/simul/${simul.id}">Back to ${simul.name} simul</a>`
+          '<div><p>Simul complete!</p><br /><br />' +
+            `<a class="button" href="/simul/${simul.id}">Back to ${simul.name} simul</a></div>`
         ),
       });
     },


### PR DESCRIPTION
The modal CSS expects a wrapper div for scrolling purposes:
https://github.com/ornicar/lila/blob/c6554780966e39ff117af33c2002f2c7b8565420/ui/common/css/component/_modal.scss#L17-L21

That CSS is currently applied to each `div.command` of the /help modal, which puts padding in the wrong place and makes scolling impossible on small screens.

There are two other modals I found which are missing a wrapper div:
https://github.com/ornicar/lila/blob/master/ui/analyse/src/serverSideUnderboard.ts#L139
https://github.com/ornicar/lila/blob/master/ui/round/src/socket.ts#L156