### PR TITLE
replace lemonlabs.uri with a whatwg compliant parser

### DIFF
--- a/app/controllers/Auth.scala
+++ b/app/controllers/Auth.scala
@@ -35,8 +35,8 @@ final class Auth(
       }
     }
 
-  private def getReferrer(implicit ctx: Context) =
-    get("referrer").filter(env.api.referrerRedirect.valid) orElse
+  private def getReferrer(implicit ctx: Context): String =
+    get("referrer").flatMap(env.api.referrerRedirect.valid) orElse
       ctxReq.session.get(api.AccessUri) getOrElse
       routes.Lobby.home.url
 
@@ -79,7 +79,7 @@ final class Auth(
 
   def login =
     Open { implicit ctx =>
-      val referrer = get("referrer").filter(env.api.referrerRedirect.valid)
+      val referrer = get("referrer").flatMap(env.api.referrerRedirect.valid)
       referrer ifTrue ctx.isAuth match {
         case Some(url) => Redirect(url).fuccess // redirect immediately if already logged in
         case None      => Ok(html.auth.login(api.loginForm, referrer)).fuccess

--- a/app/views/oAuth/authorize.scala
+++ b/app/views/oAuth/authorize.scala
@@ -60,13 +60,7 @@ object authorize {
             ),
             p(cls := "oauth__redirect")(
               "Will redirect to ",
-              raw(
-                escapeHtmlRaw(prompt.redirectUri.value.toStringPunycode)
-                  .replaceFirst(
-                    prompt.redirectUri.clientOrigin,
-                    prompt.redirectUri.clientOrigin.render
-                  )
-              )
+              prompt.redirectUri.withoutQuery
             )
           )
         )

--- a/build.sbt
+++ b/build.sbt
@@ -125,7 +125,7 @@ lazy val evaluation = module("evaluation",
 lazy val common = smallModule("common",
   Seq(),
   Seq(
-    scalalib, scalaUri, galimatias, chess, autoconfig,
+    scalalib, galimatias, chess, autoconfig,
     kamon.core, scalatags, jodaForms, scaffeine, specs2, apacheText
   ) ++ reactivemongo.bundle ++ flexmark.bundle
 )

--- a/build.sbt
+++ b/build.sbt
@@ -125,7 +125,7 @@ lazy val evaluation = module("evaluation",
 lazy val common = smallModule("common",
   Seq(),
   Seq(
-    scalalib, scalaUri, chess, autoconfig,
+    scalalib, scalaUri, galimatias, chess, autoconfig,
     kamon.core, scalatags, jodaForms, scaffeine, specs2, apacheText
   ) ++ reactivemongo.bundle ++ flexmark.bundle
 )
@@ -302,7 +302,7 @@ lazy val study = module("study",
 
 lazy val relay = module("relay",
   Seq(common, study),
-  Seq(scalaUri) ++ reactivemongo.bundle
+  Seq(scalaUri, galimatias) ++ reactivemongo.bundle
 )
 
 lazy val studySearch = module("studySearch",

--- a/build.sbt
+++ b/build.sbt
@@ -187,7 +187,7 @@ lazy val mod = module("mod",
 
 lazy val user = smallModule("user",
   Seq(common, memo, db, hub, rating, socket),
-  Seq(hasher, specs2, autoconfig, scalaUri) ++ playWs.bundle ++ reactivemongo.bundle ++ macwire.bundle
+  Seq(hasher, specs2, autoconfig, scalaUri, galimatias) ++ playWs.bundle ++ reactivemongo.bundle ++ macwire.bundle
 )
 
 lazy val game = module("game",

--- a/build.sbt
+++ b/build.sbt
@@ -187,7 +187,7 @@ lazy val mod = module("mod",
 
 lazy val user = smallModule("user",
   Seq(common, memo, db, hub, rating, socket),
-  Seq(hasher, specs2, autoconfig, scalaUri, galimatias) ++ playWs.bundle ++ reactivemongo.bundle ++ macwire.bundle
+  Seq(hasher, specs2, autoconfig, galimatias) ++ playWs.bundle ++ reactivemongo.bundle ++ macwire.bundle
 )
 
 lazy val game = module("game",

--- a/build.sbt
+++ b/build.sbt
@@ -302,7 +302,7 @@ lazy val study = module("study",
 
 lazy val relay = module("relay",
   Seq(common, study),
-  Seq(scalaUri, galimatias) ++ reactivemongo.bundle
+  Seq(galimatias) ++ reactivemongo.bundle
 )
 
 lazy val studySearch = module("studySearch",

--- a/modules/api/src/main/ReferrerRedirect.scala
+++ b/modules/api/src/main/ReferrerRedirect.scala
@@ -1,6 +1,6 @@
 package lila.api
 
-import io.lemonlabs.uri.{ AbsoluteUrl, Url }
+import io.mola.galimatias.{ URL, URLParsingSettings, StrictErrorHandler }
 import scala.util.Try
 
 import lila.common.config.BaseUrl
@@ -9,17 +9,22 @@ final class ReferrerRedirect(baseUrl: BaseUrl) {
 
   val sillyLoginReferrers = Set("/login", "/signup", "/mobile")
 
-  private lazy val lilaHost = AbsoluteUrl.parse(baseUrl.value).host.value
+  private lazy val lilaHost = URL.parse(baseUrl.value).host.toString
 
   private val validCharsRegex = """^[\w-\.:/\?&=@#%\[\]\+]+$""".r
 
   // allow relative and absolute redirects only to the same domain or
   // subdomains, excluding /mobile (which is shown after logout)
-  def valid(referrer: String): Boolean =
-    validCharsRegex.matches(referrer) &&
-      !sillyLoginReferrers(referrer) && Try {
-        val url = Url.parse(referrer)
-        url.schemeOption.fold(true)(scheme => scheme == "http" || scheme == "https") &&
-        url.hostOption.fold(true)(host => s".${host.value}".endsWith(s".$lilaHost"))
-      }.getOrElse(false)
+  def valid(referrer: String): Option[String] =
+    (!sillyLoginReferrers(referrer) && validCharsRegex.matches(referrer)) ?? Try {
+        URL.parse(
+          URLParsingSettings.create.withErrorHandler(StrictErrorHandler.getInstance),
+          URL.parse(baseUrl.value),
+          referrer
+        )
+      }.toOption
+        .filter { url =>
+          (url.scheme == "http" || url.scheme == "https") && s".${url.host}".endsWith(s".$lilaHost")
+        }
+        .map(_.toString)
 }

--- a/modules/api/src/test/ReferrerRedirectTest.scala
+++ b/modules/api/src/test/ReferrerRedirectTest.scala
@@ -30,6 +30,7 @@ class ReferrerRedirectTest extends Specification {
       r.valid("//lichess.org.evil.com") must beNone
       r.valid("/\t/evil.com") must beNone
       r.valid("/ /evil.com") must beNone
+      r.valid("http://lichess.org/") must beNone // downgrade to http
     }
   }
 }

--- a/modules/api/src/test/ReferrerRedirectTest.scala
+++ b/modules/api/src/test/ReferrerRedirectTest.scala
@@ -10,26 +10,26 @@ class ReferrerRedirectTest extends Specification {
 
   "referrer" should {
     "be valid" in {
-      r.valid("/tournament") must beTrue
-      r.valid("/@/neio") must beTrue
-      r.valid("/@/Neio") must beTrue
-      r.valid("//lichess.org") must beTrue
-      r.valid("//foo.lichess.org") must beTrue
-      r.valid("https://lichess.org/tournament") must beTrue
-      r.valid("https://lichess.org/?a_a=b-b&C[]=#hash") must beTrue
-      r.valid(
+      r.valid("/tournament") must beSome("https://lichess.org/tournament")
+      r.valid("/@/neio") must beSome("https://lichess.org/@/neio")
+      r.valid("/@/Neio") must beSome("https://lichess.org/@/Neio")
+      r.valid("//lichess.org") must beSome("https://lichess.org/")
+      r.valid("//foo.lichess.org") must beSome("https://foo.lichess.org/")
+      r.valid("https://lichess.org/tournament") must beSome("https://lichess.org/tournament")
+      r.valid("https://lichess.org/?a_a=b-b&C[]=#hash") must beSome("https://lichess.org/?a_a=b-b&C[]=#hash")
+      val legacyOauth =
         "https://oauth.lichess.org/oauth/authorize?response_type=code&client_id=NotReal1&redirect_uri=http%3A%2F%2Fexample.lichess.ovh%3A9371%2Foauth-callback&scope=challenge:read+challenge:write+board:play&state=123abc"
-      ) must beTrue
+      r.valid(legacyOauth) must beSome(legacyOauth)
     }
     "be invalid" in {
-      r.valid("") must beFalse
-      r.valid("ftp://lichess.org/tournament") must beFalse
-      r.valid("https://evil.com") must beFalse
-      r.valid("https://evil.com/foo") must beFalse
-      r.valid("//evil.com") must beFalse
-      r.valid("//lichess.org.evil.com") must beFalse
-      r.valid("/\t/evil.com") must beFalse
-      r.valid("/ /evil.com") must beFalse
+      r.valid("") must beNone
+      r.valid("ftp://lichess.org/tournament") must beNone
+      r.valid("https://evil.com") must beNone
+      r.valid("https://evil.com/foo") must beNone
+      r.valid("//evil.com") must beNone
+      r.valid("//lichess.org.evil.com") must beNone
+      r.valid("/\t/evil.com") must beNone
+      r.valid("/ /evil.com") must beNone
     }
   }
 }

--- a/modules/common/src/main/Form.scala
+++ b/modules/common/src/main/Form.scala
@@ -2,7 +2,6 @@ package lila.common
 
 import chess.format.FEN
 import chess.format.Forsyth
-import io.lemonlabs.uri._
 import org.joda.time.{ DateTime, DateTimeZone }
 import play.api.data.format.Formats._
 import play.api.data.format.{ Formatter, JodaFormats }
@@ -190,8 +189,6 @@ object Form {
   private def pluralize(pattern: String, nb: Int) =
     pattern.replace("{s}", if (nb == 1) "" else "s")
 
-  def absoluteUrl = of[AbsoluteUrl](formatter.absoluteUrlFormatter)
-
   object formatter {
     def stringFormatter[A](from: A => String, to: String => A): Formatter[A] =
       new Formatter[A] {
@@ -210,18 +207,6 @@ object Form {
           Right(trueish(v))
         }
       def unbind(key: String, value: Boolean) = Map(key -> value.toString)
-    }
-    val absoluteUrlFormatter: Formatter[AbsoluteUrl] = new Formatter[AbsoluteUrl] {
-      override val format = Some(("format.url", Nil))
-      def bind(key: String, data: Map[String, String]) =
-        data
-          .get(key)
-          .map(_.trim)
-          .toRight("error.required")
-          .flatMap(str => AbsoluteUrl.parseTry(str).toEither.left.map(_.getMessage))
-          .left
-          .map(err => (Seq(FormError(key, err.toString, Nil))))
-      def unbind(key: String, value: AbsoluteUrl) = Map(key -> value.toString)
     }
   }
 

--- a/modules/common/src/main/String.scala
+++ b/modules/common/src/main/String.scala
@@ -24,7 +24,7 @@ object String {
     slug.toLowerCase
   }
 
-  def urlencode(str: String): String = java.net.URLEncoder.encode(str, "US-ASCII")
+  def urlencode(str: String): String = java.net.URLEncoder.encode(str, "UTF-8")
 
   def hasGarbageChars(str: String) = str.chars().anyMatch(isGarbageChar)
 

--- a/modules/common/src/main/model.scala
+++ b/modules/common/src/main/model.scala
@@ -1,7 +1,9 @@
 package lila.common
 
+import io.mola.galimatias.IPv4Address.parseIPv4Address
+import io.mola.galimatias.IPv6Address.parseIPv6Address
+import scala.util.Try
 import scala.concurrent.duration._
-import io.lemonlabs.uri.{ IpV4, IpV6 }
 
 case class ApiVersion(value: Int) extends AnyVal with IntValue with Ordered[ApiVersion] {
   def compare(other: ApiVersion) = Integer.compare(value, other.value)
@@ -32,22 +34,16 @@ sealed trait IpAddress {
   def value: String
   override def toString = value
 }
-case class IpV4Address(a: Byte, b: Byte, c: Byte, d: Byte) extends IpAddress {
-  def value = IpV4(a, b, c, d).value
-}
-case class IpV6Address(a: Char, b: Char, c: Char, d: Char, e: Char, f: Char, g: Char, h: Char)
-    extends IpAddress {
-  def value = IpV6(a, b, c, d, e, f, g, h).value.stripPrefix("[").stripSuffix("]")
-}
+case class IpV4Address(value: String) extends IpAddress
+case class IpV6Address(value: String) extends IpAddress
 
 object IpAddress {
-  def from(str: String): Option[IpAddress] =
-    IpV4.parseOption(str).map(ip => IpV4Address(ip.octet1, ip.octet2, ip.octet3, ip.octet4)) orElse IpV6
-      .parseOption(f"[$str]")
-      .map(ip =>
-        IpV6Address(ip.piece1, ip.piece2, ip.piece3, ip.piece4, ip.piece5, ip.piece6, ip.piece7, ip.piece8)
-      )
-  def unchecked(str: String): IpAddress = from(str).get
+  private def parse(str: String): Try[IpAddress] = Try {
+    if (str.contains(".")) IpV4Address(parseIPv4Address(str).toString)
+    else IpV6Address(parseIPv6Address(str).toString)
+  }
+  def from(str: String): Option[IpAddress] = parse(str).toOption
+  def unchecked(str: String): IpAddress = parse(str).get
 }
 
 case class NormalizedEmailAddress(value: String) extends AnyVal with StringValue

--- a/modules/common/src/main/model.scala
+++ b/modules/common/src/main/model.scala
@@ -43,7 +43,7 @@ object IpAddress {
     else IpV6Address(parseIPv6Address(str).toString)
   }
   def from(str: String): Option[IpAddress] = parse(str).toOption
-  def unchecked(str: String): IpAddress = parse(str).get
+  def unchecked(str: String): IpAddress    = parse(str).get
 }
 
 case class NormalizedEmailAddress(value: String) extends AnyVal with StringValue

--- a/modules/db/src/main/Handlers.scala
+++ b/modules/db/src/main/Handlers.scala
@@ -10,7 +10,6 @@ import lila.common.Iso._
 import lila.common.{ EmailAddress, IpAddress, Iso, NormalizedEmailAddress }
 import chess.format.FEN
 import chess.variant.Variant
-import io.lemonlabs.uri.AbsoluteUrl
 
 trait Handlers {
 
@@ -149,10 +148,5 @@ trait Handlers {
         "limit"     -> c.limitSeconds,
         "increment" -> c.incrementSeconds
       )
-  )
-
-  implicit val absoluteUrlHandler = tryHandler[AbsoluteUrl](
-    { case str: BSONString => AbsoluteUrl parseTry str.value },
-    url => BSONString(url.toString)
   )
 }

--- a/modules/oauth/src/main/AuthorizationRequest.scala
+++ b/modules/oauth/src/main/AuthorizationRequest.scala
@@ -3,7 +3,6 @@ package lila.oauth
 import java.net.URLEncoder
 import cats.data.Validated
 import com.roundeights.hasher.Algo
-import io.lemonlabs.uri.AbsoluteUrl
 import org.joda.time.DateTime
 import play.api.libs.json._
 

--- a/modules/oauth/src/main/AuthorizationRequest.scala
+++ b/modules/oauth/src/main/AuthorizationRequest.scala
@@ -1,6 +1,5 @@
 package lila.oauth
 
-import java.net.URLEncoder
 import cats.data.Validated
 import com.roundeights.hasher.Algo
 import org.joda.time.DateTime

--- a/modules/oauth/src/main/OAuthTokenForm.scala
+++ b/modules/oauth/src/main/OAuthTokenForm.scala
@@ -1,6 +1,5 @@
 package lila.oauth
 
-import io.lemonlabs.uri.AbsoluteUrl
 import org.joda.time.DateTime
 import play.api.data._
 import play.api.data.Forms._

--- a/modules/oauth/src/main/OAuthTokenForm.scala
+++ b/modules/oauth/src/main/OAuthTokenForm.scala
@@ -6,7 +6,7 @@ import play.api.data.Forms._
 import reactivemongo.api.bson.BSONObjectID
 
 import lila.common.Bearer
-import lila.common.Form.{ absoluteUrl, cleanText }
+import lila.common.Form.cleanText
 import lila.user.User
 
 object OAuthTokenForm {

--- a/modules/oauth/src/main/Protocol.scala
+++ b/modules/oauth/src/main/Protocol.scala
@@ -1,7 +1,6 @@
 package lila.oauth
 
 import java.util.Base64
-import java.net.URLEncoder
 import scala.util.Try
 import cats.data.Validated
 import play.api.libs.json.Json

--- a/modules/oauth/src/main/Protocol.scala
+++ b/modules/oauth/src/main/Protocol.scala
@@ -2,12 +2,14 @@ package lila.oauth
 
 import java.util.Base64
 import java.net.URLEncoder
+import scala.util.Try
 import cats.data.Validated
 import play.api.libs.json.Json
 import com.roundeights.hasher.Algo
-import io.lemonlabs.uri.AbsoluteUrl
+import io.mola.galimatias.{ StrictErrorHandler, URL, URLParsingSettings }
 
 import lila.common.SecureRandom
+import lila.common.String.urlencode
 
 object Protocol {
   case class AuthorizationCode(secret: String) extends AnyVal {
@@ -63,27 +65,24 @@ object Protocol {
       }
   }
 
-  case class RedirectUri(value: AbsoluteUrl) extends AnyVal {
-    def clientOrigin =
-      s"${value.scheme}://${value.hostOption.fold("")(_.toStringPunycode)}"
+  case class RedirectUri(value: URL) extends AnyVal {
+    // https://github.com/smola/galimatias/issues/72 will be more precise
+    def clientOrigin: String = s"${value.scheme}://${value.host}"
 
     def insecure =
-      value.scheme == "http" && !value.hostOption.exists(host =>
-        List("localhost", "[::1]", "127.0.0.1").has(host.toString)
-      )
+      value.scheme == "http" && !List("localhost", "[::1]", "127.0.0.1").has(value.host.toString)
+
+    def withoutQuery: String = value.withQuery(null).toString
 
     def error(error: Error, state: Option[State]): String = value
-      .withQueryString(
-        "error"             -> Some(error.error),
-        "error_description" -> Some(error.description),
-        "state"             -> state.map(_.value)
+      .withQuery(
+        s"error=${urlencode(error.error)}&error_description=${urlencode(error.description)}&state=${urlencode(~state.map(_.value))}"
       )
       .toString
 
     def code(code: AuthorizationCode, state: Option[State]): String = value
-      .withQueryString(
-        "code"  -> Some(code.secret),
-        "state" -> state.map(_.value)
+      .withQuery(
+        s"code=${urlencode(code.secret)}&state=${urlencode(~state.map(_.value))}"
       )
       .toString
 
@@ -91,8 +90,9 @@ object Protocol {
   }
   object RedirectUri {
     def from(redirectUri: String): Validated[Error, RedirectUri] =
-      AbsoluteUrl
-        .parseOption(redirectUri)
+      Try {
+        URL.parse(URLParsingSettings.create.withErrorHandler(StrictErrorHandler.getInstance), redirectUri)
+      }.toOption
         .toValid(Error.RedirectUriInvalid)
         .ensure(Error.RedirectSchemeNotAllowed)(url =>
           List(
@@ -112,7 +112,7 @@ object Protocol {
         )
         .map(RedirectUri.apply)
 
-    def unchecked(trusted: String): RedirectUri = RedirectUri(AbsoluteUrl.parse(trusted))
+    def unchecked(trusted: String): RedirectUri = RedirectUri(URL.parse(trusted))
   }
 
   case class UncheckedRedirectUri(value: String) extends AnyVal
@@ -152,7 +152,7 @@ object Protocol {
     case object CodeVerifierTooShort        extends InvalidRequest("code_verifier too short")
 
     case class InvalidScope(val key: String) extends Error("invalid_scope") {
-      def description = s"invalid scope: ${URLEncoder.encode(key, "UTF-8")}"
+      def description = s"invalid scope: ${urlencode(key)}"
     }
 
     abstract class UnauthorizedClient(val description: String) extends Error("unauthorized_client")

--- a/modules/oauth/src/main/Protocol.scala
+++ b/modules/oauth/src/main/Protocol.scala
@@ -65,11 +65,13 @@ object Protocol {
   }
 
   case class RedirectUri(value: URL) extends AnyVal {
+    private def host: Option[String] = Option(value.host).map(_.toString)
+
     // https://github.com/smola/galimatias/issues/72 will be more precise
-    def clientOrigin: String = s"${value.scheme}://${value.host}"
+    def clientOrigin: String = s"${value.scheme}://${~host}"
 
     def insecure =
-      value.scheme == "http" && !List("localhost", "[::1]", "127.0.0.1").has(value.host.toString)
+      value.scheme == "http" && !host.exists(h => List("localhost", "[::1]", "127.0.0.1").has(h))
 
     def withoutQuery: String = value.withQuery(null).toString
 

--- a/modules/relay/src/main/RelayFetch.scala
+++ b/modules/relay/src/main/RelayFetch.scala
@@ -3,7 +3,7 @@ package lila.relay
 import akka.actor._
 import chess.format.pgn.Tags
 import com.github.blemale.scaffeine.LoadingCache
-import io.lemonlabs.uri.Url
+import io.mola.galimatias.URL
 import org.joda.time.DateTime
 import play.api.libs.json._
 import play.api.libs.ws.StandaloneWSClient
@@ -217,7 +217,7 @@ final private class RelayFetch(
     } flatMap RelayFetch.multiPgnToGames.apply
   }
 
-  private def httpGet(url: Url): Fu[String] =
+  private def httpGet(url: URL): Fu[String] =
     ws.url(url.toString)
       .withRequestTimeout(4.seconds)
       .get()
@@ -226,7 +226,7 @@ final private class RelayFetch(
         case res                      => fufail(s"[${res.status}] $url")
       }
 
-  private def httpGetJson[A: Reads](url: Url): Fu[A] =
+  private def httpGetJson[A: Reads](url: URL): Fu[A] =
     for {
       str  <- httpGet(url)
       json <- scala.concurrent.Future(Json parse str) // Json.parse throws exceptions (!)

--- a/modules/relay/src/main/RelayFormat.scala
+++ b/modules/relay/src/main/RelayFormat.scala
@@ -1,6 +1,6 @@
 package lila.relay
 
-import io.lemonlabs.uri._
+import io.mola.galimatias.URL
 import play.api.libs.json._
 import play.api.libs.ws.StandaloneWSClient
 import scala.concurrent.duration._
@@ -28,33 +28,33 @@ final private class RelayFormatApi(ws: StandaloneWSClient, cacheApi: CacheApi)(i
 
   private def guessFormat(upstream: UpstreamUrl.WithRound): Fu[RelayFormat] = {
 
-    val originalUrl = Url parse upstream.url
+    val originalUrl = URL parse upstream.url
 
     // http://view.livechesscloud.com/ed5fb586-f549-4029-a470-d590f8e30c76
-    def guessLcc(url: Url): Fu[Option[RelayFormat]] =
+    def guessLcc(url: URL): Fu[Option[RelayFormat]] =
       url.toString match {
         case UpstreamUrl.LccRegex(id) =>
           guessManyFiles(
-            Url.parse(
+            URL.parse(
               s"http://1.pool.livechesscloud.com/get/$id/round-${upstream.round | 1}/index.json"
             )
           )
         case _ => fuccess(none)
       }
 
-    def guessSingleFile(url: Url): Fu[Option[RelayFormat]] =
+    def guessSingleFile(url: URL): Fu[Option[RelayFormat]] =
       lila.common.Future.find(
         List(
           url.some,
-          !url.path.parts.contains(mostCommonSingleFileName) option addPart(url, mostCommonSingleFileName)
+          !url.pathSegments.contains(mostCommonSingleFileName) option addPart(url, mostCommonSingleFileName)
         ).flatten.distinct
-      )(looksLikePgn) dmap2 { (u: Url) =>
+      )(looksLikePgn) dmap2 { (u: URL) =>
         SingleFile(pgnDoc(u))
       }
 
-    def guessManyFiles(url: Url): Fu[Option[RelayFormat]] =
+    def guessManyFiles(url: URL): Fu[Option[RelayFormat]] =
       lila.common.Future.find(
-        List(url) ::: mostCommonIndexNames.filterNot(url.path.parts.contains).map(addPart(url, _))
+        List(url) ::: mostCommonIndexNames.filterNot(url.pathSegments.contains).map(addPart(url, _))
       )(looksLikeJson) flatMap {
         _ ?? { index =>
           val jsonUrl = (n: Int) => jsonDoc(replaceLastPart(index, s"game-$n.json"))
@@ -73,7 +73,7 @@ final private class RelayFormatApi(ws: StandaloneWSClient, cacheApi: CacheApi)(i
     logger.info(s"guessed format of $upstream: $format")
   }
 
-  private def httpGet(url: Url): Fu[Option[String]] =
+  private def httpGet(url: URL): Fu[Option[String]] =
     ws.url(url.toString)
       .withRequestTimeout(4.seconds)
       .get()
@@ -86,7 +86,7 @@ final private class RelayFormatApi(ws: StandaloneWSClient, cacheApi: CacheApi)(i
     MultiPgn.split(body, 1).value.headOption ?? { pgn =>
       lila.study.PgnImport(pgn, Nil).isValid
     }
-  private def looksLikePgn(url: Url): Fu[Boolean] = httpGet(url).map { _ exists looksLikePgn }
+  private def looksLikePgn(url: URL): Fu[Boolean] = httpGet(url).map { _ exists looksLikePgn }
 
   private def looksLikeJson(body: String): Boolean =
     try {
@@ -94,7 +94,7 @@ final private class RelayFormatApi(ws: StandaloneWSClient, cacheApi: CacheApi)(i
     } catch {
       case _: Exception => false
     }
-  private def looksLikeJson(url: Url): Fu[Boolean] = httpGet(url).map { _ exists looksLikeJson }
+  private def looksLikeJson(url: URL): Fu[Boolean] = httpGet(url).map { _ exists looksLikeJson }
 }
 
 sealed private trait RelayFormat
@@ -107,28 +107,21 @@ private object RelayFormat {
     case object Pgn  extends DocFormat
   }
 
-  case class Doc(url: Url, format: DocFormat)
+  case class Doc(url: URL, format: DocFormat)
 
-  def jsonDoc(url: Url) = Doc(url, DocFormat.Json)
-  def pgnDoc(url: Url)  = Doc(url, DocFormat.Pgn)
+  def jsonDoc(url: URL) = Doc(url, DocFormat.Json)
+  def pgnDoc(url: URL)  = Doc(url, DocFormat.Pgn)
 
   case class SingleFile(doc: Doc) extends RelayFormat
 
   type GameNumberToDoc = Int => Doc
 
-  case class ManyFiles(jsonIndex: Url, game: GameNumberToDoc) extends RelayFormat {
+  case class ManyFiles(jsonIndex: URL, game: GameNumberToDoc) extends RelayFormat {
     override def toString = s"Manyfiles($jsonIndex, ${game(0)})"
   }
 
-  def addPart(url: Url, part: String) = url.withPath(url.path addPart part)
-  def replaceLastPart(url: Url, withPart: String) =
-    if (url.path.isEmpty) addPart(url, withPart)
-    else
-      url.withPath {
-        url.path.withParts {
-          url.path.parts.init :+ withPart
-        }
-      }
+  def addPart(url: URL, part: String) = url.withPath(s"${url.path}/$part")
+  def replaceLastPart(url: URL, withPart: String) = url.withPath(s"${url.path}/../$withPart")
 
   val mostCommonSingleFileName = "games.pgn"
   val mostCommonIndexNames     = List("round.json", "index.json")

--- a/modules/relay/src/main/RelayRound.scala
+++ b/modules/relay/src/main/RelayRound.scala
@@ -118,7 +118,7 @@ object RelayRound {
       def local = asUrl.fold(true)(_.isLocal)
     }
     case class UpstreamUrl(url: String) extends Upstream {
-      def isLocal = url.contains("://127.0.0.1") || url.contains("://localhost")
+      def isLocal = url.contains("://127.0.0.1") || url.contains("://[::1]") || url.contains("://localhost")
       def withRound =
         url.split(" ", 2) match {
           case Array(u, round) => UpstreamUrl.WithRound(u, round.toIntOption)

--- a/modules/relay/src/main/RelayTourForm.scala
+++ b/modules/relay/src/main/RelayTourForm.scala
@@ -1,6 +1,5 @@
 package lila.relay
 
-import io.lemonlabs.uri.AbsoluteUrl
 import org.joda.time.DateTime
 import play.api.data._
 import play.api.data.Forms._

--- a/modules/user/src/main/Links.scala
+++ b/modules/user/src/main/Links.scala
@@ -14,16 +14,14 @@ object Links {
       .flatMap(toLink)
 
   private def toLink(line: String): Option[Link] =
-    Try(URL.parse(line)).toOption
-      .flatMap { url =>
-        val host = url.host.toString
-        host.nonEmpty && (url.scheme == "http" || url.scheme == "https") option {
-          Link.Site.allKnown.find(_ matches host).map(site => Link(site, url.toString)) | Link(
-            Link.Site.Other(host),
-            url.toString
-          )
-        }
-      }
+    for {
+      url <- Try(URL.parse(line)).toOption
+      if url.scheme == "http" || url.scheme == "https"
+      host <- Option(url.host).map(_.toString)
+    } yield Link.Site.allKnown.find(_ matches host).map(site => Link(site, url.toString)) | Link(
+      Link.Site.Other(host),
+      url.toString
+    )
 }
 
 case class Link(site: Link.Site, url: String)

--- a/modules/user/src/main/Links.scala
+++ b/modules/user/src/main/Links.scala
@@ -1,26 +1,29 @@
 package lila.user
 
-import io.lemonlabs.uri.Url
+import io.mola.galimatias.URL
 import scala.util.Try
 
 object Links {
 
-  def make(text: String): List[Link] = text.linesIterator.to(List).map(_.trim).flatMap(toLink)
-
-  private val UrlRegex = """^(?:https?://)?+([^/]+)""".r.unanchored
+  def make(text: String): List[Link] =
+    text.linesIterator
+      .to(List)
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .map { line => if (line.contains("://")) line else s"https://$line" }
+      .flatMap(toLink)
 
   private def toLink(line: String): Option[Link] =
-    line match {
-      case UrlRegex(domain) =>
-        Link.Site.allKnown find (_ matches domain) orElse
-          Try(Url.parse(domain).toStringPunycode).toOption.map(Link.Site.Other) map { site =>
-            Link(
-              site = site,
-              url = if (line startsWith "http") line else s"https://$line"
-            )
-          }
-      case _ => none
-    }
+    Try(URL.parse(line)).toOption
+      .flatMap { url =>
+        val host = url.host.toString
+        host.nonEmpty && (url.scheme == "http" || url.scheme == "https") option {
+          Link.Site.allKnown.find(_ matches host).map(site => Link(site, url.toString)) | Link(
+            Link.Site.Other(host),
+            url.toString
+          )
+        }
+      }
 }
 
 case class Link(site: Link.Site, url: String)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,6 +15,7 @@ object Dependencies {
   val scaffeine   = "com.github.blemale"         %% "scaffeine"                       % "5.1.2"  % "compile"
   val googleOAuth = "com.google.auth"             % "google-auth-library-oauth2-http" % "1.3.0"
   val scalaUri    = "io.lemonlabs"               %% "scala-uri"                       % "3.6.0"
+  val galimatias  = "io.mola.galimatias"          % "galimatias"                      % "0.2.1"
   val scalatags   = "com.lihaoyi"                %% "scalatags"                       % "0.10.0"
   val lettuce     = "io.lettuce"                  % "lettuce-core"                    % "6.1.5.RELEASE"
   val epoll       = "io.netty"                    % "netty-transport-native-epoll"    % "4.1.65.Final" classifier "linux-x86_64"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,6 @@ object Dependencies {
   val prismic     = "io.prismic"                 %% "scala-kit"                       % "1.2.19-THIB213"
   val scaffeine   = "com.github.blemale"         %% "scaffeine"                       % "5.1.2"  % "compile"
   val googleOAuth = "com.google.auth"             % "google-auth-library-oauth2-http" % "1.3.0"
-  val scalaUri    = "io.lemonlabs"               %% "scala-uri"                       % "3.6.0"
   val galimatias  = "io.mola.galimatias"          % "galimatias"                      % "0.2.1"
   val scalatags   = "com.lihaoyi"                %% "scalatags"                       % "0.10.0"
   val lettuce     = "io.lettuce"                  % "lettuce-core"                    % "6.1.5.RELEASE"


### PR DESCRIPTION
Differences between browsers (following https://url.spec.whatwg.org/) and io.lemonlabs.uri (following https://www.ietf.org/rfc/rfc3986.txt) can lead to subtle bugs.

* [x] OAuth referrer
* [x] Login redirect
* [x] lila.common
  * [x] Form
  * [x] IP parsing
* [x] lila.db
* [x] lila.relay