### PR TITLE
Resolve Wikibooks redirects

### DIFF
--- a/ui/analyse/src/wiki.ts
+++ b/ui/analyse/src/wiki.ts
@@ -9,7 +9,7 @@ export default function wikiTheory(): WikiTheory {
   const plyPrefix = (node: Tree.Node) => `${Math.floor((node.ply + 1) / 2)}${node.ply % 2 === 1 ? '._' : '...'}`;
 
   const wikiBooksUrl = 'https://en.wikibooks.org';
-  const apiArgs = 'origin=*&action=query&prop=extracts&formatversion=2&format=json&exchars=1200';
+  const apiArgs = 'redirects&origin=*&action=query&prop=extracts&formatversion=2&format=json&exchars=1200';
 
   const removeEmptyParagraph = (html: string) => html.replace(/<p>(<br \/>|\s)*<\/p>/g, '');
 


### PR DESCRIPTION
Wikibooks has redirects for common transpositions, e.g. "[Chess Opening Theory/1. Nc3/1...c5/2. e4](https://en.wikibooks.org/w/index.php?title=Chess_Opening_Theory/1._Nc3/1...c5/2._e4&redirect=no)" redirects to "[Chess Opening Theory/1. e4/1...c5/2. Nc3](https://en.wikibooks.org/wiki/Chess_Opening_Theory/1._e4/1...c5/2._Nc3)".

I added the [`redirects`](https://www.mediawiki.org/wiki/API:Query#Resolving_redirects) parameter to resolve these redirects.

I did not test this PR.