### PR TITLE
Move all tsc output to dist subdirectories

### DIFF
--- a/ui/build
+++ b/ui/build
@@ -8,7 +8,7 @@ nodever="$(node --version)"
 echo "node: $nodever"
 echo "yarn: $(yarn --version)"
 
-[[ "$nodever" =~ ^v1[2-6]\.[0-9]+\.[0-9]+$ ]] || { echo "Node version >=12 and <=16 required. Found: $nodever"; exit 1; }
+[[ "$nodever" =~ ^(v12\.[2-9][0-9]\.[0-9]+)|(v14\.1[3-9]\.[0-9]+)|(v1[5-6]\.[0-9]+\.[0-9]+)$ ]] || { echo "Node version >=12.20 or >=14.13 and <=16 required. Found: $nodever"; exit 1; }
 
 cd "$(git rev-parse --show-toplevel)"
 

--- a/ui/chess/package.json
+++ b/ui/chess/package.json
@@ -6,6 +6,17 @@
   "type": "module",
   "module": "main.js",
   "types": "main.d.ts",
+  "exports": {
+    ".": "./dist/main.js",
+    "./*": "./dist/*.js"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*"
+      ]
+    }
+  },
   "keywords": [
     "chess",
     "lichess"

--- a/ui/chess/tsconfig.json
+++ b/ui/chess/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["src"],
   "exclude": [],
   "compilerOptions": {
-    "outDir": "."
+    "outDir": "./dist"
   }
 }

--- a/ui/common/package.json
+++ b/ui/common/package.json
@@ -6,6 +6,17 @@
   "module": "common.js",
   "type": "module",
   "typings": "common",
+  "exports": {
+    ".": "./dist/common.js",
+    "./*": "./dist/*.js"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*"
+      ]
+    }
+  },
   "keywords": [
     "chess",
     "lichess"

--- a/ui/common/tsconfig.json
+++ b/ui/common/tsconfig.json
@@ -3,7 +3,7 @@
   "include": ["src"],
   "exclude": [],
   "compilerOptions": {
-    "outDir": ".",
+    "outDir": "./dist",
     "types": ["lichess", "cash", "dom-screen-wake-lock"]
   }
 }

--- a/ui/game/package.json
+++ b/ui/game/package.json
@@ -6,6 +6,17 @@
   "type": "module",
   "module": "game.js",
   "typings": "game.d.ts",
+  "exports": {
+    ".": "./dist/game.js",
+    "./*": "./dist/*.js"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*"
+      ]
+    }
+  },
   "keywords": [
     "chess",
     "lichess",

--- a/ui/game/tsconfig.json
+++ b/ui/game/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["src"],
   "exclude": [],
   "compilerOptions": {
-    "outDir": "."
+    "outDir": "./dist"
   }
 }

--- a/ui/nvui/package.json
+++ b/ui/nvui/package.json
@@ -3,6 +3,16 @@
   "version": "2.0.0",
   "private": true,
   "description": "lichess.org non-visual user interface",
+  "exports": {
+    "./*": "./dist/*.js"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*"
+      ]
+    }
+  },
   "keywords": [
     "chess",
     "lichess",

--- a/ui/nvui/tsconfig.json
+++ b/ui/nvui/tsconfig.json
@@ -3,7 +3,7 @@
   "include": ["src"],
   "exclude": [],
   "compilerOptions": {
-    "outDir": ".",
+    "outDir": "./dist",
     "types": ["lichess", "cash"]
   }
 }

--- a/ui/puz/package.json
+++ b/ui/puz/package.json
@@ -6,6 +6,17 @@
   "type": "module",
   "module": "dist/main.js",
   "types": "dist/main.d.ts",
+  "exports": {
+    ".": "./dist/main.js",
+    "./*": "./dist/*.js"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*"
+      ]
+    }
+  },
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/ui/puz/tsconfig.json
+++ b/ui/puz/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["src"],
   "exclude": [],
   "compilerOptions": {
-    "outDir": "."
+    "outDir": "./dist"
   }
 }

--- a/ui/round/src/view/button.ts
+++ b/ui/round/src/view/button.ts
@@ -37,8 +37,8 @@ function analysisButton(ctrl: RoundController): VNode | null {
 function rematchButtons(ctrl: RoundController): MaybeVNodes {
   const d = ctrl.data,
     me = !!d.player.offeringRematch,
-    them = !!d.opponent.offeringRematch,
     disabled = !me && !(d.opponent.onGame || (!d.clock && d.player.user && d.opponent.user)),
+    them = !!d.opponent.offeringRematch && !disabled,
     noarg = ctrl.noarg;
   return [
     them


### PR DESCRIPTION
To avoid all the clutter from the build output in the module base directories.

Bumps the minimum node version to >=12.20 or >=14.13 because of the export maps (which are what allow moving the output while still allowing rollup to find them correctly without explicitly specifying the `dist` directory in the import) but that hopefully shouldn't be an issue.

The `typeVersions` stuff is a bit weird but that seems to be the only way to get TS to find the stuff for now until it gets proper support for export subpaths.