### PR TITLE
remove default initial fen

### DIFF
--- a/modules/game/src/main/PgnDump.scala
+++ b/modules/game/src/main/PgnDump.scala
@@ -54,9 +54,6 @@ final class PgnDump(
   def player(p: Player, u: Option[LightUser]) =
     p.aiLevel.fold(u.fold(p.name | lila.user.User.anonymous)(_.name))("lichess AI level " + _)
 
-  private val customStartPosition: Set[chess.variant.Variant] =
-    Set(chess.variant.Chess960, chess.variant.FromPosition, chess.variant.Horde, chess.variant.RacingKings)
-
   private def eventOf(game: Game) = {
     val perf = game.perfType.fold("Standard")(_.trans(lila.i18n.defaultLang))
     game.tournamentId.map { id =>
@@ -131,9 +128,9 @@ final class PgnDump(
               }
             }
           ).some
-        ).flatten ::: customStartPosition(game.variant).??(
+        ).flatten ::: initialFen.??(fen =>
           List(
-            Tag(_.FEN, (initialFen | Forsyth.initial).value),
+            Tag(_.FEN, fen),
             Tag("SetUp", "1")
           )
         )

--- a/modules/game/src/main/PgnDump.scala
+++ b/modules/game/src/main/PgnDump.scala
@@ -54,6 +54,9 @@ final class PgnDump(
   def player(p: Player, u: Option[LightUser]) =
     p.aiLevel.fold(u.fold(p.name | lila.user.User.anonymous)(_.name))("lichess AI level " + _)
 
+  private val customStartPosition: Set[chess.variant.Variant] =
+    Set(chess.variant.Chess960, chess.variant.FromPosition, chess.variant.Horde, chess.variant.RacingKings)
+
   private def eventOf(game: Game) = {
     val perf = game.perfType.fold("Standard")(_.trans(lila.i18n.defaultLang))
     game.tournamentId.map { id =>
@@ -128,10 +131,12 @@ final class PgnDump(
               }
             }
           ).some
-        ).flatten ::: initialFen.??(fen =>
-          List(
-            Tag(_.FEN, fen),
-            Tag("SetUp", "1")
+        ).flatten ::: customStartPosition(game.variant).??(
+          initialFen.??(fen =>
+            List(
+              Tag(_.FEN, fen.value),
+              Tag("SetUp", "1")
+            )
           )
         )
       }


### PR DESCRIPTION
closes #9883

The default FEN is not necessary as it can be inferred from the variant.

FEN is anyways fetched for games with custom start position. https://github.com/ornicar/lila/blob/master/modules/game/src/main/GameRepo.scala#L436

Related discussion
https://github.com/ornicar/lila/pull/9899