### PR TITLE
Fix top player/material/clock bar on 3D boards

### DIFF
--- a/ui/analyse/css/_player-clock.scss
+++ b/ui/analyse/css/_player-clock.scss
@@ -9,6 +9,10 @@ $clock-height: 20px;
 
   &.top {
     top: #{-$clock-height};
+
+    .is3d & {
+      top: #{-$clock-height - 35px};
+    }
   }
 
   &.bottom {
@@ -37,6 +41,10 @@ $clock-height: 20px;
 
   &.top {
     @extend %box-radius-top;
+
+    .is3d & {
+      @extend %box-radius;
+    }
   }
 
   &.bottom {

--- a/ui/analyse/css/study/_player.scss
+++ b/ui/analyse/css/study/_player.scss
@@ -34,6 +34,12 @@ $player-height: 1.6rem;
     @extend %box-radius-top;
 
     top: #{-$player-height};
+
+    .is3d & {
+      @extend %box-radius;
+
+      top: calc(#{-$player-height} - 35px);
+    }
   }
 
   &-bot {


### PR DESCRIPTION
|Before|After|
|:--:|:--:|
|![analysis_before](https://user-images.githubusercontent.com/19309705/144051082-0a30ec49-a5f8-486e-9826-4fdca1e2fd75.png)|![analysis_after](https://user-images.githubusercontent.com/19309705/144051105-eae188ae-9070-469c-aef6-6170e194ac0f.png)|
|![study_before](https://user-images.githubusercontent.com/19309705/144051158-af13b8cd-cda0-49a0-88a9-f757fa8f1086.png)|![study_after](https://user-images.githubusercontent.com/19309705/144051181-fbf37c63-5cd1-4444-a89c-4e7398547216.png)|

It looks a bit weird but I'm not sure there's a better simple solution and I think it's better than it just not being visible at all.