### PR TITLE
Hide rating in gifs if hide ratings preference selected

### DIFF
--- a/app/controllers/Export.scala
+++ b/app/controllers/Export.scala
@@ -29,7 +29,7 @@ final class Export(env: Env) extends LilaController(env) {
         ExportGifRateLimitGlobal("-", msg = ctx.ip.value) {
           OptionFuResult(env.game.gameRepo gameWithInitialFen id) { case (game, initialFen) =>
             val pov = Pov(game, Color.fromName(color) | Color.white)
-            env.game.gifExport.fromPov(pov, initialFen) map
+            env.game.gifExport.fromPov(pov, initialFen, ctx.pref.showRatings) map
               stream("image/gif") map
               gameImageCacheSeconds(game)
           }
@@ -46,7 +46,7 @@ final class Export(env: Env) extends LilaController(env) {
     Open { implicit ctx =>
       ExportImageRateLimitGlobal("-", msg = ctx.ip.value) {
         OptionFuResult(env.game.gameRepo game id) { game =>
-          env.game.gifExport.gameThumbnail(game) map
+          env.game.gifExport.gameThumbnail(game, ctx.pref.showRatings) map
             stream("image/gif") map
             gameImageCacheSeconds(game)
         }

--- a/app/controllers/Study.scala
+++ b/app/controllers/Study.scala
@@ -514,7 +514,7 @@ final class Study(
       env.study.api.byIdWithChapter(id, chapterId) flatMap {
         _.fold(notFound) { case WithChapter(study, chapter) =>
           CanView(study, ctx.me) {
-            env.study.gifExport.ofChapter(chapter) map { stream =>
+            env.study.gifExport.ofChapter(chapter, ctx.pref.showRatings) map { stream =>
               Ok.chunked(stream)
                 .pipe(asAttachmentStream(s"${env.study.pgnDump.filename(study, chapter)}.gif"))
                 .as("image/gif")

--- a/modules/game/src/main/GifExport.scala
+++ b/modules/game/src/main/GifExport.scala
@@ -21,15 +21,15 @@ final class GifExport(
   private val targetMedianTime = Centis(80)
   private val targetMaxTime    = Centis(200)
 
-  def fromPov(pov: Pov, initialFen: Option[FEN]): Fu[Source[ByteString, _]] =
+  def fromPov(pov: Pov, initialFen: Option[FEN], withRating: Boolean): Fu[Source[ByteString, _]] =
     lightUserApi preloadMany pov.game.userIds flatMap { _ =>
       ws.url(s"$url/game.gif")
         .withMethod("POST")
         .addHttpHeaders("Content-Type" -> "application/json")
         .withBody(
           Json.obj(
-            "white"       -> Namer.playerTextBlocking(pov.game.whitePlayer, withRating = true)(lightUserApi.sync),
-            "black"       -> Namer.playerTextBlocking(pov.game.blackPlayer, withRating = true)(lightUserApi.sync),
+            "white"       -> Namer.playerTextBlocking(pov.game.whitePlayer, withRating)(lightUserApi.sync),
+            "black"       -> Namer.playerTextBlocking(pov.game.blackPlayer, withRating)(lightUserApi.sync),
             "comment"     -> s"${baseUrl.value}/${pov.game.id} rendered with https://github.com/niklasf/lila-gif",
             "orientation" -> pov.color.name,
             "delay"       -> targetMedianTime.centis, // default delay for frames
@@ -44,11 +44,11 @@ final class GifExport(
       }
     }
 
-  def gameThumbnail(game: Game): Fu[Source[ByteString, _]] = {
+  def gameThumbnail(game: Game, withRating: Boolean): Fu[Source[ByteString, _]] = {
     val query = List(
       "fen"         -> (Forsyth >> game.chess).value,
-      "white"       -> Namer.playerTextBlocking(game.whitePlayer, withRating = true)(lightUserApi.sync),
-      "black"       -> Namer.playerTextBlocking(game.blackPlayer, withRating = true)(lightUserApi.sync),
+      "white"       -> Namer.playerTextBlocking(game.whitePlayer, withRating)(lightUserApi.sync),
+      "black"       -> Namer.playerTextBlocking(game.blackPlayer, withRating)(lightUserApi.sync),
       "orientation" -> game.naturalOrientation.name
     ) ::: List(
       game.lastMoveKeys.map { "lastMove" -> _ },

--- a/modules/study/src/main/GifExport.scala
+++ b/modules/study/src/main/GifExport.scala
@@ -12,7 +12,7 @@ final class GifExport(
     ws: StandaloneWSClient,
     url: String
 )(implicit ec: scala.concurrent.ExecutionContext) {
-  def ofChapter(chapter: Chapter): Fu[Source[ByteString, _]] =
+  def ofChapter(chapter: Chapter, withRatings: Boolean): Fu[Source[ByteString, _]] =
     ws.url(s"$url/game.gif")
       .withMethod("POST")
       .addHttpHeaders("Content-Type" -> "application/json")
@@ -23,12 +23,12 @@ final class GifExport(
           "white" -> List(
             chapter.tags(_.WhiteTitle),
             chapter.tags(_.White),
-            chapter.tags(_.WhiteElo).map(elo => s"($elo)")
+            chapter.tags(_.WhiteElo).map(elo => if (withRatings) s"($elo)" else "")
           ).flatten.mkString(" "),
           "black" -> List(
             chapter.tags(_.BlackTitle),
             chapter.tags(_.Black),
-            chapter.tags(_.BlackElo).map(elo => s"($elo)")
+            chapter.tags(_.BlackElo).map(elo => if (withRatings) s"($elo)" else "")
           ).flatten.mkString(" "),
           "frames" -> framesRec(chapter.root +: chapter.root.mainline, Json.arr())
         )


### PR DESCRIPTION
I have tested the changes on a local instance. 
One thing that does not happen is that if the same accounts creates two gifs, one before and one after changing the setting, the generated gif the second time will not have the changed setting (only happens in normal games, studies seem to be redone every time).

My best guess is that it's because it's getting cached to avoid redoing something that has already been done before. If someone could give me a pointer how I could disable that for the case that the setting changed, I would be glad to fix it in this PR.