### PR TITLE
Don't play pv in threat mode

### DIFF
--- a/ui/ceval/src/view.ts
+++ b/ui/ceval/src/view.ts
@@ -355,7 +355,7 @@ export function renderPvs(ctrl: ParentCtrl): VNode | undefined {
           for (const event of ['touchstart', 'mousedown']) {
             el.addEventListener(event, (e: TouchEvent | MouseEvent) => {
               const uciList = getElUciList(e);
-              if (uciList.length > (pvIndex ?? 0)) {
+              if (uciList.length > (pvIndex ?? 0) && !ctrl.threatMode()) {
                 ctrl.playUciList(uciList.slice(0, (pvIndex ?? 0) + 1));
                 e.preventDefault();
               }


### PR DESCRIPTION
Clicking on pvs tries to play moves even in threat mode. This isn't a problem on the analysis board because the server rejects nonsensical moves, but in puzzles, this allows one color to move twice in a row.
Reported [in the forums](https://lichess.org/forum/lichess-feedback/bug-moves-played-within-threat-confuses-whiteblack-notation-in-scorecard).