### PR TITLE
hide rating range in lobby pools if showRatings disabled

### DIFF
--- a/ui/lobby/src/view/pools.ts
+++ b/ui/lobby/src/view/pools.ts
@@ -38,7 +38,7 @@ export function render(ctrl: LobbyController) {
         },
         [
           h('div.clock', pool.lim + '+' + pool.inc),
-          active && member!.range ? renderRange(member!.range!) : h('div.perf', pool.perf),
+          active && member!.range && ctrl.opts.showRatings ? renderRange(member!.range!) : h('div.perf', pool.perf),
           active ? spinner() : null,
         ]
       );


### PR DESCRIPTION
Closes #10214 

I opted to not show any rating range as I think that is most inline with the intended UX of no rating mode