### PR TITLE
Mobile app to show team tournaments

### DIFF
--- a/app/controllers/Tournament.scala
+++ b/app/controllers/Tournament.scala
@@ -57,7 +57,10 @@ final class Tournament(
         api = _ =>
           for {
             (visible, _) <- upcomingCache.getUnit
-            scheduleJson <- env.tournament apiJsonView visible
+            teamIds              <- ctx.userId.??(env.team.cached.teamIdsList)
+            allTeamIds = (env.featuredTeamsSetting.get().value ++ teamIds).distinct
+            teamVisible  <- repo.visibleForTeams(allTeamIds, 5 * 60)
+            scheduleJson <- env.tournament.apiJsonView(visible add teamVisible)
           } yield Ok(scheduleJson)
       )
     }


### PR DESCRIPTION
### Motivation

One of the many ways in which "user organized" tournaments are currently in a disadvantage compared to the "official" lichess arenas is that they are almost impossible to access on mobile app.

This is a source of substantial frustration in lichess players, to the point a workaround has actually been invented and is being communicated mouth-to-mouth about how to join a community arena on mobile app (see private description of lichess.org/team/underground-crazyhouse-hourly-arenas for details of the workaround). 

Goal of this PR is to make this workaround obsolete and make team tournaments visible in mobile app's "Tournaments" screen

### Implementation details

- Scope: This change will affect requests to "/tournament" endpoint when made with "application/vnd.lichess.vXY+json" header.
- As far as I can tell this is only the mobile application but am not familiar enough with the whole thing so just guessing
- Same endpoint when called as part of web browsing includes different set of tournaments (one that includes team tournaments)

I am not sure if changes I am proposing are correct, but I do not see any obvious reason why requests to the same service should differ in their result depending whether it is generating JSON response or building an html page. 

Would be curious to know what the reasons are if it turns out this is intentional behaviour and not a case of omission 