### PR TITLE
Use 'Cross-Origin-Embedder-Policy: credentialless' in Chrome 96+

### DIFF
--- a/app/controllers/LilaController.scala
+++ b/app/controllers/LilaController.scala
@@ -65,10 +65,11 @@ abstract private[controllers] class LilaController(val env: Env)
   implicit def reqConfig(implicit req: RequestHeader) = ui.EmbedConfig(req)
   def reqLang(implicit req: RequestHeader)            = I18nLangPicker(req)
 
-  protected def EnableSharedArrayBuffer(res: Result): Result =
+  protected def EnableSharedArrayBuffer(res: Result)(implicit req: RequestHeader): Result =
     res.withHeaders(
       "Cross-Origin-Opener-Policy"   -> "same-origin",
-      "Cross-Origin-Embedder-Policy" -> "require-corp"
+      "Cross-Origin-Embedder-Policy" -> (if (HTTPRequest isChrome96OrMore req) "credentialless"
+                                         else "require-corp")
     )
 
   protected def NoCache(res: Result): Result =

--- a/modules/common/src/main/HTTPRequest.scala
+++ b/modules/common/src/main/HTTPRequest.scala
@@ -45,6 +45,7 @@ object HTTPRequest {
 
   private def uaContains(req: RequestHeader, str: String) = userAgent(req).exists(_ contains str)
   def isChrome(req: RequestHeader)                        = uaContains(req, "Chrome/")
+  val isChrome96OrMore                                    = UaMatcher("""Chrome/(?:\d{3,}|9[6-9])""")
 
   def origin(req: RequestHeader): Option[String] = req.headers get HeaderNames.ORIGIN
 


### PR DESCRIPTION
On pages embedding Stockfish (i.e. using SharedArrayBuffer).
To allow custom backgrounds from non-CORS pages.