### PR TITLE
study: Fix comments focus behavior

### DIFF
--- a/ui/analyse/css/study/panel/_comment.scss
+++ b/ui/analyse/css/study/panel/_comment.scss
@@ -3,6 +3,10 @@
     margin: 1em 0;
   }
 
+  .goto-current {
+    float: right;
+  }
+
   #comment-text {
     @extend %box-shadow;
 

--- a/ui/analyse/src/study/studyComments.ts
+++ b/ui/analyse/src/study/studyComments.ts
@@ -63,21 +63,6 @@ export function currentComments(ctrl: AnalyseCtrl, includingMine: boolean): VNod
               ),
             })
           : null,
-        isMine && study.vm.mode.write
-          ? h('a.edit', {
-              attrs: {
-                'data-icon': '',
-                title: 'Edit',
-              },
-              hook: bind(
-                'click',
-                _ => {
-                  study.commentForm.start(chapter.id, ctrl.path, node);
-                },
-                ctrl.redraw
-              ),
-            })
-          : null,
         authorDom(by),
         ...(node.san ? [' on ', h('span.node', nodeFullName(node))] : []),
         ': ',

--- a/ui/common/css/component/_button.scss
+++ b/ui/common/css/component/_button.scss
@@ -58,6 +58,18 @@
     }
   }
 
+  &-link {
+    @extend %button-none;
+
+    color: $c-link;
+
+    &:hover,
+    &:active,
+    &:focus {
+      color: $c-link-hover;
+    }
+  }
+
   &.button-empty {
     transition: none;
 


### PR DESCRIPTION
Fixes #9718
Closes #9599 

The comment box now consistently gains focus when pressing `d` and keeps that focus when switching to another move, except when making a move on the board (unlike currently, where the focus is kept through some navigation, e.g. scrolling and clicking the arrow buttons, but not through clicking on a move in the table).

There's also a new `X` button to immediately start editing the comment for the current move when the comment for another move is shown.