### PR TITLE
Quickly select game participant in personal opening explorer #10064 

### DIFF
--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -41,6 +41,9 @@ export class ExplorerConfigCtrl {
   myName?: string;
 
   constructor(readonly root: AnalyseCtrl, readonly variant: VariantKey, readonly onClose: () => void) {
+    let previous: string[] = [];
+    if (root.data.player.user?.id !== undefined) previous.push(root.data.player.user.id);
+    if (root.data.opponent.user?.id !== undefined) previous.push(root.data.opponent.user.id);
     this.myName = document.body.dataset['user'];
     if (variant === 'standard') this.allDbs.unshift('masters');
     this.data = {
@@ -54,7 +57,7 @@ export class ExplorerConfigCtrl {
       playerName: {
         open: prop(false),
         value: storedProp<string>('explorer.player.name', document.body.dataset['user'] || ''),
-        previous: storedJsonProp<string[]>('explorer.player.name.previous', () => []),
+        previous: storedJsonProp<string[]>('explorer.player.name.previous', () => previous),
       },
       color: prop('white'),
     };
@@ -292,11 +295,14 @@ const playerModal = (ctrl: ExplorerConfigCtrl) => {
       ]),
       h(
         'div.previous',
-        [...(ctrl.myName ? [ctrl.myName] : []), ...ctrl.data.playerName.previous()].map(name =>
+        [
+          ...(ctrl.data.playerName.previous().indexOf(ctrl.myName || '') === -1 ? [ctrl.myName] : []),
+          ...ctrl.data.playerName.previous(),
+        ].map(name =>
           h(
             `button.button${name == ctrl.myName ? '.button-green' : ''}`,
             {
-              hook: bind('click', () => onSelect(name)),
+              hook: bind('click', () => onSelect(name || "")),
             },
             name
           )

--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -41,10 +41,14 @@ export class ExplorerConfigCtrl {
   myName?: string;
 
   constructor(readonly root: AnalyseCtrl, readonly variant: VariantKey, readonly onClose: () => void) {
-    let previous: string[] = [];
-    if (root.data.player.user?.id !== undefined) previous.push(root.data.player.user.id);
-    if (root.data.opponent.user?.id !== undefined) previous.push(root.data.opponent.user.id);
     this.myName = document.body.dataset['user'];
+    let previous: string[] = [];
+    if (root.data.player.user?.id !== undefined && root.data.player.user.id !== this.myName) {
+      previous.push(root.data.player.user.id);
+    }
+    if (root.data.opponent.user?.id !== undefined && root.data.opponent.user.id !== this.myName) {
+      previous.push(root.data.opponent.user.id);
+    }
     if (variant === 'standard') this.allDbs.unshift('masters');
     this.data = {
       open: prop(false),
@@ -295,14 +299,11 @@ const playerModal = (ctrl: ExplorerConfigCtrl) => {
       ]),
       h(
         'div.previous',
-        [
-          ...(ctrl.data.playerName.previous().indexOf(ctrl.myName || '') === -1 ? [ctrl.myName] : []),
-          ...ctrl.data.playerName.previous(),
-        ].map(name =>
+        [...(ctrl.myName ? [ctrl.myName] : []), ...ctrl.data.playerName.previous()].map(name =>
           h(
             `button.button${name == ctrl.myName ? '.button-green' : ''}`,
             {
-              hook: bind('click', () => onSelect(name || "")),
+              hook: bind('click', () => onSelect(name)),
             },
             name
           )


### PR DESCRIPTION
Fixes #10064 by @niklasf.

The last hunk of the file has a bit of overengineering because if you remove the first element of the `div.previous` array (`...(ctrl.data.playerName.previous().indexOf(ctrl.myName || '') === -1 ? [ctrl.myName] : [])`) you can get duplicated items with cache users. This does not happen with new users (like opening a private tab) but it will happen in some cases, if the user had a player history already. 

Please review and if you want anything added let me know @niklasf.