### PR TITLE
String parsing of keyboard move input fix

### DIFF
--- a/ui/round/src/plugins/keyboardMove.ts
+++ b/ui/round/src/plugins/keyboardMove.ts
@@ -58,7 +58,7 @@ lichess.keyboardMove = function (opts: Opts) {
     } else if (v.match(crazyhouseRegex)) {
       // Incomplete crazyhouse strings such as Q@ or Q@a should do nothing.
       if (v.length > 3 || (v.length > 2 && v.startsWith('@'))) {
-	if (v.length === 3) v = 'P' + v;
+        if (v.length === 3) v = 'P' + v;
         opts.ctrl.drop(v.slice(2) as Key, v[0].toUpperCase());
         clear();
       }

--- a/ui/round/src/plugins/keyboardMove.ts
+++ b/ui/round/src/plugins/keyboardMove.ts
@@ -4,7 +4,7 @@ import { KeyboardMove } from '../keyboardMove';
 
 const keyRegex = /^[a-h][1-8]$/;
 const fileRegex = /^[a-h]$/;
-const crazyhouseRegex = /^\w?@[a-h][1-8]$/;
+const crazyhouseRegex = /^\w?@([a-h]|[a-h][1-8])?$/;
 const ambiguousPromotionCaptureRegex = /^([a-h]x?)?[a-h](1|8)$/;
 const promotionRegex = /^([a-h]x?)?[a-h](1|8)=?[nbrqkNBRQK]$/;
 
@@ -31,9 +31,11 @@ lichess.keyboardMove = function (opts: Opts) {
     // consider 0's as O's for castling
     v = v.replace(/0/g, 'O');
     const foundUci = v.length >= 2 && legalSans && sanToUci(v, legalSans);
-    if (v == 'resign') {
-      opts.ctrl.resign(true, true);
-      clear();
+    if (v.length > 0 && 'resign'.startsWith(v.toLowerCase())) {
+      if (v.toLowerCase() === 'resign') {
+        opts.ctrl.resign(true, true);
+        clear();
+      }
     } else if (legalSans && foundUci) {
       // ambiguous castle
       if (v.toLowerCase() === 'o-o' && legalSans['O-O-O'] && !submitOpts.force) return;
@@ -54,9 +56,12 @@ lichess.keyboardMove = function (opts: Opts) {
       opts.ctrl.promote(foundUci.slice(0, 2) as Key, foundUci.slice(2) as Key, v.slice(-1).toUpperCase());
       clear();
     } else if (v.match(crazyhouseRegex)) {
-      if (v.length === 3) v = 'P' + v;
-      opts.ctrl.drop(v.slice(2) as Key, v[0].toUpperCase());
-      clear();
+      // Incomplete crazyhouse strings such as Q@ or Q@a should do nothing.
+      if (v.length > 3 || (v.length > 2 && v.startsWith('@'))) {
+	if (v.length === 3) v = 'P' + v;
+        opts.ctrl.drop(v.slice(2) as Key, v[0].toUpperCase());
+        clear();
+      }
     } else if (v.length > 0 && 'clock'.startsWith(v.toLowerCase())) {
       if ('clock' === v.toLowerCase()) {
         readClocks(opts.ctrl.clock());


### PR DESCRIPTION
Closes issue #10058 

# Changes

* Edited regex for Crazyhouse keyboard move inputs so that the `@` is recognized without looking like an error. 

* Also put in a similar fix to the `resign` input so that the string is recognized while being typed.

# How to Test
1. Ensure that `Input moves with the keyboard` is set to `Yes` in settings
2. Start a Crazyhouse variant game
3. After a peice has been taken, attempt to place it using the `@` character, such as `B@a3`
4. Attempt to resign the game by inputting `resign`
5. Both (3) and (4) should not cause an error sound or cause the box to turn red at any point in the input.

Refer to issue #10058 for full details