### PR TITLE
Fix zoom input range

### DIFF
--- a/ui/dasher/src/board.ts
+++ b/ui/dasher/src/board.ts
@@ -87,8 +87,8 @@ export function view(ctrl: BoardCtrl): VNode {
             h('input.range', {
               attrs: {
                 type: 'range',
-                min: 100,
-                max: 200,
+                min: 0,
+                max: 100,
                 step: 1,
                 value: ctrl.readZoom(),
               },


### PR DESCRIPTION
After #9675, zoom is represented in the range [0, 100] instead of [100, 200].
Reported [in the forums](https://lichess.org/forum/lichess-feedback/resizing-board#4).