### PR TITLE
Highlight original poster in forum topic

### DIFF
--- a/app/views/forum/post.scala
+++ b/app/views/forum/post.scala
@@ -44,7 +44,10 @@ object post {
     st.article(cls := List("forum-post" -> true, "erased" -> post.erased), id := post.number)(
       div(cls := "forum-post__metas")(
         (!post.erased || canModCateg) option div(
-          authorLink(post = post, cssClass = "author".some),
+          authorLink(
+            post = post,
+            cssClass = s"author${if (topic.userId == post.userId) " author__op" else ""}".some
+          ),
           a(href := url)(
             post.updatedAt
               .map { updatedAt =>

--- a/ui/site/css/forum/_post.scss
+++ b/ui/site/css/forum/_post.scss
@@ -17,6 +17,13 @@
       margin-right: 1rem;
     }
 
+    a.author__op {
+      padding: 0.2em;
+      padding-right: 1em;
+      border-radius: 0.3em;
+      background: mix($c-primary, $c-bg-box, 12%);
+    }
+
     .anchor {
       @extend %break-nope;
 


### PR DESCRIPTION
Resolves #9836 

I've explored a bit how OP's highlighting is implemented in other forums and seems that the most common patterns are showing "OP" badge next to a username or simply highlighting a username (or even the whole post header) with some different background.

My personal feeling is that adding a different background to user link is a better choice than "OP" badge cause even though "OP" is a pretty common phrase in web it still might be misunderstood by non-English speaking users.

I looked it up in other Lichess pages for some suitable pattern/colors in order not to bring something new and found that topic badge design from [Study topics](https://lichess.org/study/topic) might work. Using the same background colors highlights the user link well (but doesn't draw too much attention) and all the parts of the user link (online indicator, title, username) are clearly visible in Light/Dark/Transparent background.

Highlighting is applied only to real user links and isn't to other author "names" like  _\<erased\>_, _Anonimous_ or _A Lichess Moderator_.

|        | Not OP | OP |
| ----- | ---------- | ---- |
| Light | ![light-author-not-op](https://user-images.githubusercontent.com/66057996/134577381-d01c03ae-6ae2-4ded-84e6-ccc431f85a92.png) | ![light-author-op](https://user-images.githubusercontent.com/66057996/134577382-78f5bff9-878a-4418-af22-b331ddceca6c.png)|
| Dark | ![dark-author-not-op](https://user-images.githubusercontent.com/66057996/134577374-3c322586-51b4-4df2-b16d-5716d6bd4efb.png) | ![dark-author-op](https://user-images.githubusercontent.com/66057996/134577380-92da2fa4-6af2-43c2-a8cd-e6aaaaf4f618.png)|
| Transparent | ![transparent-author-not-op](https://user-images.githubusercontent.com/66057996/134577383-2a8a58f1-3261-4cc1-9221-d0e390fee7a8.png) | ![transparent-author-op](https://user-images.githubusercontent.com/66057996/134577385-03297889-6a71-472d-9019-8a24081f84f5.png) |
