### PR TITLE
Fix sbed-sbed communication

### DIFF
--- a/modules/msg/src/main/MsgSecurity.scala
+++ b/modules/msg/src/main/MsgSecurity.scala
@@ -119,7 +119,7 @@ final private class MsgSecurity(
       spam.detect(text) ?? fuccess(Spam.some)
 
     private def isTroll(contacts: User.Contacts): Fu[Option[Verdict]] =
-      (contacts.orig.isTroll && !contacts.dest.isTroll) ?? fuccess(Troll.some)
+      contacts.orig.isTroll ?? fuccess(Troll.some)
 
     private def isDirt(user: User.Contact, text: String, isNew: Boolean): Fu[Option[Verdict]] =
       (isNew && Analyser(text).dirty) ??


### PR DESCRIPTION
Private messages communication between shadow-banned users was still possible (received notifications, messages weren't hidden in inbox).