### PR TITLE
Bots cannot like ublogs.

### DIFF
--- a/app/controllers/Ublog.scala
+++ b/app/controllers/Ublog.scala
@@ -156,9 +156,11 @@ final class Ublog(env: Env) extends LilaController(env) {
     }
 
   def like(id: String, v: Boolean) = Auth { implicit ctx => me =>
-    NotForKids {
-      env.ublog.rank.like(UblogPost.Id(id), me, v) map { likes =>
-        Ok(likes.value)
+    NoBot {
+      NotForKids {
+        env.ublog.rank.like(UblogPost.Id(id), me, v) map { likes =>
+          Ok(likes.value)
+        }
       }
     }
   }


### PR DESCRIPTION
For now they can still post blogs, which could be useful to post articles (like maia) on their specifities and/or development.