### PR TITLE
Fix game priority sorting

### DIFF
--- a/modules/game/src/main/GameRepo.scala
+++ b/modules/game/src/main/GameRepo.scala
@@ -198,9 +198,9 @@ final class GameRepo(val coll: Coll)(implicit ec: scala.concurrent.ExecutionCont
       )
     )
 
-  // Use Env.round.proxy.urgentGames to get in-heap states!
+  // Use env.round.proxyRepo.urgentGames to get in-heap states!
   def urgentPovsUnsorted(user: User): Fu[List[Pov]] =
-    coll.list[Game](Query nowPlaying user.id, Game.maxPlayingRealtime) dmap {
+    coll.list[Game](Query nowPlaying user.id) dmap {
       _ flatMap { Pov(_, user) }
     }
 

--- a/modules/game/src/main/Pov.scala
+++ b/modules/game/src/main/Pov.scala
@@ -79,6 +79,7 @@ object Pov {
   private def povVecOrder(a: Pov) = Vector(!a.isMyTurn, orInf(a.remainingSeconds) < 30, a.hasMoved)
 
   def priority(a: Pov, b: Pov) =
+    // sort according to (in order), my turn first, then games with 30s or less, then games not started, then games with less time on clock
     if (!a.isMyTurn && !b.isMyTurn) isFresher(a, b)
     else
       povVecOrder(a)

--- a/modules/game/src/main/Pov.scala
+++ b/modules/game/src/main/Pov.scala
@@ -74,20 +74,21 @@ object Pov {
   private def isFresher(a: Pov, b: Pov) = {
     val aDate = a.game.movedAt.getSeconds
     val bDate = b.game.movedAt.getSeconds
-    if (aDate == bDate) a.gameId < b.gameId
-    else aDate > bDate
+    aDate > bDate
   }
+  private def povVecOrder(a: Pov) = Vector(!a.isMyTurn, orInf(a.remainingSeconds) < 30, a.hasMoved)
 
   def priority(a: Pov, b: Pov) =
     if (!a.isMyTurn && !b.isMyTurn) isFresher(a, b)
-    else if (!a.isMyTurn && b.isMyTurn) false
-    else if (a.isMyTurn && !b.isMyTurn) true
-    // first move has priority over games with more than 30s left
-    else if (!a.hasMoved && orInf(b.remainingSeconds) > 30) true
-    else if (!b.hasMoved && orInf(a.remainingSeconds) > 30) false
-    else if (orInf(a.remainingSeconds) < orInf(b.remainingSeconds)) true
-    else if (orInf(b.remainingSeconds) < orInf(a.remainingSeconds)) false
-    else isFresher(a, b)
+    else
+      povVecOrder(a)
+        .zip(povVecOrder(b))
+        .filter { case (a, b) => a != b }
+        .headOption
+        .map { case (a, b) =>
+          a < b
+        }
+        .getOrElse(orInf(a.remainingSeconds) < orInf(b.remainingSeconds))
 }
 
 case class PovRef(gameId: Game.ID, color: Color) {

--- a/modules/game/src/main/Pov.scala
+++ b/modules/game/src/main/Pov.scala
@@ -76,7 +76,7 @@ object Pov {
     val bDate = b.game.movedAt.getSeconds
     aDate > bDate
   }
-  private def povVecOrder(a: Pov) = Vector(!a.isMyTurn, orInf(a.remainingSeconds) < 30, a.hasMoved)
+  private def povVecOrder(a: Pov) = Vector(!a.isMyTurn, orInf(a.remainingSeconds) > 30, a.hasMoved)
 
   def priority(a: Pov, b: Pov) =
     // sort according to (in order), my turn first, then games with 30s or less, then games not started, then games with less time on clock

--- a/modules/round/src/main/GameProxyRepo.scala
+++ b/modules/round/src/main/GameProxyRepo.scala
@@ -51,7 +51,12 @@ final class GameProxyRepo(
       }.sequenceFu map { povs =>
         try {
           povs sortWith Pov.priority
-        } catch { case _: IllegalArgumentException => povs.sortBy(-_.game.movedAt.getSeconds) }
+        } catch {
+          case e: IllegalArgumentException => {
+            lila.log("round").error(s"Could not sort current games of $user: $e")
+            povs.sortBy(-_.game.movedAt.getSeconds)
+          }
+        }
       }
     }
 }


### PR DESCRIPTION
Ensuring games where it's your turn always come first.

Removing `Game.maxPlayingRealtime` limit since that query is used to fetch correspondence games too, and number of game is limited during creation. `resignAllGamesOf` which use similar query did not implement that limit.

Fix `Pov.priority`, ensuring it correctly implements a partial order. New implementation is equivalent to

```scala
else if (!a.isMyTurn && b.isMyTurn) false
else if (a.isMyTurn && !b.isMyTurn) true
// first move has priority over games with more than 30s left
else if (orInf(a.remainingSeconds) < 30 && orInf(b.remainingSeconds) > 30) true
else if (orInf(b.remainingSeconds) < 30 && orInf(a.remainingSeconds) > 30) false
else if (!a.hasMoved && b.hasMoved) true
else if (!b.hasMoved && a.hasMoved) false
else orInf(a.remainingSeconds) < orInf(b.remainingSeconds)
```

If we want to stick to boolean operations only.

In theory the error cathing exception could be removed altogether, but if I'm wrong it'd lead to internal server error on the homepage and every game page, so better be safe.

fix #10222