### PR TITLE
Update TypeScript to 4.4 and use `@types/web` instead of TS provided `dom` lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@typescript-eslint/parser": "^4.29.2",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.1.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "xml2js": "0.4.23"
   },
   "devDependencies": {
+    "@types/web": "=0.0.32",
     "@typescript-eslint/eslint-plugin": "^4.29.2",
     "@typescript-eslint/parser": "^4.29.2",
     "eslint": "^7.32.0",

--- a/ui/@build/rollupProject/package.json
+++ b/ui/@build/rollupProject/package.json
@@ -13,6 +13,6 @@
     "rollup": "^2.56.2",
     "rollup-plugin-terser": "^7.0.2",
     "tslib": "^2.3.1",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   }
 }

--- a/ui/@build/rollupProject/package.json
+++ b/ui/@build/rollupProject/package.json
@@ -10,6 +10,7 @@
     "@rollup/plugin-commonjs": "^20.0.0",
     "@rollup/plugin-node-resolve": "^13.0.4",
     "@rollup/plugin-typescript": "^8.2.5",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "rollup-plugin-terser": "^7.0.2",
     "tslib": "^2.3.1",

--- a/ui/analyse/package.json
+++ b/ui/analyse/package.json
@@ -18,6 +18,7 @@
     "@types/debounce-promise": "^3.1.4",
     "@types/highcharts": "=4.2.57",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "@types/yaireo__tagify": "^4.7",
     "highcharts": "=4.2.5",
     "prop-types": "^15.7.2",

--- a/ui/analyse/package.json
+++ b/ui/analyse/package.json
@@ -22,7 +22,7 @@
     "highcharts": "=4.2.5",
     "prop-types": "^15.7.2",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "@badrap/result": "^0.2",

--- a/ui/ceval/package.json
+++ b/ui/ceval/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "chessops": "^0.10.0",

--- a/ui/ceval/package.json
+++ b/ui/ceval/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "typescript": "^4.4.3"
   },
   "dependencies": {

--- a/ui/ceval/tsconfig.json
+++ b/ui/ceval/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["src"],
   "compilerOptions": {
     "outDir": "./dist",
-    "types": ["lichess", "cash"]
+    "types": ["lichess", "web", "cash"]
   }
 }

--- a/ui/challenge/package.json
+++ b/ui/challenge/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/challenge/package.json
+++ b/ui/challenge/package.json
@@ -13,7 +13,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "dev": "rollup --config",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -22,6 +22,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   }

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -23,6 +23,6 @@
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   }
 }

--- a/ui/chat/tsconfig.json
+++ b/ui/chat/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["src"],
   "compilerOptions": {
     "outDir": "./dist",
-    "types": ["lichess", "cash"]
+    "types": ["lichess", "web", "cash"]
   }
 }

--- a/ui/chess/package.json
+++ b/ui/chess/package.json
@@ -35,6 +35,6 @@
   },
   "devDependencies": {
     "@types/lichess": "2.0.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   }
 }

--- a/ui/chess/package.json
+++ b/ui/chess/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "typescript": "^4.4.3"
   }
 }

--- a/ui/cli/package.json
+++ b/ui/cli/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/cli/package.json
+++ b/ui/cli/package.json
@@ -12,7 +12,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "dev": "rollup --config",

--- a/ui/common/package.json
+++ b/ui/common/package.json
@@ -36,6 +36,7 @@
     "@types/cash": "8.0.0",
     "@types/dom-screen-wake-lock": "1.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "typescript": "^4.4.3"
   }
 }

--- a/ui/common/package.json
+++ b/ui/common/package.json
@@ -36,6 +36,6 @@
     "@types/cash": "8.0.0",
     "@types/dom-screen-wake-lock": "1.0.0",
     "@types/lichess": "2.0.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   }
 }

--- a/ui/common/tsconfig.json
+++ b/ui/common/tsconfig.json
@@ -4,6 +4,6 @@
   "exclude": [],
   "compilerOptions": {
     "outDir": "./dist",
-    "types": ["lichess", "cash", "dom-screen-wake-lock"]
+    "types": ["lichess", "web", "cash", "dom-screen-wake-lock"]
   }
 }

--- a/ui/dasher/package.json
+++ b/ui/dasher/package.json
@@ -14,7 +14,7 @@
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "dev": "rollup --config",

--- a/ui/dasher/package.json
+++ b/ui/dasher/package.json
@@ -13,6 +13,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/dasher/tsconfig.json
+++ b/ui/dasher/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "types": ["lichess", "cash"]
+    "types": ["lichess", "web", "cash"]
   }
 }

--- a/ui/dgt/package.json
+++ b/ui/dgt/package.json
@@ -9,7 +9,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "chessops": "^0.10.0"

--- a/ui/dgt/package.json
+++ b/ui/dgt/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/dgt/src/play.ts
+++ b/ui/dgt/src/play.ts
@@ -48,7 +48,7 @@ export default function (token: string) {
       console.warn('JSON Object for Speech Keywords seems incomplete. Using English default.');
     }
   } catch (error) {
-    console.error('Invalid JSON Object for Speech Keywords. Using English default. ' + Error(error).message);
+    console.error('Invalid JSON Object for Speech Keywords. Using English default. ' + error);
   }
 
   //Lichess Integration with Board API
@@ -250,7 +250,7 @@ export default function (token: string) {
                 connectToGameStream(data.game.id);
               } catch (error) {
                 //This will trigger if connectToGameStream fails
-                console.error('connectToEventStream - Failed to connect to game stream. ' + Error(error).message);
+                console.error('connectToEventStream - Failed to connect to game stream. ' + error);
               }
             } else if (data.type == 'challenge') {
               //Challenge received
@@ -262,7 +262,7 @@ export default function (token: string) {
               console.warn('connectToEventStream - ' + data.error);
             }
           } catch (error) {
-            console.error('connectToEventStream - Unable to parse JSON or Unexpected error. ' + Error(error).message);
+            console.error('connectToEventStream - Unable to parse JSON or Unexpected error. ' + error);
           }
         } else {
           //Signal that some empty message arrived. This is normal to keep the connection alive.
@@ -374,7 +374,7 @@ export default function (token: string) {
               console.log('connectToGameStream - ' + data.error);
             }
           } catch (error) {
-            console.error('connectToGameStream - No valid game data or Unexpected error. ' + Error(error).message);
+            console.error('connectToGameStream - No valid game data or Unexpected error. ' + error);
           }
         } else {
           //Signal that some empty message arrived
@@ -540,7 +540,7 @@ export default function (token: string) {
       if (verbose) console.log(board(chess.board));
       if (verbose) console.log(chess.turn + "'s turn");
     } catch (error) {
-      console.error(`initializeChessBoard - Error: ${error.message}`);
+      console.error(`initializeChessBoard - Error: ${error}`);
     }
   }
 
@@ -593,7 +593,7 @@ export default function (token: string) {
         if (verbose) console.log(chess.turn + "'s turn");
       }
     } catch (error) {
-      console.error(`updateChessBoard - Error: ${error.message}`);
+      console.error(`updateChessBoard - Error: ${error}`);
     }
   }
 
@@ -1137,7 +1137,7 @@ export default function (token: string) {
       try {
         extendedSanMove = extendedSanMove.replace(keywordsBase[i], ' ' + keywords[keywordsBase[i]].toLowerCase() + ' ');
       } catch (error) {
-        console.error(`raplaceKeywords - Error replacing keyword. ${keywordsBase[i]} . ${Error(error).message}`);
+        console.error(`raplaceKeywords - Error replacing keyword. ${keywordsBase[i]} . ${error}`);
       }
     }
     return extendedSanMove;
@@ -1215,7 +1215,7 @@ export default function (token: string) {
         }
       }
     } catch (err) {
-      console.warn('compareMoves - ' + Error(err).message);
+      console.warn('compareMoves - ' + err);
     }
     return false;
   }

--- a/ui/editor/package.json
+++ b/ui/editor/package.json
@@ -15,7 +15,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "chessground": "^8.1.7",

--- a/ui/editor/package.json
+++ b/ui/editor/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/game/package.json
+++ b/ui/game/package.json
@@ -36,6 +36,6 @@
   },
   "devDependencies": {
     "@types/lichess": "2.0.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   }
 }

--- a/ui/game/package.json
+++ b/ui/game/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "typescript": "^4.4.3"
   }
 }

--- a/ui/insight/package.json
+++ b/ui/insight/package.json
@@ -18,6 +18,7 @@
     "@types/cash": "8.0.0",
     "@types/highcharts": "=4.2.57",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "highcharts": "=4.2.5",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"

--- a/ui/insight/package.json
+++ b/ui/insight/package.json
@@ -20,7 +20,7 @@
     "@types/lichess": "2.0.0",
     "highcharts": "=4.2.5",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "common": "2.0.0",

--- a/ui/insight/tsconfig.json
+++ b/ui/insight/tsconfig.json
@@ -5,6 +5,6 @@
     "paths": {
       "numeral": ["./@types/numeral"]
     },
-    "types": ["lichess", "cash"]
+    "types": ["lichess", "web", "cash"]
   }
 }

--- a/ui/learn/package.json
+++ b/ui/learn/package.json
@@ -17,7 +17,7 @@
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "@types/chess.js": "=0.10.1",

--- a/ui/learn/package.json
+++ b/ui/learn/package.json
@@ -16,6 +16,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/learn/tsconfig.json
+++ b/ui/learn/tsconfig.json
@@ -5,7 +5,7 @@
     "paths": {
       "chessground": ["@types/chessground"]
     },
-    "types": ["lichess", "cash"]
+    "types": ["lichess", "web", "cash"]
   },
   "extends": "../tsconfig.base.json"
 }

--- a/ui/lobby/package.json
+++ b/ui/lobby/package.json
@@ -17,6 +17,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/debounce-promise": "^3.1.4",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/lobby/package.json
+++ b/ui/lobby/package.json
@@ -18,7 +18,7 @@
     "@types/debounce-promise": "^3.1.4",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "chessground": "^8.1.7",

--- a/ui/msg/package.json
+++ b/ui/msg/package.json
@@ -9,6 +9,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/msg/package.json
+++ b/ui/msg/package.json
@@ -10,7 +10,7 @@
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "common": "2.0.0",

--- a/ui/msg/tsconfig.json
+++ b/ui/msg/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "types": ["lichess", "cash"]
+    "types": ["lichess", "web", "cash"]
   }
 }

--- a/ui/notify/package.json
+++ b/ui/notify/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/notify/package.json
+++ b/ui/notify/package.json
@@ -13,7 +13,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "dev": "rollup --config",

--- a/ui/nvui/package.json
+++ b/ui/nvui/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "chess": "2.0.0",

--- a/ui/nvui/package.json
+++ b/ui/nvui/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "typescript": "^4.4.3"
   },
   "dependencies": {

--- a/ui/nvui/tsconfig.json
+++ b/ui/nvui/tsconfig.json
@@ -4,6 +4,6 @@
   "exclude": [],
   "compilerOptions": {
     "outDir": "./dist",
-    "types": ["lichess", "cash"]
+    "types": ["lichess", "web", "cash"]
   }
 }

--- a/ui/palantir/package.json
+++ b/ui/palantir/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/palantir/package.json
+++ b/ui/palantir/package.json
@@ -17,7 +17,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "@types/webrtc": "^0.0.27",

--- a/ui/puz/package.json
+++ b/ui/puz/package.json
@@ -32,6 +32,6 @@
   },
   "devDependencies": {
     "@types/lichess": "2.0.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   }
 }

--- a/ui/puz/package.json
+++ b/ui/puz/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "typescript": "^4.4.3"
   }
 }

--- a/ui/puzzle/package.json
+++ b/ui/puzzle/package.json
@@ -16,6 +16,7 @@
     "@types/cash": "8.0.0",
     "@types/chart.js": "^2.9.29",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/puzzle/package.json
+++ b/ui/puzzle/package.json
@@ -17,7 +17,7 @@
     "@types/chart.js": "^2.9.29",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "ceval": "2.0.0",

--- a/ui/puzzle/tsconfig.json
+++ b/ui/puzzle/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "types": ["lichess", "cash"]
+    "types": ["lichess", "web", "cash"]
   }
 }

--- a/ui/racer/package.json
+++ b/ui/racer/package.json
@@ -15,6 +15,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/racer/package.json
+++ b/ui/racer/package.json
@@ -16,7 +16,7 @@
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "chess": "2.0.0",

--- a/ui/racer/tsconfig.json
+++ b/ui/racer/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "types": ["lichess", "cash"]
+    "types": ["lichess", "web", "cash"]
   }
 }

--- a/ui/round/package.json
+++ b/ui/round/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/round/package.json
+++ b/ui/round/package.json
@@ -15,7 +15,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "ab": "https://github.com/lichess-org/ab-stub",

--- a/ui/serviceWorker/package.json
+++ b/ui/serviceWorker/package.json
@@ -9,7 +9,7 @@
     "@build/rollupProject": "2.0.0",
     "rollup": "^2.56.2",
     "types-serviceworker": "^0.0.1",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "dev": "rollup --config",

--- a/ui/simul/package.json
+++ b/ui/simul/package.json
@@ -14,7 +14,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "chat": "2.0.0",

--- a/ui/simul/package.json
+++ b/ui/simul/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/site/package.json
+++ b/ui/site/package.json
@@ -11,6 +11,7 @@
     "@types/debounce-promise": "^3.1.4",
     "@types/fnando__sparkline": "^0.3.2",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "@types/yaireo__tagify": "^4.7",
     "@types/zxcvbn": "^4.4.0",
     "chessground": "^8.1.7",

--- a/ui/site/package.json
+++ b/ui/site/package.json
@@ -16,7 +16,7 @@
     "chessground": "^8.1.7",
     "rollup": "^2.56.2",
     "rollup-plugin-copy": "^3.3.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "@fnando/sparkline": "^0.3.10",

--- a/ui/site/src/component/functions.ts
+++ b/ui/site/src/component/functions.ts
@@ -1,11 +1,3 @@
-// TODO: Remove this when TypeScript 4.4.3 gets released
-//       TS 4.4 introduced support for requestIdleCallback but 4.4.2 hangs rollup
-declare global {
-  interface Window {
-    requestIdleCallback(callback: () => void, options?: { timeout: number }): void;
-  }
-}
-
 export const requestIdleCallback = (f: () => void, timeout?: number) => {
   if (window.requestIdleCallback) window.requestIdleCallback(f, timeout ? { timeout } : undefined);
   else requestAnimationFrame(f);

--- a/ui/site/src/component/socket.ts
+++ b/ui/site/src/component/socket.ts
@@ -162,7 +162,7 @@ export default class StrongSocket {
       let stack: string;
       try {
         stack = new Error().stack!.split('\n').join(' / ').replace(/\s+/g, ' ');
-      } catch (e) {
+      } catch (e: any) {
         stack = `${e.message} ${navigator.userAgent}`;
       }
       if (!stack.includes('round.nvui')) setTimeout(() => this.send('rep', { n: `soc: ${message} ${stack}` }), 10000);
@@ -257,7 +257,7 @@ export default class StrongSocket {
     }
   };
 
-  debug = (msg: string, always = false) => {
+  debug = (msg: unknown, always = false) => {
     if (always || this.options.debug) console.debug(msg);
   };
 
@@ -278,7 +278,7 @@ export default class StrongSocket {
     }
   };
 
-  onError = (e: Event) => {
+  onError = (e: unknown) => {
     this.options.debug = true;
     this.debug('error: ' + JSON.stringify(e));
     this.tryOtherUrl = true;

--- a/ui/site/src/site.ts
+++ b/ui/site/src/site.ts
@@ -137,7 +137,7 @@ lichess.load.then(() => {
       }, 1000);
 
     // prevent zoom when keyboard shows on iOS
-    if (/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream) {
+    if (/iPad|iPhone|iPod/.test(navigator.userAgent) && 'MSStream' in window) {
       const el = document.querySelector('meta[name=viewport]') as HTMLElement;
       el.setAttribute('content', el.getAttribute('content') + ',maximum-scale=1.0');
     }

--- a/ui/speech/package.json
+++ b/ui/speech/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/speech/package.json
+++ b/ui/speech/package.json
@@ -16,7 +16,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "dev": "rollup --config",

--- a/ui/storm/package.json
+++ b/ui/storm/package.json
@@ -15,6 +15,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/storm/package.json
+++ b/ui/storm/package.json
@@ -16,7 +16,7 @@
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "chess": "2.0.0",

--- a/ui/storm/tsconfig.json
+++ b/ui/storm/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "types": ["lichess", "cash"]
+    "types": ["lichess", "web", "cash"]
   }
 }

--- a/ui/swiss/package.json
+++ b/ui/swiss/package.json
@@ -16,7 +16,7 @@
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "chat": "2.0.0",

--- a/ui/swiss/package.json
+++ b/ui/swiss/package.json
@@ -15,6 +15,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/cash": "8.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/swiss/tsconfig.json
+++ b/ui/swiss/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "types": ["lichess", "cash"]
+    "types": ["lichess", "web", "cash"]
   }
 }

--- a/ui/tournament/package.json
+++ b/ui/tournament/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/tournament/package.json
+++ b/ui/tournament/package.json
@@ -15,7 +15,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "chat": "2.0.0",

--- a/ui/tournamentCalendar/package.json
+++ b/ui/tournamentCalendar/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/tournamentCalendar/package.json
+++ b/ui/tournamentCalendar/package.json
@@ -15,7 +15,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "common": "2.0.0",

--- a/ui/tournamentSchedule/package.json
+++ b/ui/tournamentSchedule/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "rollup": "^2.56.2",
     "typescript": "^4.4.3"
   },

--- a/ui/tournamentSchedule/package.json
+++ b/ui/tournamentSchedule/package.json
@@ -15,7 +15,7 @@
     "@build/rollupProject": "2.0.0",
     "@types/lichess": "2.0.0",
     "rollup": "^2.56.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "common": "2.0.0",

--- a/ui/tree/package.json
+++ b/ui/tree/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/lichess": "2.0.0",
+    "@types/web": "=0.0.32",
     "typescript": "^4.4.3"
   },
   "dependencies": {

--- a/ui/tree/package.json
+++ b/ui/tree/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/lichess": "2.0.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "common": "2.0.0"

--- a/ui/tsconfig.base.json
+++ b/ui/tsconfig.base.json
@@ -10,7 +10,7 @@
     "moduleResolution": "node",
     "target": "ES2017",
     "module": "esnext",
-    "lib": ["DOM", "ES2017", "DOM.iterable"],
-    "types": ["lichess"]
+    "lib": ["ES2017"],
+    "types": ["lichess", "web"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -287,6 +287,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
   integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
+"@types/web@=0.0.32":
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/@types/web/-/web-0.0.32.tgz#f0fd2a26f49719fe999a6a7edc7a37d13b288bec"
+  integrity sha512-P6r3FT1Ta4ClRVQylpanWN25tYn9fVb68b1eA2thEr5CxjxKJBZMCMXy+di+p3cHVZ0xiqKKLE2cr6iKdgDY2w==
+
 "@types/webrtc@^0.0.27":
   version "0.0.27"
   resolved "https://registry.yarnpkg.com/@types/webrtc/-/webrtc-0.0.27.tgz#cf9118fa0ac54e530f0ee16c45b8e34df70ef47d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5462,10 +5462,10 @@ types-serviceworker@^0.0.1:
   resolved "https://registry.yarnpkg.com/types-serviceworker/-/types-serviceworker-0.0.1.tgz#3d356e176d3b987d2164b34e609c591e67d31f1c"
   integrity sha512-EKO/SZ3AsHEZsqv+bsdlTCz5k955riOksnYGlG6JhVwNTVsPWj/TScTbiNVZ5+mmX8TcEXF0C8aSxUw0jTDpIw==
 
-typescript@^4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
+  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
 
 unc-path-regex@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
`@types/web` is the same as the TS provided `dom` lib (and provided by the same people from the same source) but is independent of the TS version. This allows updating TS and the web types independently of each other.

Though the main reason for switching is that the `dom` lib shipped with the current TS 4.4 version removed too many web interfaces as "deprecated", some of which we used, and it's not clear when it will get updated. `@types/web` provides a much more up-to-date version which already added the ones that were removed by mistake back in.