### PR TITLE
ui/gulp: Induce non-zero exit status when sass build fails

### DIFF
--- a/ui/gulpfile.js
+++ b/ui/gulpfile.js
@@ -1,5 +1,6 @@
 const gulp = require('gulp');
 const sass = require('gulp-sass')(require('node-sass'));
+const PluginError = require('plugin-error');
 const sourcemaps = require('gulp-sourcemaps');
 const autoprefixer = require('gulp-autoprefixer');
 const sassInheritance = require('gulp-sass-inheritance');
@@ -31,18 +32,21 @@ const build = () =>
     //filter out internal imports (folders and files starting with "_" )
     .pipe(filter(file => !/\/_/.test(file.path) || !/^_/.test(file.relative)))
     .pipe(sourcemaps.init())
-    .pipe(sass(sassOptions).on('error', sass.logError))
+    .pipe(
+      sass(sassOptions).on('error', err => {
+        throw new PluginError('sass', err.messageFormatted, { showProperties: false });
+      })
+    )
     .pipe(sourcemaps.write())
     .pipe(renameAs('dev'))
     .pipe(destination());
 
-const setWatching = async () => {
+const startWatching = () => {
   global.isWatching = true;
+  gulp.watch(sourcesGlob, { ignoreInitial: false }, build);
 };
 
-const startWatching = () => gulp.watch(sourcesGlob, build);
-
-gulp.task('css', gulp.series([createThemedBuilds, setWatching, build, startWatching]));
+gulp.task('css', gulp.series([createThemedBuilds, startWatching]));
 
 gulp.task('css-dev', gulp.series([createThemedBuilds, build]));
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,7 +22,8 @@
     "gulp-sass-inheritance": "^1.1",
     "breakpoint-sass": "^2.7.1",
     "gulp-size": "^4.0.1",
-    "gulp-sourcemaps": "^3.0.0"
+    "gulp-sourcemaps": "^3.0.0",
+    "plugin-error": "^1.0.1"
   },
   "scripts": {
     "gulp": "gulp"


### PR DESCRIPTION
Closes #7190

This seems to be the best way to keep nicely formatted error messages, don't abort watching but still cause the tasks to actually fail for the non-zero exit code.

`plugin-error` is already a dependency of `gulp-sass` (and probably more) so not really an extra dependency.