### PR TITLE
Render grid lines behind other chart elements

### DIFF
--- a/public/javascripts/chart/ratingDistribution.js
+++ b/public/javascripts/chart/ratingDistribution.js
@@ -85,6 +85,7 @@ lichess.ratingDistributionChart = function (data) {
               rotation: -45,
             },
             gridLineWidth: 1,
+            gridZIndex: -1,
             tickInterval: 100,
             plotLines: (function (v) {
               var right = v > 1800;
@@ -117,6 +118,7 @@ lichess.ratingDistributionChart = function (data) {
               title: {
                 text: trans.noarg('players'),
               },
+              gridZIndex: -1,
             },
             {
               // cumulative


### PR DESCRIPTION
Lower the z index of the x/y gridlines so they don't obscure other chart elements like the "Your rating" line.

Fixes #9926