### PR TITLE
Activate "Duel pairing" mode in arenas with only 2 "actually active and present" users (even if more than 2 are unpaused, but not all of them present) 

### DIFF
--- a/modules/tournament/src/main/arena/PairingSystem.scala
+++ b/modules/tournament/src/main/arena/PairingSystem.scala
@@ -26,7 +26,7 @@ final private[tournament] class PairingSystem(
     for {
       lastOpponents        <- pairingRepo.lastOpponents(tour.id, users.all, Math.min(300, users.size * 4))
       onlyTwoActivePlayers = (tour.nbPlayers <= 12) ?? users.size == 2
-      data = Data(tour, lastOpponents, ranking, onlyTwoActivePlayers )
+      data = Data(tour, lastOpponents, ranking, onlyTwoActivePlayers)
       preps    <- (lastOpponents.hash.isEmpty || users.haveWaitedEnough) ?? evenOrAll(data, users)
       pairings <- prepsToPairings(preps)
     } yield pairings

--- a/modules/tournament/src/main/arena/PairingSystem.scala
+++ b/modules/tournament/src/main/arena/PairingSystem.scala
@@ -25,8 +25,8 @@ final private[tournament] class PairingSystem(
   ): Fu[Pairings] = {
     for {
       lastOpponents        <- pairingRepo.lastOpponents(tour.id, users.all, Math.min(300, users.size * 4))
-      onlyTwoActivePlayers <- (tour.nbPlayers <= 12) ?? playerRepo.countActive(tour.id).dmap(2 ==)
-      data = Data(tour, lastOpponents, ranking, onlyTwoActivePlayers)
+      onlyTwoActivePlayers = (tour.nbPlayers <= 12) ?? users.size == 2
+      data = Data(tour, lastOpponents, ranking, onlyTwoActivePlayers )
       preps    <- (lastOpponents.hash.isEmpty || users.haveWaitedEnough) ?? evenOrAll(data, users)
       pairings <- prepsToPairings(preps)
     } yield pairings


### PR DESCRIPTION
### Rationale

Pairing algorithm in arenas when there are only 2 **un-paused** players has different behavior allowing for players to be paired more than once consecutively - "duel mode" in some sense.

This is great, and especially useful for small community organized tournaments.

However current implementation is not perfect.

Often in small tournaments, people leave the tournament page without actually pausing. This way it often happens that 3 or more players are un-paused so "duel mode" is not activated, even though there could be only 2 of those un-paused players that are in fact active and present in the tournament page and available for pairing.

This PR tries to change the logic for duel mode activation to happen when having only 2 **actually active** players and not just **unpaused**.

This is especially useful for small community organized tournaments which often struggle to gain initial "seed amount" of active players and get stuck with many inactive, but un-paused players, even though in a lot of those cases there are actually 2 active players, who however are unable to keep playing and maintaining the tournament alive for more people to join, effectively killing the tournament.


### Technical details

Change is very small, however I am still not at all confident I understand the whole pairing mechanics so could be wrong. 

Still decided to make a PR instead of opening an issue for this problem, so even if my fix is wrong, please consider fixing this properly as it will have significant impact on small community organized arenas trying to lift off!