### PR TITLE
Fix dragging 3D piece elevation

### DIFF
--- a/ui/common/css/vendor/chessground/_chessground.scss
+++ b/ui/common/css/vendor/chessground/_chessground.scss
@@ -114,7 +114,7 @@ piece {
 
   &.dragging {
     cursor: move;
-    z-index: z('cg__piece.dragging');
+    z-index: z('cg__piece.dragging') !important;
   }
 
   &.anim {


### PR DESCRIPTION
Currently _dragging z-index_ set in CSS is not applying to 3D pieces cause piece's _z-index_ set as inline style overwrites it. As a result dragging piece might be displayed under other pieces.

https://user-images.githubusercontent.com/66057996/134406773-54b0be2c-8605-4fb8-9c22-c374ec644217.mp4

This could be fixed by adding _!important_ rule to _dragging z-index_ in CSS.

Naturally, it's not the best practice to rely on _!important_ rule, but since _z-index_ for 3D pieces is set as an inline style that is the only option to override it. Other option could be reusing inline styles, i.e., setting _dragging z-index_ on drag start and setting back _normal z-index_ on drag end, but this looks less pragmatic since the same _dragging z-index_ would be defined in both _css_ and _js_ in this case.

I'll also prepare a PR in _chessground_ with similar changes but the PR's will be independent from each other.