### PR TITLE
Public-chat page: remove "simul" channel

### DIFF
--- a/modules/chat/src/main/ChatApi.scala
+++ b/modules/chat/src/main/ChatApi.scala
@@ -163,8 +163,7 @@ final class ChatApi(
           text = data.text,
           busChan = data.chan match {
             case "tournament" => _.Tournament
-            case "swiss"      => _.Swiss
-            case _            => _.Simul
+            case _      => _.Swiss
           }
         )
       }

--- a/modules/chat/src/main/ChatTimeout.scala
+++ b/modules/chat/src/main/ChatTimeout.scala
@@ -100,7 +100,7 @@ object ChatTimeout {
   val form = Form(
     mapping(
       "roomId" -> nonEmptyText,
-      "chan"   -> lila.common.Form.stringIn(Set("tournament", "simul", "swiss")),
+      "chan"   -> lila.common.Form.stringIn(Set("tournament", "swiss")),
       "userId" -> nonEmptyText,
       "reason" -> nonEmptyText,
       "text"   -> nonEmptyText


### PR DESCRIPTION
They were removed from the public-chat page.