### PR TITLE
Don't adjust colorIt when aborting fixed color lobby games

### DIFF
--- a/modules/game/src/main/GameRepo.scala
+++ b/modules/game/src/main/GameRepo.scala
@@ -1,5 +1,7 @@
 package lila.game
 
+import scala.concurrent.duration._
+
 import chess.format.{ FEN, Forsyth }
 import chess.{ Color, Status }
 import org.joda.time.DateTime
@@ -18,6 +20,8 @@ final class GameRepo(val coll: Coll)(implicit ec: scala.concurrent.ExecutionCont
   import BSONHandlers._
   import Game.{ ID, BSONFields => F }
   import Player.holdAlertBSONHandler
+
+  val fixedColorLobbyCache = new lila.memo.ExpireSetMemo(2 hours)
 
   def game(gameId: ID): Fu[Option[Game]]              = coll.byId[Game](gameId)
   def gameFromSecondary(gameId: ID): Fu[Option[Game]] = coll.secondaryPreferred.byId[Game](gameId)

--- a/modules/lobby/src/main/AbortListener.scala
+++ b/modules/lobby/src/main/AbortListener.scala
@@ -4,6 +4,7 @@ import lila.game.{ Pov, Source }
 
 final private class AbortListener(
     userRepo: lila.user.UserRepo,
+    gameRepo: lila.game.GameRepo,
     seekApi: SeekApi,
     lobbyActor: LobbySyncActor
 )(implicit ec: scala.concurrent.ExecutionContext) {
@@ -14,7 +15,10 @@ final private class AbortListener(
       lobbyActor.registerAbortedGame(pov.game)
 
   private def cancelColorIncrement(pov: Pov): Unit =
-    if (pov.game.source.exists(s => s == Source.Lobby || s == Source.Pool)) pov.game.userIds match {
+    if (
+      pov.game.source
+        .exists(s => s == Source.Lobby || s == Source.Pool) && !gameRepo.fixedColorLobbyCache.get(pov.game.id)
+    ) pov.game.userIds match {
       case List(u1, u2) =>
         userRepo.incColor(u1, -1)
         userRepo.incColor(u2, 1)

--- a/modules/lobby/src/main/Biter.scala
+++ b/modules/lobby/src/main/Biter.scala
@@ -36,6 +36,7 @@ final private class Biter(
       _ <- gameRepo insertDenormalized game
     } yield {
       lila.mon.lobby.hook.join.increment()
+      rememberIfFixedColor(hook.realColor, game)
       JoinHook(sri, hook, game, creatorColor)
     }
 
@@ -50,7 +51,14 @@ final private class Biter(
         blackUser = creatorColor.fold(user.some, owner.some)
       ).withUniqueId
       _ <- gameRepo insertDenormalized game
-    } yield JoinSeek(user.id, seek, game, creatorColor)
+    } yield {
+      rememberIfFixedColor(seek.realColor, game)
+      JoinSeek(user.id, seek, game, creatorColor)
+    }
+
+  private def rememberIfFixedColor(color: Color, game: Game) =
+    if (color != Color.Random)
+      gameRepo.fixedColorLobbyCache put game.id
 
   private def assignCreatorColor(
       creatorUser: Option[User],

--- a/modules/user/src/main/UserRepo.scala
+++ b/modules/user/src/main/UserRepo.scala
@@ -173,7 +173,7 @@ final class UserRepo(val coll: Coll)(implicit ec: scala.concurrent.ExecutionCont
     coll
       .update(ordered = false, WriteConcern.Unacknowledged)
       .one(
-        $id(userId) ++ (value < 0).??($doc(F.colorIt $gt -3)),
+        $id(userId) ++ (if (value < 0) $doc(F.colorIt $gt -3) else $doc(F.colorIt $lt 5)),
         $inc(F.colorIt -> value)
       )
       .unit


### PR DESCRIPTION
Not sure about the cache duration. Normal games are auto-aborted after 1 hour and correspondence games after 1 day I think but unlimited only after 10 days.

Also added an upper limit of 5 to be safe.