### PR TITLE
Call the unescapeUnderscoreInLinks function

### DIFF
--- a/modules/ublog/src/main/UblogMarkup.scala
+++ b/modules/ublog/src/main/UblogMarkup.scala
@@ -30,7 +30,7 @@ final class UblogMarkup(baseUrl: config.BaseUrl, assetBaseUrl: config.AssetBaseU
     unescapeAtUsername.apply andThen
     renderer(s"ublog:${post.id}") andThen
     imageParagraph andThen
-    unescapeAtUsername.apply
+    unescapeUnderscoreInLinks.apply
 
   // replace game GIFs URLs with actual game URLs that can be embedded
   private object replaceGameGifs {


### PR DESCRIPTION
For #9767, `unescapeUnderscoreInLinks` was defined but wasn't being called after 5225485c7bf3386a127148614d7f28e0a1a78007, as `unescapeAtUsername` was called twice instead.