### PR TITLE
css: Make .button display: inline-block

### DIFF
--- a/ui/common/css/component/_button.scss
+++ b/ui/common/css/component/_button.scss
@@ -9,6 +9,7 @@
   text-align: center;
   user-select: none;
   white-space: nowrap;
+  display: inline-block;
 
   @include transition;
 


### PR DESCRIPTION
`button` tags are already `inline-block` so this just makes `a` tags consistent with them.

Main reason is to allow proper line-wrapping and avoid overflow on the team edit page (the buttons at the top) and in certain cases also blogs (when viewing as oneself, with the edit button) on slim screens.

I checked some random pages with buttons and I don't think this breaks anything?