### PR TITLE
Show correct position when timing out before the move reaches the server

### DIFF
--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -533,6 +533,14 @@ export default class RoundController {
     d.game.status = o.status;
     d.game.boosted = o.boosted;
     this.userJump(this.lastPly());
+    // If losing/drawing on time but locally it is the opponent's turn, move did not reach server before the end
+    if (
+      o.status.name === 'outoftime' &&
+      d.player.color !== o.winner &&
+      this.chessground.state.turnColor === d.opponent.color
+    ) {
+      this.reload(d);
+    }
     this.chessground.stop();
     if (o.ratingDiff) {
       d.player.ratingDiff = o.ratingDiff[d.player.color];


### PR DESCRIPTION
Previous behavior kept the board unsynced with the server position, confusing players as to why they lost on time AFTER moving. It wasn't until the expiration of the `TransientMove` that the board would be synced again.

Unlike when premoving I haven't found an easy way to undo the move, hence reloading chessground. I have restricted it to `outoftime` outcome for now, maybe `abort` would make sense too.

Illustration of the initial issue:
<img width="1430" alt="Screenshot 2021-09-24 at 18 18 57 cropped" src="https://user-images.githubusercontent.com/56031107/134743350-5d1c9cb2-fa19-4bf6-aacb-83c018331a8a.png">
