### PR TITLE
Prefer ongoing ceval over cloud

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -340,19 +340,26 @@ interface Paginator<A> {
 declare namespace Tree {
   export type Path = string;
 
-  export interface ClientEval {
+  interface ClientEvalBase {
     fen: Fen;
-    maxDepth: number;
     depth: number;
-    knps: number;
     nodes: number;
-    millis: number;
     pvs: PvData[];
-    cloud?: boolean;
     cp?: number;
     mate?: number;
-    retried?: boolean;
   }
+  export interface CloudEval extends ClientEvalBase {
+    cloud: true;
+    maxDepth: undefined;
+    millis: undefined;
+  }
+  export interface LocalEval extends ClientEvalBase {
+    cloud?: false;
+    maxDepth: number;
+    knps: number;
+    millis: number;
+  }
+  export type ClientEval = CloudEval | LocalEval;
 
   export interface ServerEval {
     cp?: number;
@@ -392,7 +399,7 @@ declare namespace Tree {
     dests?: string;
     drops?: string | null;
     check?: Key;
-    threat?: ClientEval;
+    threat?: LocalEval;
     ceval?: ClientEval;
     eval?: ServerEval;
     tbhit?: TablebaseHit | null;

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -598,9 +598,14 @@ export default class AnalyseCtrl {
     this.tree.updateAt(path, (node: Tree.Node) => {
       if (node.fen !== ev.fen && !isThreat) return;
       if (isThreat) {
-        if (!node.threat || isEvalBetter(ev, node.threat) || node.threat.maxDepth < ev.maxDepth) node.threat = ev;
-      } else if (isEvalBetter(ev, node.ceval)) node.ceval = ev;
-      else if (node.ceval && ev.maxDepth > node.ceval.maxDepth) node.ceval.maxDepth = ev.maxDepth;
+        const threat = ev as Tree.LocalEval;
+        if (!node.threat || isEvalBetter(threat, node.threat) || node.threat.maxDepth < threat.maxDepth)
+          node.threat = threat;
+      } else if (!node.ceval || isEvalBetter(ev, node.ceval)) node.ceval = ev;
+      else if (!ev.cloud) {
+        if (node.ceval.cloud && ev.maxDepth > node.ceval.depth) node.ceval = ev;
+        else if (ev.maxDepth > node.ceval.maxDepth!) node.ceval.maxDepth = ev.maxDepth;
+      }
 
       if (path === this.path) {
         this.setAutoShapes();

--- a/ui/analyse/src/practice/practiceCtrl.ts
+++ b/ui/analyse/src/practice/practiceCtrl.ts
@@ -66,7 +66,7 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
   function commentable(node: Tree.Node, bonus = 0): boolean {
     if (node.tbhit || root.outcome(node)) return true;
     const ceval = node.ceval;
-    return ceval ? ceval.depth + bonus >= 15 || (ceval.depth >= 13 && ceval.millis > 3000) : false;
+    return ceval ? ceval.depth + bonus >= 15 || (ceval.depth >= 13 && !ceval.cloud && ceval.millis > 3000) : false;
   }
 
   function playable(node: Tree.Node): boolean {

--- a/ui/analyse/src/retrospect/retroCtrl.ts
+++ b/ui/analyse/src/retrospect/retroCtrl.ts
@@ -143,7 +143,7 @@ export function make(root: AnalyseCtrl, color: Color): RetroCtrl {
   }
 
   function isCevalReady(node: Tree.Node): boolean {
-    return node.ceval ? node.ceval.depth >= 18 || (node.ceval.depth >= 14 && node.ceval.millis > 7000) : false;
+    return node.ceval ? node.ceval.depth >= 18 || (node.ceval.depth >= 14 && (node.ceval.millis ?? 0) > 7000) : false;
   }
 
   function checkCeval(): void {

--- a/ui/ceval/src/util.ts
+++ b/ui/ceval/src/util.ts
@@ -1,5 +1,5 @@
-export function isEvalBetter(a: Tree.ClientEval, b?: Tree.ClientEval): boolean {
-  return !b || a.depth > b.depth || (a.depth === b.depth && a.nodes > b.nodes);
+export function isEvalBetter(a: Tree.ClientEval, b: Tree.ClientEval): boolean {
+  return a.depth > b.depth || (a.depth === b.depth && a.nodes > b.nodes);
 }
 
 export function renderEval(e: number): string {

--- a/ui/ceval/src/view.ts
+++ b/ui/ceval/src/view.ts
@@ -53,7 +53,7 @@ function localEvalInfo(ctrl: ParentCtrl, evs: NodeEvals): Array<VNode | string> 
   return t;
 }
 
-function threatInfo(ctrl: ParentCtrl, threat?: Tree.ClientEval | false): string {
+function threatInfo(ctrl: ParentCtrl, threat?: Tree.LocalEval | false): string {
   if (!threat) return ctrl.trans.noarg('loadingEngine');
   let t = ctrl.trans('depthX', (threat.depth || 0) + '/' + threat.maxDepth);
   if (threat.knps) t += ', ' + Math.round(threat.knps) + ' knodes/s';
@@ -161,7 +161,9 @@ export function renderCeval(ctrl: ParentCtrl): VNode | undefined {
   if (bestEv && typeof bestEv.cp !== 'undefined') {
     pearl = renderEval(bestEv.cp);
     percent = evs.client
-      ? Math.min(100, Math.round((100 * evs.client.depth) / (evs.client.maxDepth || instance.effectiveMaxDepth())))
+      ? evs.client.cloud
+        ? 100
+        : Math.min(100, Math.round((100 * evs.client.depth) / evs.client.maxDepth))
       : 0;
   } else if (bestEv && defined(bestEv.mate)) {
     pearl = '#' + bestEv.mate;

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -331,8 +331,10 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
       emit: function (ev, work) {
         tree.updateAt(work.path, function (node) {
           if (work.threatMode) {
-            if (!node.threat || node.threat.depth <= ev.depth || node.threat.maxDepth < ev.maxDepth) node.threat = ev;
-          } else if (!node.ceval || node.ceval.depth <= ev.depth || node.ceval.maxDepth < ev.maxDepth) node.ceval = ev;
+            const threat = ev as Tree.LocalEval;
+            if (!node.threat || node.threat.depth <= threat.depth || node.threat.maxDepth < threat.maxDepth)
+              node.threat = threat;
+          } else if (!node.ceval || node.ceval.depth <= ev.depth || node.ceval.maxDepth! < ev.maxDepth!) node.ceval = ev;
           if (work.path === vm.path) {
             setAutoShapes();
             redraw();


### PR DESCRIPTION
As discussed on Discord, it's strange to have a ceval going on without being able to see anything. Since there isn't really space to nicely show both the cloud eval depth and the ongoing work, preferring the local eval if it's ongoing seems to be the best option.

This now prefers incoming local evals over cloud evals if the local eval has a higher max depth than the cloud eval has actual depth. This should only happen when the user asked to go deeper than the cloud eval or in the rare case that the cloud eval's depth is so low that the initial local eval isn't stopped, in which case it should quickly catch up anyway.

Coincidentally, this also means users are now able to disregard cloud evaluations in case they are faulty (e.g. due to #9715) or have an overrated depth due to improvements between SF versions.