### PR TITLE
Don't animate spinner motion according to prefer-reduced-motion

### DIFF
--- a/ui/common/css/component/_loader.scss
+++ b/ui/common/css/component/_loader.scss
@@ -78,6 +78,12 @@ $total_len: $len1 + $len2 + $len3;
     animation-name: mask3;
   }
 
+  @media (prefers-reduced-motion: reduce) {
+    path {
+      animation: none !important;
+    }
+  }
+
   g {
     animation: spinner-color 11s steps(1) infinite;
     stroke-dasharray: $total_len $total_len;


### PR DESCRIPTION
Disables the path animation of the loading spinner if the OS asks for reduced animation.