### PR TITLE
Add preview to challenges from position.

### DIFF
--- a/modules/challenge/src/main/JsonView.scala
+++ b/modules/challenge/src/main/JsonView.scala
@@ -76,7 +76,8 @@ final class JsonView(
             )
           case TimeControl.Unlimited => Json.obj("type" -> "unlimited")
         }),
-        "color" -> c.colorChoice.toString.toLowerCase,
+        "color"      -> c.colorChoice.toString.toLowerCase,
+        "finalColor" -> c.finalColor.toString.toLowerCase,
         "perf" -> Json.obj(
           "icon" -> iconChar(c).toString,
           "name" -> c.perfType.trans

--- a/ui/challenge/css/_challenge.scss
+++ b/ui/challenge/css/_challenge.scss
@@ -127,5 +127,14 @@
     .color-icon::before {
       vertical-align: text-top;
     }
+
+    .position {
+      display: none;
+    }
+
+    &:hover .position,
+    .blind-mode & .position {
+      @extend %flex-between-nowrap;
+    }
   }
 }

--- a/ui/challenge/src/interfaces.ts
+++ b/ui/challenge/src/interfaces.ts
@@ -51,6 +51,7 @@ export interface Challenge {
   rated: boolean;
   timeControl: TimeControl;
   color: Color | 'random';
+  finalColor: Color;
   perf: {
     icon: string;
     name: string;

--- a/ui/challenge/src/view.ts
+++ b/ui/challenge/src/view.ts
@@ -57,7 +57,7 @@ function challenge(ctrl: Ctrl, dir: ChallengeDirection) {
         ]),
         c.variant.key === 'fromPosition'
           ? h('div.position.mini-board.cg-wrap.is2d', {
-              attrs: { 'data-state': `${c.initialFen},${opposite(c.finalColor)}` },
+              attrs: { 'data-state': `${c.initialFen},${dir === 'in' ? opposite(c.finalColor) : c.finalColor}` },
               hook: {
                 insert(vnode) {
                   lichess.miniBoard.init(vnode.elm as HTMLElement);

--- a/ui/challenge/src/view.ts
+++ b/ui/challenge/src/view.ts
@@ -1,6 +1,7 @@
 import { Ctrl, Challenge, ChallengeData, ChallengeDirection, ChallengeUser, TimeControl } from './interfaces';
 import { h, VNode } from 'snabbdom';
 import spinner from 'common/spinner';
+import { opposite } from 'chessground/util';
 
 export const loaded = (ctrl: Ctrl): VNode =>
   ctrl.redirecting()
@@ -54,6 +55,16 @@ function challenge(ctrl: Ctrl, dir: ChallengeDirection) {
             attrs: { 'data-icon': c.perf.icon },
           }),
         ]),
+        c.variant.key === 'fromPosition'
+          ? h('div.position.mini-board.cg-wrap.is2d', {
+              attrs: { 'data-state': `${c.initialFen},${opposite(c.finalColor)}` },
+              hook: {
+                insert(vnode) {
+                  lichess.miniBoard.init(vnode.elm as HTMLElement);
+                },
+              },
+            })
+          : null,
         h('div.buttons', (dir === 'in' ? inButtons : outButtons)(ctrl, c)),
       ]
     );


### PR DESCRIPTION
Even though the starting position is sent to the challenged client there is currently no way to see it before you decide to accept or decline the challenge. For prearranged challenges between friends this is fine, but for a streamer taking challenges it could be nice to be able to make sure you only accept challenges where the position is somewhat interesting, and not just a mate in one challenge just to score a cheap win (these "games" can of course be aborted).

This change adds a miniboard with the position to challenges of type from position. To make sure the board is oriented correctly for the challengee I have also modified the challenge information sent to include the actual colour chosen in case it is random.