### PR TITLE
Don't hide challenge buttons in blind mode

### DIFF
--- a/ui/challenge/css/_challenge.scss
+++ b/ui/challenge/css/_challenge.scss
@@ -31,6 +31,10 @@
 
     .buttons {
       display: none;
+
+      body.blind-mode & {
+        display: flex;
+      }
     }
 
     &:hover .buttons {


### PR DESCRIPTION
Screen readers don't read `display: none` elements.

https://lichess.org/forum/lichess-feedback/blind-players-cannot-accept-challenges
https://lichess.org/forum/lichess-feedback/accessibility-issue-with-nvda-screen-reader-to-accept-or-decline-a-challenge