### PR TITLE
Fix dubious puzzle rating showing differently from no puzzle rating

### DIFF
--- a/app/views/user/show/side.scala
+++ b/app/views/user/show/side.scala
@@ -35,7 +35,7 @@ object side {
         },
         span(
           h3(perfType.trans),
-          if (isPuzzle && u.perfs.dubiousPuzzle && !ctx.is(u)) st.rating("?")
+          if (isPuzzle && u.perfs.dubiousPuzzle && !ctx.is(u)) st.rating(strong("?"))
           else
             st.rating(
               if (perf.glicko.clueless) strong("?")


### PR DESCRIPTION
I'm not sure it was intended that others can see the difference between 'no puzzle rating' and 'dubious puzzle rating', because the former has the question-mark in bold and the latter does not.  This pull request changes both question marks to bold so they look the same.