### PR TITLE
Removing dasher padding to get rid of extra space

### DIFF
--- a/ui/dasher/css/_dasher.scss
+++ b/ui/dasher/css/_dasher.scss
@@ -169,6 +169,7 @@
       flex: 0 0 1em;
       width: 1em;
       margin: 1rem;
+      padding-top: 0;
       writing-mode: bt-lr;
       -webkit-appearance: slider-vertical;
     }

--- a/ui/dasher/css/_dasher.scss
+++ b/ui/dasher/css/_dasher.scss
@@ -170,6 +170,7 @@
       width: 1em;
       margin: 1rem;
       padding-top: 0;
+      padding-bottom:0;
       writing-mode: bt-lr;
       -webkit-appearance: slider-vertical;
     }


### PR DESCRIPTION
Removing the padding-top from the dasher, so that there will be no extra space sticking out in the dasher when the sound is set to full.

### Before: 
Full sound:
![before](https://user-images.githubusercontent.com/39833033/133475204-25adc8fc-82f4-418d-bf22-7628281d97da.PNG)
Mute:
![before_mute](https://user-images.githubusercontent.com/39833033/133478239-07dbe0b3-cbb4-42be-835b-70931348dbe4.PNG)


### After removing the padding top:
Full sound:
![after](https://user-images.githubusercontent.com/39833033/133475282-62536fe9-5340-4eff-9946-334f8641aacf.PNG)
Mute:
![after_mute](https://user-images.githubusercontent.com/39833033/133478310-6ca6448d-0abf-499c-b449-856e535b745f.PNG)

