### PR TITLE
Allow sending translatable announcements from CLI

### DIFF
--- a/app/views/base/layout.scala
+++ b/app/views/base/layout.scala
@@ -183,6 +183,7 @@ object layout {
   private val dataI18n          = attr("data-i18n")
   private val dataNonce         = attr("data-nonce")
   private val dataAnnounce      = attr("data-announce")
+  private val dataAnnounceI18n  = attr("data-announce-i18n")
   val dataSoundSet              = attr("data-sound-set")
   val dataTheme                 = attr("data-theme")
   val dataPieceSet              = attr("data-piece-set")
@@ -277,6 +278,7 @@ object layout {
           dataTheme := ctx.currentBg,
           dataPieceSet := ctx.currentPieceSet.name,
           dataAnnounce := AnnounceStore.get.map(a => safeJsonValue(a.json)),
+          dataAnnounceI18n := safeJsonValue(i18nJsObject(announceI18nKeys)),
           style := zoomable option s"--zoom:${ctx.zoom}"
         )(
           blindModeForm,
@@ -299,7 +301,7 @@ object layout {
           )(body),
           ctx.me.exists(_.enabled) option div(
             id := "friend_box",
-            dataI18n := safeJsonValue(i18nJsObject(i18nKeys))
+            dataI18n := safeJsonValue(i18nJsObject(friendBoxI18nKeys))
           )(
             div(cls := "friend_box_title")(trans.nbFriendsOnline.plural(0, iconTag(""))),
             div(cls := "content_wrap none")(
@@ -389,5 +391,7 @@ object layout {
       )
   }
 
-  private val i18nKeys = List(trans.nbFriendsOnline.key)
+  private val friendBoxI18nKeys = List(trans.nbFriendsOnline.key)
+
+  private val announceI18nKeys = AnnounceStore.predefinedMessageI18Keys.map(_.key)
 }

--- a/app/views/board/bits.scala
+++ b/app/views/board/bits.scala
@@ -38,7 +38,7 @@ object bits {
         "baseUrl"   -> s"$netBaseUrl${routes.Editor.load("")}",
         "animation" -> Json.obj("duration" -> ctx.pref.animationMillis),
         "is3d"      -> ctx.pref.is3d,
-        "i18n"      -> i18nJsObject(i18nKeyes)
+        "i18n"      -> i18nJsObject(i18nKeys)
       )
       .add("fen" -> fen)
 
@@ -48,7 +48,7 @@ object bits {
     "tablebaseEndpoint" -> tablebaseEndpoint
   )
 
-  private val i18nKeyes = List(
+  private val i18nKeys = List(
     trans.setTheBoard,
     trans.boardEditor,
     trans.startPosition,

--- a/app/views/dev.scala
+++ b/app/views/dev.scala
@@ -68,7 +68,8 @@ object dev {
           ),
           h2("Command examples:"),
           pre("""uptime
-announce 10 minutes Lichess will restart!
+announce 10 minutes [restart]
+announce 10 minutes Arbitrary announcement text
 announce cancel
 change asset version
 fishnet client create {username}

--- a/modules/api/src/main/AnnounceStore.scala
+++ b/modules/api/src/main/AnnounceStore.scala
@@ -7,10 +7,19 @@ import scala.concurrent.duration._
 import scala.util.Try
 
 import lila.hub.actorApi.Announce
+import lila.i18n.I18nKeys
 
 object AnnounceStore {
 
   private var current = none[Announce]
+
+  private val predefinedMessageI18nMap = Map(
+    "restart" -> I18nKeys.lichessWillRestart
+  )
+
+  val predefinedMessageKeys = predefinedMessageI18nMap.keys.toList
+
+  val predefinedMessageI18Keys = predefinedMessageI18nMap.values.toList
 
   def get: Option[Announce] = {
     current foreach { c =>
@@ -37,6 +46,26 @@ object AnnounceStore {
           Announce(msg, date, json)
         }.toOption
       case _ => none
+    })
+    get
+  }
+
+  // examples:
+  // msgKey: "restart", durationStr: "5 minutes"
+  def setPredefined(msgKey: String, durationStr: String): Option[Announce] = {
+    set(predefinedMessageI18nMap.get(msgKey) match {
+      case Some(i18nKey) =>
+        Try {
+          val date    = DateTime.now plusSeconds Duration(durationStr).toSeconds.toInt
+          val isoDate = ISODateTimeFormat.dateTime print date
+          val json = Json.obj(
+            "msg"     -> i18nKey.txt()(lila.i18n.defaultLang),
+            "i18nKey" -> i18nKey.key,
+            "date"    -> isoDate
+          )
+          Announce(msgKey, date, json)
+        }.toOption
+      case None => none
     })
     get
   }

--- a/modules/api/src/main/AnnounceStore.scala
+++ b/modules/api/src/main/AnnounceStore.scala
@@ -33,20 +33,17 @@ object AnnounceStore {
   }
 
   // examples:
-  // 5 minutes Lichess will restart
-  // 20 seconds Cthulhu will awake
-  def set(str: String): Option[Announce] = {
-    set(str.split(" ").toList match {
-      case length :: unit :: rest =>
-        Try {
-          val msg     = rest mkString " "
-          val date    = DateTime.now plusSeconds Duration(s"$length $unit").toSeconds.toInt
-          val isoDate = ISODateTimeFormat.dateTime print date
-          val json    = Json.obj("msg" -> msg, "date" -> isoDate)
-          Announce(msg, date, json)
-        }.toOption
-      case _ => none
-    })
+  // msg: "Lichess will restart", durationStr: "5 minutes"
+  // msg: "Cthulhu will awake", durationStr: "20 seconds"
+  def set(msg: String, durationStr: String): Option[Announce] = {
+    set(
+      Try {
+        val date    = DateTime.now plusSeconds Duration(durationStr).toSeconds.toInt
+        val isoDate = ISODateTimeFormat.dateTime print date
+        val json    = Json.obj("msg" -> msg, "date" -> isoDate)
+        Announce(msg, date, json)
+      }.toOption
+    )
     get
   }
 

--- a/modules/api/src/main/Cli.scala
+++ b/modules/api/src/main/Cli.scala
@@ -63,8 +63,8 @@ Available message keys: ${AnnounceStore.predefinedMessageKeys.mkString(", ")}"""
           )
       }
 
-    case "announce" :: msgWords =>
-      AnnounceStore.set(msgWords mkString " ") match {
+    case "announce" :: length :: unit :: msgWords =>
+      AnnounceStore.set(msgWords mkString " ", s"$length $unit") match {
         case Some(announce) =>
           Bus.publish(announce, "announce")
           fuccess(announce.json.toString)

--- a/modules/api/src/main/Cli.scala
+++ b/modules/api/src/main/Cli.scala
@@ -50,6 +50,19 @@ final private[api] class Cli(
       AnnounceStore set none
       Bus.publish(AnnounceStore.cancel, "announce")
       fuccess("Removed announce")
+
+    case "announce" :: length :: unit :: s"[${msgKey}]" :: Nil =>
+      AnnounceStore.setPredefined(msgKey, s"$length $unit") match {
+        case Some(announce) =>
+          Bus.publish(announce, "announce")
+          fuccess(announce.json.toString)
+        case None =>
+          fuccess(
+            s"""Invalid announce. Format: `announce <length> <unit> [<msgKey>]` or just `announce cancel` to cancel it
+Available message keys: ${AnnounceStore.predefinedMessageKeys.mkString(", ")}"""
+          )
+      }
+
     case "announce" :: msgWords =>
       AnnounceStore.set(msgWords mkString " ") match {
         case Some(announce) =>

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -765,6 +765,7 @@ val `availableInNbLanguages` = new I18nKey("availableInNbLanguages")
 val `nbSecondsToPlayTheFirstMove` = new I18nKey("nbSecondsToPlayTheFirstMove")
 val `nbSeconds` = new I18nKey("nbSeconds")
 val `andSaveNbPremoveLines` = new I18nKey("andSaveNbPremoveLines")
+val `lichessWillRestart` = new I18nKey("lichessWillRestart")
 
 object arena {
 val `arenaTournaments` = new I18nKey("arena:arenaTournaments")

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -885,4 +885,5 @@ Leave empty to start games from the normal initial position.</string>
   <string name="abortTheGame">Abort the game</string>
   <string name="resignTheGame">Resign the game</string>
   <string name="youCantStartNewGame">You can't start a new game until this one is finished.</string>
+  <string name="lichessWillRestart">Lichess will restart</string>
 </resources>

--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -187,6 +187,7 @@ interface LichessStorageEvent {
 interface LichessAnnouncement {
   msg?: string;
   date?: string;
+  i18nKey?: I18nKey;
 }
 
 interface LichessEditor {

--- a/ui/dasher/src/board.ts
+++ b/ui/dasher/src/board.ts
@@ -25,7 +25,7 @@ export function ctrl(data: BoardData, trans: Trans, redraw: Redraw, close: Close
     () =>
       xhr
         .text('/pref/zoom?v=' + readZoom(), { method: 'post' })
-        .catch(() => lichess.announce({ msg: 'Failed to save zoom' })),
+        .catch(() => lichess.announce({ msg: 'Failed to save board size' })),
     1000
   );
 

--- a/ui/site/src/component/announce.ts
+++ b/ui/site/src/component/announce.ts
@@ -8,13 +8,15 @@ const kill = () => {
   $('#announce').remove();
 };
 
-const announce = (d: LichessAnnouncement) => {
+const announce = (d: LichessAnnouncement, i18n?: I18nDict) => {
   kill();
-  if (d.msg) {
+  const msg = (d.i18nKey && i18n?.[d.i18nKey]) ?? d.msg;
+
+  if (msg) {
     $('body')
       .append(
         '<div id="announce" class="announce">' +
-          escapeHtml(d.msg) +
+          escapeHtml(msg) +
           (d.date ? '<time class="timeago" datetime="' + d.date + '"></time>' : '') +
           '<div class="actions"><a class="close">×</a></div>' +
           '</div>'

--- a/ui/site/src/site.ts
+++ b/ui/site/src/site.ts
@@ -153,8 +153,12 @@ lichess.load.then(() => {
         })
         .then(reload);
 
-    const pageAnnounce = document.body.getAttribute('data-announce');
-    if (pageAnnounce) announce(JSON.parse(pageAnnounce));
+    const announceI18n = JSON.parse(document.body.getAttribute('data-announce-i18n')!);
+    const dataAnnounce = document.body.getAttribute('data-announce');
+
+    if (dataAnnounce) {
+      announce(JSON.parse(dataAnnounce), announceI18n);
+    }
 
     serviceWorker();
 
@@ -169,7 +173,7 @@ lichess.load.then(() => {
     pubsub.on('socket.in.finish', e =>
       document.querySelectorAll('.mini-game-' + e.id).forEach((el: HTMLElement) => miniGame.finish(el, e.win))
     );
-    pubsub.on('socket.in.announce', announce);
+    pubsub.on('socket.in.announce', announcement => announce(announcement, announceI18n));
     pubsub.on('socket.in.tournamentReminder', (data: { id: string; name: string }) => {
       if ($('#announce').length || $('body').data('tournament-id') == data.id) return;
       const url = '/tournament/' + data.id;


### PR DESCRIPTION
Resolves #8978

As proposed in the issue discussion - in addition to possibility to make arbitrary announcements it might be valuable to predefine some common announcements so that they could be translated. This will help all users to understand what has been announced. Apparently _"Lichess will restart"_ is the only common announcement at the time, but the proposed solution allows to easily add more options if needed.

The proposal is to use a special format for predefined announcement - in place of an arbitrary message text type a predefined message key in square brackets (if some other format looks better - it could be easily adjusted). This allows to explicitly understand that user tries to use a predefined message so in case of typo or non-existent key a helpful error message will be displayed listing available message keys. If message key exists - _msg_  property of the announcement JSON will contain English text (as a fallback value) and an additional property _i18nKey_ will contain an i18n key which will be used to translate the message at client-side. Currently it's not possible to translate the message on backend since the same JSON is being sent to all clients using _Out.tellAll_.

Examples:

|        | Command | Result |
| ----- | -------------- | -------- |
| Arbitrary announcement (unchanged) | `announce 10 minutes Something will happen` | `announce 10 minutes Something will happen` <br><br> `{"msg":"Something will happen","date":"2021-10-21T23:15:24.529+03:00"}` | 
| Announce restart (current) | `announce 10 minutes Lichess will restart` | `announce 10 minutes Lichess will restart` <br><br> `{"msg":"Lichess will restart","date":"2021-10-21T23:15:24.529+03:00"}` |
| Announce restart (proposed) | `announce 10 minutes [restart]` | `announce 10 minutes [restart]` <br><br>  `{"msg":"Lichess will restart","i18nKey":"lichessWillRestart","date":"2021-10-21T23:15:24.529+03:00"}` |
| Announce, non-existing message key (proposed) | `announce 10 minutes [restatr]` | `announce 10 minutes [restatr]` <br><br> ```Invalid announce. Format: `announce <length> <unit> [<msgKey>]` or just `announce cancel` to cancel it``` <br> ```Available message keys: restart``` |
