### PR TITLE
tweak fishnet book move selection

### DIFF
--- a/modules/fishnet/src/main/FishnetOpeningBook.scala
+++ b/modules/fishnet/src/main/FishnetOpeningBook.scala
@@ -69,7 +69,7 @@ object FishnetOpeningBook {
 
     def randomPonderedMove(turn: Color, level: Int): Option[Move] = {
       val sum         = moves.map(_.score(turn, level)).sum
-      val novelty     = 14
+      val novelty     = 5 * 14 // score of 5 winning games
       val rng         = ThreadLocalRandom.nextInt(sum + novelty)
       moves
         .foldLeft((none[Move], 0)) { case ((found, it), next) =>


### PR DESCRIPTION
so that low levels can still play natural blunders from the book

at level 1, the weight is proportional the number of times the move has been played: wins + draws + losses
at level 8, the weight is proportional to the expectation value: wins + 1/2 draws

when there are few games in the database, give fishnet a higher chance to think on its own