### PR TITLE
Improve maximum hash table memory estimation.

### DIFF
--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -117,7 +117,8 @@ export default function (opts: CevalOpts): CevalCtrl {
     Math.min(Math.ceil((navigator.hardwareConcurrency || 1) / 4), maxThreads)
   );
 
-  const maxHashSize = Math.min(((navigator.deviceMemory || 0.25) * 1024) / 8, growableSharedMem ? 1024 : 16);
+  const estimatedMinMemory = (technology == 'hce' || technology == 'nnue') ? 2.0 : 0.5;
+  const maxHashSize = Math.min(((navigator.deviceMemory || estimatedMinMemory) * 1024) / 8, growableSharedMem ? 1024 : 16);
   const hashSize = storedProp(storageKey('ceval.hash-size'), 16);
 
   const multiPv = storedProp(storageKey('ceval.multipv'), opts.multiPvDefault || 1);


### PR DESCRIPTION
Some browsers don't report navigator.deviceMemory to keep
fingerprintability to a minimum. Currently, lila assumes that
such a machine provides at most 256MB RAM, thus setting a 32MB
max hashtable limit.

This was a reasonable starting point when Stockfish was pure
JavaScript in a single thread, but with up 16 core WASM support
this limitation is a bit more painful.

Modify the memory estimation: if the browser is modern enough to
have full WASM/SharedArrayBuffer support, and thus run the
parallel WASM versions, assume the machine has at least 2GB of
RAM. If it doesn't, assume 512MB. This gives a maximum hashtable
of 256MB and 64MB, respectively.

The assumed minimum RAM values roughly correspond to Firefox's
official system requirements for the 32-bit and 64-bit version.
Although that doesn't necessarily correspond to WASM support,
it's a reasonable starting point for a guess.

Note that guessing wrong isn't harmful, it just gives the user
the option to shoot themselves in the foot, and even that is
limited because we still only use 1/8th of the guessed system RAM.