### PR TITLE
don't show close button when no game found

### DIFF
--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -244,8 +244,7 @@ function showEmpty(ctrl: AnalyseCtrl, data?: OpeningData): VNode {
       h('strong', ctrl.trans.noarg('noGameFound')),
       ctrl.explorer.config.fullHouse()
         ? null
-        : h('p.explanation', ctrl.trans.noarg('maybeIncludeMoreGamesFromThePreferencesMenu')),
-      closeButton(ctrl),
+        : h('p.explanation', ctrl.trans.noarg('maybeIncludeMoreGamesFromThePreferencesMenu'))
     ]),
   ]);
 }

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -244,7 +244,7 @@ function showEmpty(ctrl: AnalyseCtrl, data?: OpeningData): VNode {
       h('strong', ctrl.trans.noarg('noGameFound')),
       ctrl.explorer.config.fullHouse()
         ? null
-        : h('p.explanation', ctrl.trans.noarg('maybeIncludeMoreGamesFromThePreferencesMenu'))
+        : h('p.explanation', ctrl.trans.noarg('maybeIncludeMoreGamesFromThePreferencesMenu')),
     ]),
   ]);
 }


### PR DESCRIPTION
This addresses issue #10238

Motivations of the change:

1/ It's not clear what the close button is going to do when pressed

2/ The message 'no game found' is only for the player tab, but the close button removes everything (masters, lichess and player)