### PR TITLE
Flatten rating line to today

### DIFF
--- a/public/javascripts/chart/ratingHistory.js
+++ b/public/javascripts/chart/ratingHistory.js
@@ -2,6 +2,14 @@ lichess.ratingHistoryChart = function (data, { singlePerfName, perfIndex }) {
   var oneDay = 86400000;
   function smoothDates(data) {
     if (!data.length) return [];
+    
+    // If last rating wasn't today, add to the array
+    var today = new Date().setUTCHours(0,0,0,0);
+    var lastRating = data[data.length - 1];
+    if (lastRating[0] != today) {
+      data.push([today, lastRating[1]]);
+    }
+
     var begin = data[0][0];
     var end = data[data.length - 1][0];
     var reversed = data.slice().reverse();

--- a/public/javascripts/chart/ratingHistory.js
+++ b/public/javascripts/chart/ratingHistory.js
@@ -4,7 +4,7 @@ lichess.ratingHistoryChart = function (data, { singlePerfName, perfIndex }) {
     if (!data.length) return [];
     
     // If last rating wasn't today, add to the array
-    var today = new Date().setUTCHours(0,0,0,0);
+    var today = new Date().setUTCHours(0, 0, 0, 0);
     var lastRating = data[data.length - 1];
     if (lastRating[0] != today) {
       data.push([today, lastRating[1]]);


### PR DESCRIPTION
Last year we did this one to make a horizontal line in the ratings chart for days with no activity: https://github.com/ornicar/lila/pull/6902

But the end of the ratings chart is whatever day you last played:

<img width="1132" alt="Screen Shot 2021-09-17 at 1 53 02 PM" src="https://user-images.githubusercontent.com/28961086/133852350-fc4f15f2-ea66-4535-ae37-e506073d78fb.png">

In theory the line should end at today. If no activity in three months, it should just be a horizontal line.