### PR TITLE
Add hover arrows for mouseover of forks

### DIFF
--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -56,8 +56,14 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
     return [];
   }
   const instance = ctrl.getCeval();
-  const hovering = ctrl.explorer.hovering() || instance.hovering();
   const { eval: nEval = {} as Partial<Tree.ServerEval>, fen: nFen, ceval: nCeval, threat: nThreat } = ctrl.node;
+
+  let hovering = ctrl.explorer.hovering();
+
+  if (!hovering || hovering.fen !== nFen) {
+    ctrl.explorer.hovering(null);
+    hovering = instance.hovering();
+  }
 
   let shapes: DrawShape[] = [],
     badNode;

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -58,12 +58,6 @@ function moveTableAttributes(ctrl: AnalyseCtrl, fen: Fen) {
           if (uci) ctrl.explorerMove(uci);
         });
       },
-      postpatch(old: VNode) {
-        setTimeout(() => {
-          const el = old.elm as HTMLElement;
-          ctrl.explorer.setHovering($(el).attr('data-fen')!, $(el).find('tr:hover').attr('data-uci'));
-        }, 100);
-      },
     },
   };
 }

--- a/ui/analyse/src/fork.ts
+++ b/ui/analyse/src/fork.ts
@@ -53,7 +53,7 @@ export function make(root: AnalyseCtrl): ForkCtrl {
     highlight(it) {
       if (!displayed() || !defined(it)) {
         root.explorer.setHovering(root.node.fen, null);
-        return
+        return;
       }
 
       const nodeUci = root.node.children[it]?.uci;
@@ -65,12 +65,11 @@ export function make(root: AnalyseCtrl): ForkCtrl {
       if (displayed()) {
         it = defined(it) ? it : selected;
 
-        const childNode = root.node.children[it]
+        const childNode = root.node.children[it];
         if (defined(childNode)) {
           root.userJumpIfCan(root.path + childNode.id);
           return true;
         }
-
       }
       return undefined;
     },
@@ -99,7 +98,7 @@ export function view(root: AnalyseCtrl, concealOf?: ConcealOf) {
             it = parseInt(
               (target.parentNode as HTMLElement).getAttribute('data-it') || target.getAttribute('data-it') || ''
             );
-            root.fork.highlight(it);
+          root.fork.highlight(it);
         });
         el.addEventListener('mouseout', _ => {
           root.fork.highlight();

--- a/ui/analyse/src/fork.ts
+++ b/ui/analyse/src/fork.ts
@@ -13,6 +13,7 @@ export interface ForkCtrl {
   };
   next: () => boolean | undefined;
   prev: () => boolean | undefined;
+  highlight: (it?: number) => void;
   proceed: (it?: number) => boolean | undefined;
 }
 
@@ -49,11 +50,27 @@ export function make(root: AnalyseCtrl): ForkCtrl {
       }
       return undefined;
     },
+    highlight(it) {
+      if (!displayed() || !defined(it)) {
+        root.explorer.setHovering(root.node.fen, null);
+        return
+      }
+
+      const nodeUci = root.node.children[it]?.uci;
+      const uci = defined(nodeUci) ? nodeUci : null;
+
+      root.explorer.setHovering(root.node.fen, uci);
+    },
     proceed(it) {
       if (displayed()) {
         it = defined(it) ? it : selected;
-        root.userJumpIfCan(root.path + root.node.children[it].id);
-        return true;
+
+        const childNode = root.node.children[it]
+        if (defined(childNode)) {
+          root.userJumpIfCan(root.path + childNode.id);
+          return true;
+        }
+
       }
       return undefined;
     },
@@ -76,6 +93,16 @@ export function view(root: AnalyseCtrl, concealOf?: ConcealOf) {
             );
           root.fork.proceed(it);
           root.redraw();
+        });
+        el.addEventListener('mouseover', e => {
+          const target = e.target as HTMLElement,
+            it = parseInt(
+              (target.parentNode as HTMLElement).getAttribute('data-it') || target.getAttribute('data-it') || ''
+            );
+            root.fork.highlight(it);
+        });
+        el.addEventListener('mouseout', _ => {
+          root.fork.highlight();
         });
       }),
     },


### PR DESCRIPTION
In the current analysis view, the opening database has a hover functionality.
If you hover over any moves in the opening explorer,
an arrow will appear, showing you that move on the board.


This pull requests implements the same functionality for the fork selection box.
![Fork selection arrow](https://i.imgur.com/Sn2E4Ew.png)

Just a nice-to-have feature that I wanted myself as I'm relatively new to chess and am not yet fast enough at reading moves by name. The arrows make it nicer to browser studies imo.

Potential Issues
==========

The opening explorer effectively made the assumption it was the only tool adding a hover arrow to the board. `postpatch` effectively removed any hovers produced by other tools as a result. Therefore I had to remove this, but it did serve a function, which was to ensure `hovering` was correctly cleared when no longer hovering a move, as you could not rely on "mouseout" to always trigger in cases where you navigate the board in ways other than using the mouse.

I have removed that logic, and instead added new logic, which sets `hovering` to `null` when the `fen` does not match the current board `fen` (i.e. it's an invalid hover). This is done in `autoShape` though, which feels odd, but it's also the location in which the property is actually checked.

As far as I can tell with my own testing, this works fine now. And is actually cleaner than the weird 100ms timeout method used before. 

This is the first time I've done any development on lichess, and it's quite a large project. I don't think there are any side effects here, but let me know if there's other testing I should be doing.
