### PR TITLE
Tourney Schedule: trunc seconds when fitting tourney bars into lanes

### DIFF
--- a/ui/tournamentSchedule/src/view.ts
+++ b/ui/tournamentSchedule/src/view.ts
@@ -70,9 +70,15 @@ function group(arr: Tournament[], grouper: (t: Tournament) => number): Lane[] {
     });
 }
 
+function truncSeconds(epoch: number): number {
+  return epoch - (epoch % (60*1000));
+}
+
 function fitLane(lane: Lane, tour2: Tournament) {
   return !lane.some(function (tour1: Tournament) {
-    return !(tour1.finishesAt <= tour2.startsAt || tour2.finishesAt <= tour1.startsAt);
+    const r = !(truncSeconds(tour1.finishesAt) <= truncSeconds(tour2.startsAt) || truncSeconds(tour2.finishesAt) <= truncSeconds(tour1.startsAt));
+    if (r) console.log("r=", r, tour1, tour2);
+    return r;
   });
 }
 

--- a/ui/tournamentSchedule/src/view.ts
+++ b/ui/tournamentSchedule/src/view.ts
@@ -71,12 +71,15 @@ function group(arr: Tournament[], grouper: (t: Tournament) => number): Lane[] {
 }
 
 function truncSeconds(epoch: number): number {
-  return epoch - (epoch % (60*1000));
+  return epoch - (epoch % (60 * 1000));
 }
 
 function fitLane(lane: Lane, tour2: Tournament) {
   return !lane.some(function (tour1: Tournament) {
-    return !(truncSeconds(tour1.finishesAt) <= truncSeconds(tour2.startsAt) || truncSeconds(tour2.finishesAt) <= truncSeconds(tour1.startsAt));
+    return !(
+      truncSeconds(tour1.finishesAt) <= truncSeconds(tour2.startsAt) ||
+      truncSeconds(tour2.finishesAt) <= truncSeconds(tour1.startsAt)
+    );
   });
 }
 

--- a/ui/tournamentSchedule/src/view.ts
+++ b/ui/tournamentSchedule/src/view.ts
@@ -76,9 +76,7 @@ function truncSeconds(epoch: number): number {
 
 function fitLane(lane: Lane, tour2: Tournament) {
   return !lane.some(function (tour1: Tournament) {
-    const r = !(truncSeconds(tour1.finishesAt) <= truncSeconds(tour2.startsAt) || truncSeconds(tour2.finishesAt) <= truncSeconds(tour1.startsAt));
-    if (r) console.log("r=", r, tour1, tour2);
-    return r;
+    return !(truncSeconds(tour1.finishesAt) <= truncSeconds(tour2.startsAt) || truncSeconds(tour2.finishesAt) <= truncSeconds(tour1.startsAt));
   });
 }
 


### PR DESCRIPTION
### Rationale

When calculating which bar can or cannot fit on which lane, the logic sometimes discards a bar as unable to fit just because of an overlap in mere seconds, which creates huge gaps in the timeline which however seem unnecessary because overlap is invisible or negligable.

This lichess forum post contains one screenshot showing the problem:

https://lichess.org/forum/team-underground-crazyhouse-hourly-arenas/tournament-timeline-gaps#1

However I am almost sure i have seen this problem happening not only with community organized tourneys, but also with official tournaments when they start/end on a full hour sometimes.

### Technical details

- I've added truncation to a whole minute when comparing the epoch value for start/end of tourneys in the UI logic
- Don't know if an existing util js/ts function or library that does such truncation exists so i have written my own in that same file - let me know if there is something existing that implements this and i will replace it in the code
- Alternatively i was considering getting rid of the source of those (random) seconds, but don't know really. The (or one) source of those is intentional addition of random seconds to prevent some sort of spike of server load on full hours (i guess when most official arenas start). Happens here https://github.com/ornicar/lila/pull/6261 : https://github.com/ornicar/lila/commit/c4342e19ae22b090faecd1649f9d5154c9211b89#diff-42e4cda0c4dac64a147396581ef0805034c6d801be71cd457af194df8b7ae652
- Frankly it is a bit confusing seeing random seconds added to the start time one has picked for the tourney they are creating, but this (the UI fix) was the easiest to implement fix and not even sure exactly what the alternative should be exactly as to still prevent those spikes and keep tourneys at non-randomized start times. 




