### PR TITLE
Add filtering by status to api/user/{username}/tournament/created

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -272,12 +272,12 @@ final class Api(
   def tournamentsByOwner(name: String, status: List[Int]) =
     Action.async { implicit req =>
       implicit val lang = reqLang
-      (name != "lichess") ?? env.user.repo.named(name) flatMap {
+      (name != lila.user.User.lichessId) ?? env.user.repo.named(name) flatMap {
         _ ?? { user =>
           val nb = getInt("nb", req) | Int.MaxValue
           jsonStream {
             env.tournament.api
-              .byOwnerStream(user, status, MaxPerSecond(20), nb)
+              .byOwnerStream(user, status flatMap lila.tournament.Status.apply, MaxPerSecond(20), nb)
               .mapAsync(1)(env.tournament.apiJsonView.fullJson)
           }.fuccess
         }

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -269,7 +269,7 @@ final class Api(
       }
     }
 
-  def tournamentsByOwner(name: String) =
+  def tournamentsByOwner(name: String, status: List[Int]) =
     Action.async { implicit req =>
       implicit val lang = reqLang
       (name != "lichess") ?? env.user.repo.named(name) flatMap {
@@ -277,7 +277,7 @@ final class Api(
           val nb = getInt("nb", req) | Int.MaxValue
           jsonStream {
             env.tournament.api
-              .byOwnerStream(user, MaxPerSecond(20), nb)
+              .byOwnerStream(user, status, MaxPerSecond(20), nb)
               .mapAsync(1)(env.tournament.apiJsonView.fullJson)
           }.fuccess
         }

--- a/bin/mongodb/tournament-lichess.js
+++ b/bin/mongodb/tournament-lichess.js
@@ -1,0 +1,6 @@
+db.tournament2.update({ createdBy: 'lichess' }, { $unset: { createdBy: 1 } }, { multi: 1 });
+db.tournament2.dropIndex('createdBy_1_startsAt_-1');
+db.tournament2.createIndex(
+  { createdBy: 1, startsAt: -1, status: 1 },
+  { partialFilterExpression: { createdBy: { $exists: true } } }
+);

--- a/conf/routes
+++ b/conf/routes
@@ -640,7 +640,7 @@ GET   /api/user/puzzle-activity        controllers.Puzzle.activity
 GET   /api/puzzle/daily                controllers.Puzzle.apiDaily
 GET   /api/puzzle/activity             controllers.Puzzle.activity
 GET   /api/puzzle/dashboard/:days      controllers.Puzzle.apiDashboard(days: Int)
-GET   /api/user/:name/tournament/created controllers.Api.tournamentsByOwner(name: String)
+GET   /api/user/:name/tournament/created controllers.Api.tournamentsByOwner(name: String, status: List[Int])
 GET   /api/user/:name                  controllers.Api.user(name: String)
 GET   /api/user/:name/activity         controllers.Api.activity(name: String)
 POST  /api/user/:name/note             controllers.User.apiWriteNote(name: String)

--- a/modules/tournament/src/main/Status.scala
+++ b/modules/tournament/src/main/Status.scala
@@ -10,7 +10,7 @@ sealed abstract private[tournament] class Status(val id: Int) extends Ordered[St
   def is(f: Status.type => Status): Boolean = is(f(Status))
 }
 
-private[tournament] object Status {
+object Status {
 
   case object Created  extends Status(10)
   case object Started  extends Status(20)

--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -668,9 +668,9 @@ final class TournamentApi(
         }
       }
 
-  def byOwnerStream(owner: User, perSecond: MaxPerSecond, nb: Int): Source[Tournament, _] =
+  def byOwnerStream(owner: User, status: List[Int], perSecond: MaxPerSecond, nb: Int): Source[Tournament, _] =
     tournamentRepo
-      .sortedCursor(owner, perSecond.value)
+      .sortedCursor(owner, status, perSecond.value)
       .documentSource(nb)
       .throttle(perSecond.value, 1 second)
 

--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -668,7 +668,12 @@ final class TournamentApi(
         }
       }
 
-  def byOwnerStream(owner: User, status: List[Int], perSecond: MaxPerSecond, nb: Int): Source[Tournament, _] =
+  def byOwnerStream(
+      owner: User,
+      status: List[Status],
+      perSecond: MaxPerSecond,
+      nb: Int
+  ): Source[Tournament, _] =
     tournamentRepo
       .sortedCursor(owner, status, perSecond.value)
       .documentSource(nb)

--- a/modules/tournament/src/main/TournamentRepo.scala
+++ b/modules/tournament/src/main/TournamentRepo.scala
@@ -389,12 +389,12 @@ final class TournamentRepo(val coll: Coll, playerCollName: CollName)(implicit
 
   private[tournament] def sortedCursor(
       owner: lila.user.User,
-      status: List[Int],
+      status: List[Status],
       batchSize: Int,
       readPreference: ReadPreference = ReadPreference.secondaryPreferred
   ): AkkaStreamCursor[Tournament] =
     coll
-      .find($doc("createdBy" -> owner.id ) ++ ( !status.isEmpty ?? $doc("status" $in status) ))
+      .find($doc("createdBy" -> owner.id) ++ (status.nonEmpty ?? $doc("status" $in status)))
       .sort($sort desc "startsAt")
       .batchSize(batchSize)
       .cursor[Tournament](readPreference)

--- a/modules/tournament/src/main/TournamentRepo.scala
+++ b/modules/tournament/src/main/TournamentRepo.scala
@@ -389,11 +389,12 @@ final class TournamentRepo(val coll: Coll, playerCollName: CollName)(implicit
 
   private[tournament] def sortedCursor(
       owner: lila.user.User,
+      status: List[Int],
       batchSize: Int,
       readPreference: ReadPreference = ReadPreference.secondaryPreferred
   ): AkkaStreamCursor[Tournament] =
     coll
-      .find($doc("createdBy" -> owner.id))
+      .find($doc("createdBy" -> owner.id ) ++ ( !status.isEmpty ?? $doc("status" $in status) ))
       .sort($sort desc "startsAt")
       .batchSize(batchSize)
       .cursor[Tournament](readPreference)


### PR DESCRIPTION
### Rationale

Current API endpoint always returns all tournaments created by a given user - past ("status":30), currently running ("status":20) and future ("status":10)

People who organize tournaments regularly on lichess.org and would like to provide a list of upcoming tournaments on their own web site for participants to join would have to filter out all past tournaments after first receive a huge JSON containing mostly irrelevant records.

This can be especially slow with time once many completed tournaments accumulate and number of past tournaments becomes significantly larger than the regularly organized future tournaments (which at any given moment are somewhat constant). 

Taking into account also the throttling that is happening during generating those JSON results by lichess API, this can significantly cripple performance, resulting in near a minute wait to eventually display ~10 records.

See for example: 
https://iwantzh.github.io/list.html
https://iwantzh.github.io/

I don't believe this use case is unique for above site - in fact some of those lichess users included in above site maintain by hand similar pages on their own chess club websites with a separate lists of future and past tournaments as well, albeit not using the lichess api (at the moment) at least shows that is maybe a common use case.

### Implementation details

Added "status" url parameter, that can be used multiple times for any combination of statuses the api client is interested in. 

For example: 
- `api/user/{username}/tournament/created?status=10&status=20` returns all tournaments by the given user, that have not finished
- `api/user/{username}/tournament/created` works as before, returns all tournaments by the user


For status values, the same numeric constants are used as the ones that can be seen in the resulting JSON's "status" property.

### Remaining work/Open questions:

If this PR is merged, let me know if you want me to also make a PR for the API doc. 
I believe it is here: https://github.com/lichess-org/api/blob/master/doc/specs/lichess-api.yaml