### PR TITLE
Name study chapter from user-provided value

### DIFF
--- a/modules/study/src/main/ChapterMaker.scala
+++ b/modules/study/src/main/ChapterMaker.scala
@@ -49,7 +49,7 @@ final private class ChapterMaker(
         parsed
           .tags(_.Black)
           .ifTrue {
-            data.name.value.isEmpty || data.isDefaultName
+            data.name.value.isEmpty || Chapter.isDefaultName(data.name)
           }
           .map { black =>
             Chapter.Name(s"$white - $black")


### PR DESCRIPTION
When creating a new study chapter from a PGN, the user-provided name is ignored and replaced by a default string generated from the player names.

In ChapterMaker, I found the 'isDefaultName' _boolean_ is used to verify if the user changed the Name field in the UI. Unfortunately this value is always set to true. 

With this patch, we instead use the 'Chapter.isDefaultName' _function_ to test the condition. The function correctly tests the chapter name against the regex, and the user-provided name is selected when it doesn't match (as verified in my local Lichess mirror).

I suspect that a more comprehensive fix may be to remove the isDefaultName _boolean_ altogether. However, this variable is still being used elsewhere (ChapterMaker.scala:134). As a new contributor, I prefer this more conservative approach.