### PR TITLE
issue-1088 | Fix: + and # sign are not removed from Wikibooks URL

### DIFF
--- a/ui/analyse/src/wiki.ts
+++ b/ui/analyse/src/wiki.ts
@@ -31,7 +31,7 @@ export default function wikiTheory(): WikiTheory {
   return debounce(
     async (nodes: Tree.Node[]) => {
       const pathParts = nodes.slice(1).map(n => `${plyPrefix(n)}${n.san}`);
-      const path = pathParts.join('/').replace(/[+!#]/g,'') ?? '';
+      const path = pathParts.join('/').replace(/[+!#?]/g,'') ?? '';
       if (pathParts.length > 30 || !path || path.length > 255) show('');
       if (!path) show('');
       else if (cache.has(path)) show(cache.get(path)!);

--- a/ui/analyse/src/wiki.ts
+++ b/ui/analyse/src/wiki.ts
@@ -31,8 +31,9 @@ export default function wikiTheory(): WikiTheory {
   return debounce(
     async (nodes: Tree.Node[]) => {
       const pathParts = nodes.slice(1).map(n => `${plyPrefix(n)}${n.san}`);
-      const path = pathParts.join('/');
+      const path = pathParts.join('/').replace(/[+!#]/g,'') ?? '';
       if (pathParts.length > 30 || !path || path.length > 255) show('');
+      if (!path) show('');
       else if (cache.has(path)) show(cache.get(path)!);
       else if (
         Array.from({ length: pathParts.length }, (_, i) => -i - 1)


### PR DESCRIPTION
## Changes

Replacing the characters: `+` `!` `#` `?` after they are read from `PGN` textarea on the Analysis Board Page, this was done to solve this[ issue-10088](https://github.com/ornicar/lila/issues/10088):

>  Steps to reproduce the bug
> 
> Open the Analysis Board, and import following PGN:
> 1. e4 b6 2. d4 Bb7 3. Bd3 f5 4. exf5 Bxg2 5. Qh5+ g6
> Chess_Opening_Theory/1._e4/1...b6/2._d4/2...Bb7/3._Bd3/3...f5/4._exf5/4...Bxg2/5._Qh5/5...g6 should be displayed.
> 
> Import following PGN:
> 1. f3 e5 2. g4 Qh4#
> Chess_Opening_Theory/1._f3/1...e5/2._g4/2...Qh4 should be displayed.
> 
> What happened instead?
> The + and # signs were not removed when creating the Wikibooks URL. If you navigate to the move Qh5+ the Wikibooks page does get displayed but only because the + sign is interpreted as a trailing space and stripped.
> 
> Note that some Wikibooks pages do include +, !, and ? signs in the title, which goes against their Conventions for organization. I will rename those pages.