### PR TITLE
preserve variant when editing game position (fixes #10230)

### DIFF
--- a/app/controllers/Setup.scala
+++ b/app/controllers/Setup.scala
@@ -17,6 +17,7 @@ import views._
 
 final class Setup(
     env: Env,
+    editorC: => Editor,
     challengeC: => Challenge,
     apiC: => Api
 ) extends LilaController(env)
@@ -48,7 +49,8 @@ final class Setup(
           html.setup.forms.ai(
             form,
             env.fishnet.aiPerfApi.intRatings,
-            form("fen").value map FEN.clean flatMap ValidFen(getBool("strict"))
+            form("fen").value map FEN.clean flatMap ValidFen(getBool("strict")),
+            editorC.editorUrl
           )
         }
       } else Redirect(s"${routes.Lobby.home}#ai").fuccess
@@ -65,11 +67,11 @@ final class Setup(
         fuccess(forms friendFilled get("fen").map(FEN.clean)) flatMap { form =>
           val validFen = form("fen").value map FEN.clean flatMap ValidFen(strict = false)
           userId ?? env.user.repo.named flatMap {
-            case None => Ok(html.setup.forms.friend(form, none, none, validFen)).fuccess
+            case None => Ok(html.setup.forms.friend(form, none, none, validFen, editorC.editorUrl)).fuccess
             case Some(user) =>
               env.challenge.granter(ctx.me, user, none) map {
                 case Some(denied) => BadRequest(lila.challenge.ChallengeDenied.translated(denied))
-                case None         => Ok(html.setup.forms.friend(form, user.some, none, validFen))
+                case None         => Ok(html.setup.forms.friend(form, user.some, none, validFen, editorC.editorUrl))
               }
           }
         }

--- a/app/controllers/Study.scala
+++ b/app/controllers/Study.scala
@@ -19,6 +19,7 @@ import views._
 
 final class Study(
     env: Env,
+    editorC: => Editor,
     userAnalysisC: => UserAnalysis,
     apiC: => Api,
     prismicC: Prismic
@@ -272,7 +273,7 @@ final class Study(
               contrib <- env.study.studyRepo.recentByContributor(me.id, 50)
               res <-
                 if (owner.isEmpty && contrib.isEmpty) createStudy(data, me)
-                else Ok(html.study.create(data, owner, contrib)).fuccess
+                else Ok(html.study.create(data, owner, contrib, editorC.editorUrl)).fuccess
             } yield res
         )
     }

--- a/app/views/board/bits.scala
+++ b/app/views/board/bits.scala
@@ -32,10 +32,10 @@ object bits {
   def miniSpan(fen: chess.format.FEN, color: chess.Color = chess.White, lastMove: String = "") =
     mini(fen, color, lastMove)(span)
 
-  def jsData(fen: Option[String] = None)(implicit ctx: Context) =
+  def editorJsData(fen: Option[String] = None)(implicit ctx: Context) =
     Json
       .obj(
-        "baseUrl"   -> s"$netBaseUrl${routes.Editor.load("")}",
+        "baseUrl"   -> s"$netBaseUrl${routes.Editor.index}",
         "animation" -> Json.obj("duration" -> ctx.pref.animationMillis),
         "is3d"      -> ctx.pref.is3d,
         "i18n"      -> i18nJsObject(i18nKeyes)

--- a/app/views/board/editor.scala
+++ b/app/views/board/editor.scala
@@ -19,7 +19,7 @@ object editor {
       moreJs = frag(
         jsModule("editor"),
         embedJsUnsafeLoadThen(
-          s"""const data=${safeJsonValue(bits.jsData(fen))};data.positions=$positionsJson;
+          s"""const data=${safeJsonValue(bits.editorJsData(fen))};data.positions=$positionsJson;
 data.endgamePositions=$endgamePositionsJson;LichessEditor(document.getElementById('board-editor'), data);"""
         )
       ),

--- a/app/views/setup/bits.scala
+++ b/app/views/setup/bits.scala
@@ -11,10 +11,17 @@ private object bits {
 
   val prefix = "sf_"
 
-  def fenInput(field: Field, strict: Boolean, validFen: Option[lila.setup.ValidFen])(implicit
+  def fenInput(
+      field: Field,
+      strict: Boolean,
+      validFen: Option[lila.setup.ValidFen],
+      editorUrl: (chess.format.FEN, chess.variant.Variant) => String
+  )(implicit
       ctx: Context
   ) = {
-    val url = field.value.fold(routes.Editor.index)(routes.Editor.load).url
+    val url = field.value.fold(routes.Editor.index.url) { fen =>
+      editorUrl(chess.format.FEN(fen), chess.variant.Standard)
+    }
     div(cls := "fen_position optional_config")(
       frag(
         div(

--- a/app/views/setup/forms.scala
+++ b/app/views/setup/forms.scala
@@ -55,13 +55,18 @@ object forms {
       )
     }
 
-  def ai(form: Form[_], ratings: Map[Int, Int], validFen: Option[lila.setup.ValidFen])(implicit
+  def ai(
+      form: Form[_],
+      ratings: Map[Int, Int],
+      validFen: Option[lila.setup.ValidFen],
+      editorUrl: (chess.format.FEN, chess.variant.Variant) => String
+  )(implicit
       ctx: Context
   ) =
     layout("ai", trans.playWithTheMachine(), routes.Setup.ai) {
       frag(
         renderVariant(form, translatedAiVariantChoices),
-        fenInput(form("fen"), strict = true, validFen),
+        fenInput(form("fen"), strict = true, validFen, editorUrl),
         renderTimeMode(form, allowAnon = true),
         if (ctx.blind)
           frag(
@@ -93,7 +98,8 @@ object forms {
       form: Form[_],
       user: Option[User],
       error: Option[String],
-      validFen: Option[lila.setup.ValidFen]
+      validFen: Option[lila.setup.ValidFen],
+      editorUrl: (chess.format.FEN, chess.variant.Variant) => String
   )(implicit ctx: Context) =
     layout(
       "friend",
@@ -106,7 +112,7 @@ object forms {
           userLink(u, cssClass = "target".some)
         },
         renderVariant(form, translatedVariantChoicesWithVariantsAndFen),
-        fenInput(form("fen"), strict = false, validFen),
+        fenInput(form("fen"), strict = false, validFen, editorUrl),
         renderTimeMode(form, allowAnon = true),
         ctx.isAuth option div(cls := "mode_choice buttons")(
           renderRadios(form("mode"), translatedModeChoices)

--- a/app/views/study/create.scala
+++ b/app/views/study/create.scala
@@ -15,12 +15,13 @@ object create {
   def apply(
       data: lila.study.StudyForm.importGame.Data,
       owner: List[Study.IdName],
-      contrib: List[Study.IdName]
+      contrib: List[Study.IdName],
+      editorUrl: (chess.format.FEN, chess.variant.Variant) => String
   )(implicit ctx: Context) =
     views.html.site.message(
       title = trans.toStudy.txt(),
       icon = Some(""),
-      back = data.fen.map(f => routes.Editor.load(f.value).url),
+      back = data.fen.map(fen => editorUrl(fen, chess.variant.Variant.orDefault(~data.variantStr))),
       moreCss = cssTag("study.create").some
     ) {
       div(cls := "study-create")(

--- a/ui/analyse/package.json
+++ b/ui/analyse/package.json
@@ -31,7 +31,7 @@
     "ceval": "2.0.0",
     "chat": "2.0.0",
     "chess": "2.0.0",
-    "chessground": "^8.1.8",
+    "chessground": "^8.1.9",
     "chessops": "^0.10.2",
     "common": "2.0.0",
     "debounce-promise": "^3.1.2",

--- a/ui/chess/package.json
+++ b/ui/chess/package.json
@@ -29,7 +29,7 @@
     "prod": "$npm_execpath run compile"
   },
   "dependencies": {
-    "chessground": "^8.1.8",
+    "chessground": "^8.1.9",
     "common": "2.0.0",
     "snabbdom": "^3.0.1"
   },

--- a/ui/common/package.json
+++ b/ui/common/package.json
@@ -29,7 +29,7 @@
     "prod": "$npm_execpath run compile"
   },
   "dependencies": {
-    "chessground": "^8.1.8",
+    "chessground": "^8.1.9",
     "snabbdom": "^3.0.1"
   },
   "devDependencies": {

--- a/ui/editor/package.json
+++ b/ui/editor/package.json
@@ -19,7 +19,7 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
-    "chessground": "^8.1.8",
+    "chessground": "^8.1.9",
     "chessops": "^0.10.2",
     "common": "2.0.0",
     "snabbdom": "^3.0.1"

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -76,11 +76,7 @@ export default class EditorCtrl {
   onChange(): void {
     const fen = this.getFen();
     if (!this.cfg.embed) {
-      const params = new URLSearchParams();
-      if (fen !== INITIAL_FEN || this.rules !== 'chess') params.set('fen', fen);
-      if (this.rules !== 'chess') params.set('variant', lichessVariant(this.rules));
-      const paramsString = params.toString();
-      window.history.replaceState(null, '', '/editor' + (paramsString ? '?' + paramsString : ''));
+      window.history.replaceState(null, '', this.makeEditorUrl(fen));
     }
     this.options.onChange?.(fen);
     this.redraw();
@@ -142,11 +138,13 @@ export default class EditorCtrl {
 
   makeAnalysisUrl(legalFen: string): string {
     const variant = this.rules === 'chess' ? '' : lichessVariant(this.rules) + '/';
-    return this.makeUrl(`/analysis/${variant}`, legalFen);
+    return `/analysis/${variant}/${urlFen(legalFen)}`;
   }
 
-  makeUrl(baseUrl: string, fen: string): string {
-    return baseUrl + encodeURIComponent(fen).replace(/%20/g, '_').replace(/%2F/g, '/');
+  makeEditorUrl(fen: string): string {
+    if (fen === INITIAL_FEN && this.rules === 'chess') return this.cfg.baseUrl;
+    const variant = this.rules === 'chess' ? '' : '?variant=' + lichessVariant(this.rules);
+    return `${this.cfg.baseUrl}/${urlFen(fen)}${variant}`;
   }
 
   bottomColor(): Color {
@@ -219,4 +217,8 @@ export default class EditorCtrl {
     if (this.chessground!.state.orientation !== o) this.chessground!.toggleOrientation();
     this.redraw();
   }
+}
+
+function urlFen(fen: string): string {
+  return encodeURIComponent(fen).replace(/%20/g, '_').replace(/%2F/g, '/');
 }

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -364,7 +364,7 @@ function inputs(ctrl: EditorCtrl, fen: string): VNode | undefined {
         attrs: {
           readonly: true,
           spellcheck: false,
-          value: ctrl.makeUrl(ctrl.cfg.baseUrl, fen),
+          value: ctrl.makeEditorUrl(fen),
         },
       }),
     ]),

--- a/ui/game/package.json
+++ b/ui/game/package.json
@@ -31,7 +31,7 @@
     "prod": "$npm_execpath run compile"
   },
   "dependencies": {
-    "chessground": "^8.1.8",
+    "chessground": "^8.1.9",
     "snabbdom": "^3.0.1"
   },
   "devDependencies": {

--- a/ui/lobby/package.json
+++ b/ui/lobby/package.json
@@ -22,7 +22,7 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
-    "chessground": "^8.1.8",
+    "chessground": "^8.1.9",
     "common": "2.0.0",
     "debounce-promise": "^3.1.2",
     "snabbdom": "^3.0.1"

--- a/ui/nvui/package.json
+++ b/ui/nvui/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "chess": "2.0.0",
-    "chessground": "^8.1.8",
+    "chessground": "^8.1.9",
     "chessops": "^0.10.2",
     "snabbdom": "^3.0.1"
   }

--- a/ui/puz/package.json
+++ b/ui/puz/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "chessops": "^0.10.2",
     "snabbdom": "^3.0.1",
-    "chessground": "^8.1.8",
+    "chessground": "^8.1.9",
     "common": "2.0.0"
   },
   "devDependencies": {

--- a/ui/puzzle/package.json
+++ b/ui/puzzle/package.json
@@ -24,7 +24,7 @@
     "ceval": "2.0.0",
     "chart.js": "^2.9",
     "chess": "2.0.0",
-    "chessground": "^8.1.8",
+    "chessground": "^8.1.9",
     "chessops": "^0.10.2",
     "common": "2.0.0",
     "nvui": "2.0.0",

--- a/ui/racer/package.json
+++ b/ui/racer/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "chess": "2.0.0",
-    "chessground": "^8.1.8",
+    "chessground": "^8.1.9",
     "chessops": "^0.10.2",
     "common": "2.0.0",
     "puz": "2.0.0",

--- a/ui/round/package.json
+++ b/ui/round/package.json
@@ -22,7 +22,7 @@
     "ab": "https://github.com/lichess-org/ab-stub",
     "chat": "2.0.0",
     "chess": "2.0.0",
-    "chessground": "^8.1.8",
+    "chessground": "^8.1.9",
     "common": "2.0.0",
     "game": "2.0.0",
     "nvui": "2.0.0",

--- a/ui/round/src/crazy/crazyView.ts
+++ b/ui/round/src/crazy/crazyView.ts
@@ -18,7 +18,7 @@ export default function pocket(ctrl: RoundController, color: Color, position: Po
     usable = usablePos && !ctrl.replaying() && ctrl.isPlaying(),
     activeColor = color === ctrl.data.player.color;
   const capturedPiece = ctrl.justCaptured;
-  const captured = capturedPiece && (capturedPiece['promoted'] ? 'pawn' : capturedPiece.role);
+  const captured = capturedPiece && (capturedPiece.promoted ? 'pawn' : capturedPiece.role);
   return h(
     'div.pocket.is2d.pocket-' + position,
     {

--- a/ui/simul/package.json
+++ b/ui/simul/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "chat": "2.0.0",
-    "chessground": "^8.1.8",
+    "chessground": "^8.1.9",
     "common": "2.0.0",
     "game": "2.0.0",
     "snabbdom": "^3.0.1"

--- a/ui/site/package.json
+++ b/ui/site/package.json
@@ -14,7 +14,7 @@
     "@types/web": "=0.0.32",
     "@types/yaireo__tagify": "^4.7",
     "@types/zxcvbn": "^4.4.0",
-    "chessground": "^8.1.8",
+    "chessground": "^8.1.9",
     "rollup": "^2.56.2",
     "rollup-plugin-copy": "^3.3.0",
     "typescript": "^4.4.3"

--- a/ui/storm/package.json
+++ b/ui/storm/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "chess": "2.0.0",
-    "chessground": "^8.1.8",
+    "chessground": "^8.1.9",
     "chessops": "^0.10.2",
     "common": "2.0.0",
     "puz": "2.0.0",

--- a/ui/swiss/package.json
+++ b/ui/swiss/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "chat": "2.0.0",
-    "chessground": "^8.1.8",
+    "chessground": "^8.1.9",
     "common": "2.0.0",
     "game": "2.0.0",
     "snabbdom": "^3.0.1"

--- a/ui/tournament/package.json
+++ b/ui/tournament/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "chat": "2.0.0",
-    "chessground": "^8.1.8",
+    "chessground": "^8.1.9",
     "common": "2.0.0",
     "game": "2.0.0",
     "snabbdom": "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,10 +1028,10 @@ chessground@^4.4:
     merge "1.2.0"
     mithril "github:ornicar/mithril.js#v1.0.1"
 
-chessground@^8.1.8:
-  version "8.1.8"
-  resolved "https://registry.yarnpkg.com/chessground/-/chessground-8.1.8.tgz#6b177dbdee35ae7dfa9956c2a180bd1b66a1517a"
-  integrity sha512-WbIh/tLRALmS/u2Iu+Msfqy+zBE0Whs2PbkCVrMiKu8jPuyNrAD5ajKfwI7hkfLsO6uCf5Sd7+8ydYJzXMuxSg==
+chessground@^8.1.9:
+  version "8.1.9"
+  resolved "https://registry.yarnpkg.com/chessground/-/chessground-8.1.9.tgz#92e0c8113ca8cd45adf8a2a68c839fbc8cc5d5a8"
+  integrity sha512-IZSgOzNtQFE1YNAwtYJYqHwIY/+fHK5ZLhg6qq0nLM/580S1A3hcinfz7mxDwMMeIkcnM4n11IOQfrco9fcJIg==
 
 chessops@^0.10.2:
   version "0.10.2"


### PR DESCRIPTION
Find all places that produce editor links on the server and client side and let them produce identical URLs, taking into account the variant.

Also needs chessground 8.1.9 to fully fix #10230 (handling of `~` was broken at some point, `[]`-style pockets were causing runtime errors).