### PR TITLE
Fix overflow in fishnet opening book

### DIFF
--- a/modules/common/src/main/Random.scala
+++ b/modules/common/src/main/Random.scala
@@ -47,6 +47,8 @@ abstract class Random {
 
 object ThreadLocalRandom extends Random {
   override def current = java.util.concurrent.ThreadLocalRandom.current
+
+  def nextLong(n: Long): Long = current.nextLong(n)
 }
 
 object SecureRandom extends Random {

--- a/modules/fishnet/src/main/FishnetOpeningBook.scala
+++ b/modules/fishnet/src/main/FishnetOpeningBook.scala
@@ -69,10 +69,10 @@ object FishnetOpeningBook {
 
     def randomPonderedMove(turn: Color, level: Int): Option[Move] = {
       val sum         = moves.map(_.score(turn, level)).sum
-      val novelty     = 5 * 14 // score of 5 winning games
-      val rng         = ThreadLocalRandom.nextInt(sum + novelty)
+      val novelty     = 5L * 14 // score of 5 winning games
+      val rng         = ThreadLocalRandom.nextLong(sum + novelty)
       moves
-        .foldLeft((none[Move], 0)) { case ((found, it), next) =>
+        .foldLeft((none[Move], 0L)) { case ((found, it), next) =>
           val nextIt = it + next.score(turn, level)
           (found orElse (nextIt > rng).option(next), nextIt)
         }
@@ -80,12 +80,12 @@ object FishnetOpeningBook {
     }
   }
 
-  case class Move(uci: Uci, white: Int, draws: Int, black: Int) {
-    def score(turn: Color, level: Int) =
+  case class Move(uci: Uci, white: Long, draws: Long, black: Long) {
+    def score(turn: Color, level: Int): Long =
       // interpolate: real frequency at lvl 1, expectation value at lvl 8
-      14 * turn.fold(white, black) +
-      (15 - level) * draws +
-      (16 - 2 * level) * turn.fold(black, white)
+      14L * turn.fold(white, black) +
+      (15L - level) * draws +
+      (16L - 2 * level) * turn.fold(black, white)
   }
 
   implicit val moveReader     = Json.reads[Move]


### PR DESCRIPTION
On certain levels, e.g. SF level 2 in Blitz, the total number of moves * 14 (during [score calculation](https://github.com/ornicar/lila/blob/master/modules/fishnet/src/main/FishnetOpeningBook.scala#L86)) will overflow the int limit and `nextInt` will throw since the bound will be negative.