### PR TITLE
Show user's best perf in rating graph navigator

### DIFF
--- a/app/views/user/perfStat.scala
+++ b/app/views/user/perfStat.scala
@@ -30,7 +30,7 @@ object perfStat {
           frag(
             jsTag("chart/ratingHistory.js"),
             embedJsUnsafeLoadThen(
-              s"lichess.ratingHistoryChart($rc,'${perfType.trans(lila.i18n.defaultLang)}');"
+              s"lichess.ratingHistoryChart($rc,{singlePerfName:'${perfType.trans(lila.i18n.defaultLang)}'});"
             )
           )
         }

--- a/app/views/user/show/page.scala
+++ b/app/views/user/show/page.scala
@@ -11,6 +11,7 @@ import lila.app.ui.ScalatagsTemplate._
 import lila.common.paginator.Paginator
 import lila.game.Game
 import lila.user.User
+import lila.history.RatingChartApi
 
 object page {
 
@@ -84,7 +85,9 @@ object page {
       info.ratingChart.map { ratingChart =>
         frag(
           jsTag("chart/ratingHistory.js"),
-          embedJsUnsafeLoadThen(s"lichess.ratingHistoryChart($ratingChart)")
+          embedJsUnsafeLoadThen(
+            s"lichess.ratingHistoryChart($ratingChart,{perfIndex:${RatingChartApi.bestPerfIndex(info.user)}})"
+          )
         )
       },
       withSearch option jsModule("gameSearch"),

--- a/modules/history/src/main/RatingChartApi.scala
+++ b/modules/history/src/main/RatingChartApi.scala
@@ -43,24 +43,7 @@ final class RatingChartApi(
         historyApi get userId map2 { (history: History) =>
           lila.common.String.html.safeJsonValue {
             Json.toJson {
-              import lila.rating.PerfType._
-              List(
-                Bullet,
-                Blitz,
-                Rapid,
-                Classical,
-                Correspondence,
-                Chess960,
-                KingOfTheHill,
-                ThreeCheck,
-                Antichess,
-                Atomic,
-                Horde,
-                RacingKings,
-                Crazyhouse,
-                Puzzle,
-                UltraBullet
-              ) map { pt =>
+              RatingChartApi.perfTypes map { pt =>
                 Json.obj(
                   "name"   -> pt.trans(lila.i18n.defaultLang),
                   "points" -> ratingsMapToJson(userId, createdAt, history(pt))
@@ -71,4 +54,28 @@ final class RatingChartApi(
         }
       }
     }
+}
+
+object RatingChartApi {
+
+  def bestPerfIndex(user: User): Int = user.bestPerf ?? { perfTypes indexOf _ }
+
+  import lila.rating.PerfType._
+  private val perfTypes = List(
+    Bullet,
+    Blitz,
+    Rapid,
+    Classical,
+    Correspondence,
+    Chess960,
+    KingOfTheHill,
+    ThreeCheck,
+    Antichess,
+    Atomic,
+    Horde,
+    RacingKings,
+    Crazyhouse,
+    Puzzle,
+    UltraBullet
+  )
 }

--- a/modules/user/src/main/User.scala
+++ b/modules/user/src/main/User.scala
@@ -106,6 +106,8 @@ case class User(
 
   def best3Perfs: List[PerfType] = bestOf(User.firstRow, 3)
 
+  def bestPerf: Option[PerfType] = bestOf(User.firstRow ::: User.secondRow, 1) headOption
+
   def hasEstablishedRating(pt: PerfType) = perfs(pt).established
 
   def isPatron = plan.active

--- a/public/javascripts/chart/ratingHistory.js
+++ b/public/javascripts/chart/ratingHistory.js
@@ -1,4 +1,4 @@
-lichess.ratingHistoryChart = function (data, singlePerfName) {
+lichess.ratingHistoryChart = function (data, { singlePerfName, perfIndex }) {
   var oneDay = 86400000;
   function smoothDates(data) {
     if (!data.length) return [];
@@ -95,6 +95,9 @@ lichess.ratingHistoryChart = function (data, singlePerfName) {
             labels: disabled,
             lineWidth: 0,
             tickWidth: 0,
+          },
+          navigator: {
+            baseSeries: perfIndex,
           },
           scrollbar: disabled,
           series: data


### PR DESCRIPTION
The navigator below the rating graph on a user's profile always shows bullet rating history. This PR shows the user's rating history from their most played time control or variant instead. 