### PR TITLE
Fix gap below round board on new Chromium

### DIFF
--- a/ui/round/css/_app-layout.scss
+++ b/ui/round/css/_app-layout.scss
@@ -47,7 +47,7 @@
   display: grid;
 
   @include breakpoint($mq-col1) {
-    grid-template-rows: auto $col1-pocket-height $col1-user-height $col1-mat-height auto $expiration-height $col1-mat-height $col1-user-height $col1-pocket-height;
+    grid-template-rows: auto auto $col1-user-height $col1-mat-height auto auto $col1-mat-height $col1-user-height auto;
     grid-template-areas: 'moves' 'pocket-top' 'user-top' 'mat-top' 'board' 'expi-bot' 'mat-bot' 'user-bot' 'pocket-bot' 'kb-move' 'controls';
 
     // Put clocks and players in the same grid cell.
@@ -78,7 +78,6 @@
 
   @include breakpoint($mq-col2) {
     grid-template-columns: $col2-uniboard-width $col2-uniboard-table;
-    grid-template-rows: 1fr $material-height $clock-height $expiration-height $user-height $moves-height $controls-height $user-height $expiration-height $clock-height $material-height 1fr;
     grid-template-areas: 'board .' 'board mat-top' 'board clock-top' 'board expi-top' 'board user-top' 'board moves' 'board controls' 'board user-bot' 'board expi-bot' 'board clock-bot' 'board mat-bot' 'board .' 'kb-move .';
     grid-column-gap: $block-gap;
 

--- a/ui/round/css/_constants.scss
+++ b/ui/round/css/_constants.scss
@@ -12,12 +12,3 @@ $rmoves-tag: 'rm6';
 $moves-tag: 'l4x';
 $index-tag: 'i5z';
 $active-class: 'a1t';
-
-// app-layout
-$col1-pocket-height: auto;
-$material-height: auto;
-$clock-height: auto;
-$expiration-height: min-content;
-$user-height: auto;
-$moves-height: auto;
-$controls-height: auto;

--- a/ui/round/css/_streamer.scss
+++ b/ui/round/css/_streamer.scss
@@ -5,7 +5,6 @@ $player-height: 30px;
 @include breakpoint($mq-col2-uniboard) {
   .round__app {
     grid-template-columns: $col2-uniboard-width $col2-uniboard-table;
-    grid-template-rows: $player-height 1fr $material-height $expiration-height $moves-height $controls-height $expiration-height $material-height 1fr $player-height;
     grid-template-areas: 'user-top .' 'board .' 'board mat-top' 'board expi-top' 'board moves' 'board controls' 'board expi-bot' 'board mat-bot' 'board .' 'user-bot .' 'kb-move .';
 
     margin-top: -0.5em;


### PR DESCRIPTION
Since that one Chrome update a few weeks ago that broke the chat height as well, there's also a weird gap on round pages between the crosstable and the board.

https://lichess.org/tv/classical is an easy way to see it. In Firefox it looks like before.