### PR TITLE
Remove top border of puzzle__moves

### DIFF
--- a/ui/puzzle/css/_tools.scss
+++ b/ui/puzzle/css/_tools.scss
@@ -15,8 +15,7 @@
 .puzzle__moves {
   flex: 2 1 auto;
   overflow: auto;
-  border: $border;
-  border-width: 1px 0;
+  border-bottom: $border;
   position: relative;
 
   /* required by line::before */


### PR DESCRIPTION
The top border of the moves list is perceived as an off-by-one error:
Because it looks like a shadow it appears to be 1px below the chess board.

before:
<img width="341" alt="before" src="https://user-images.githubusercontent.com/339762/146676592-232d7e38-7aa1-47cc-b223-f7e859fa697d.png">
after:
<img width="595" alt="after" src="https://user-images.githubusercontent.com/339762/146676589-6c79df1f-79c6-43a4-a6db-86ed36f43bac.png">