### PR TITLE
Bugfix in PlayStreak

### DIFF
--- a/modules/perfStat/src/main/PerfStat.scala
+++ b/modules/perfStat/src/main/PerfStat.scala
@@ -73,8 +73,8 @@ case class PlayStreak(nb: Streaks, time: Streaks, lastDate: Option[DateTime]) {
     pov.game.durationSeconds.fold(this) { seconds =>
       val cont = seconds < 3 * 60 * 60 && isContinued(pov.game.createdAt)
       copy(
-        nb = nb(cont, pov)(1),
-        time = time(cont, pov)(seconds),
+        nb = nb(cont, pov, 1)(1),
+        time = time(cont, pov, seconds)(seconds),
         lastDate = pov.game.movedAt.some
       )
     }
@@ -95,6 +95,10 @@ case class Streaks(cur: Streak, max: Streak) {
     copy(
       cur = cur(cont, pov)(v)
     ).setMax
+  def apply(cont: Boolean, pov: Pov, r: Int)(v: Int) =
+    copy(
+      cur = cur(cont, pov, r)(v)
+    ).setMax
   def reset          = copy(cur = Streak.init)
   private def setMax = copy(max = if (cur.v >= max.v) cur else max)
 }
@@ -102,11 +106,18 @@ object Streaks {
   val init = Streaks(Streak.init, Streak.init)
 }
 case class Streak(v: Int, from: Option[GameAt], to: Option[GameAt]) {
-  def apply(cont: Boolean, pov: Pov)(v: Int) = if (cont) inc(pov, v) else Streak.init
+  def apply(cont: Boolean, pov: Pov)(v: Int)         = if (cont) inc(pov, v) else Streak.init
+  def apply(cont: Boolean, pov: Pov, r: Int)(v: Int) = if (cont) inc(pov, v) else res(pov, r)
   private def inc(pov: Pov, by: Int) =
     copy(
       v = v + by,
       from = from orElse GameAt(pov.game.createdAt, pov.gameId).some,
+      to = GameAt(pov.game.movedAt, pov.gameId).some
+    )
+  private def res(pov: Pov, by: Int) =
+    copy(
+      v = by,
+      from = GameAt(pov.game.createdAt, pov.gameId).some,
       to = GameAt(pov.game.movedAt, pov.gameId).some
     )
   def period = new Period(v * 1000L)


### PR DESCRIPTION
Bug: the first game of a new streak is not counted in the streak,
neither in `games played in a row` nor in `max time spent playing`. Bug
is not present if the game is the first one ever under that time
control.
Step to reproduce: play one rated game using a time control previously
used (e.g. blitz) even though not in the last hour, than go to
`lichess.org/@/<user>/perf/blitz` and note
that both `current streak` at the bottom of the page are still zero.
From the second game the `current streak` of `games played in a row` is
systematically one less than expected, while the other one does not
count the elapsed time of the first game.

Troubleshooting: the bug is due to the call at `Streak.init`
(i.e. `(0, none, none)`) when a game is discontinued from the previous one.
I propose, with this commit, to substitute that call with a new function
inspired by `inc`. This new function is called `res` (from `reset`):
its aim is to set `nb` and `time` dynamically after the first game
of the new streak.