### PR TITLE
Public chats grid flex fix 

### DIFF
--- a/ui/site/css/mod/_communication.scss
+++ b/ui/site/css/mod/_communication.scss
@@ -43,6 +43,7 @@
 
   .player_chats {
     @extend %break-word;
+    @extend %flex-wrap;
 
     overflow: hidden;
   }


### PR DESCRIPTION
Issue: 
On smaller displays the public-chat page can push tournament chats to the next row rather than always render 3 chats in a row. This happens when 1 of the 3 tournament title texts is longer than the others and wraps to a new line. 

Before 

https://user-images.githubusercontent.com/77537716/135719388-bfc37caf-aa25-4599-a0d0-ab72dcd3b1a5.mov


After

https://user-images.githubusercontent.com/77537716/135719412-33ea9c72-2401-425a-8e55-45ccfd84e055.mov




