### PR TITLE
Use `user.id` in `?pov=`

### DIFF
--- a/app/views/user/perfStat.scala
+++ b/app/views/user/perfStat.scala
@@ -274,7 +274,7 @@ object perfStat {
             tr(
               td(userIdLink(r.opId.value.some, withOnline = false), " (", r.opInt, ")"),
               td(
-                a(cls := "glpt", href := s"${routes.Round.watcher(r.gameId, "white")}?pov=${user.username}")(
+                a(cls := "glpt", href := s"${routes.Round.watcher(r.gameId, "white")}?pov=${user.id}")(
                   absClientDateTime(r.at)
                 )
               )


### PR DESCRIPTION
The syntax `?pov=<username>` doesn't seems to work if username has uppercase letters (e.g. https://lichess.org/@/G-Lorenz/perf/blitz, where my games against Toro2003 and Petersellers are still shown from white perspective), while it works if the username has only lowercase letters or if it is written in lowercase.