### PR TITLE
Add placeholders and default dates for explorer

### DIFF
--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -16,6 +16,7 @@ const allSpeeds: ExplorerSpeed[] = ['ultraBullet', 'bullet', 'blitz', 'rapid', '
 const allModes: ExplorerMode[] = ['casual', 'rated'];
 const allRatings = [1600, 1800, 2000, 2200, 2500];
 const minYear = 1952;
+const minLichessYear = 2012;
 
 type Month = string;
 type ByDbSetting = {
@@ -53,8 +54,8 @@ export class ExplorerConfigCtrl {
     const byDbData = {} as ByDbSettings;
     for (const db of this.allDbs) {
       byDbData[db] = {
-        since: storedProp('explorer.since-2.' + db, ''),
-        until: storedProp('explorer.until-2.' + db, ''),
+        since: storedProp('explorer.since-2.' + db, (db === 'masters' ? minYear : minLichessYear) + '-01'),
+        until: storedProp('explorer.until-2.' + db, new Date().toISOString().slice(0, 7)),
       };
     }
     this.data = {
@@ -220,7 +221,9 @@ const monthInput = (prop: StoredProp<Month>, after: () => Month, redraw: Redraw)
     key: after() ? 'until-month' : 'since-month',
     attrs: {
       type: 'month',
+      title: `Insert year and month in YYYY-MM format starting from ${minYear}-01`,
       pattern: '^(19|20)[0-9]{2}-(0[1-9]|1[012])$',
+      placeholder: 'YYYY-MM',
       min: `${minYear}-01`,
       max,
       value: prop() > max ? max : prop(),
@@ -251,6 +254,8 @@ const yearInput = (prop: StoredProp<Month>, after: () => Month, redraw: Redraw) 
     attrs: {
       key: after() ? 'until-year' : 'since-year',
       type: 'number',
+      title: `Insert year in YYYY format starting from ${minYear}`,
+      placeholder: 'YYYY',
       min: minYear,
       max: new Date().toISOString().slice(0, 4),
       value: prop().split('-')[0],


### PR DESCRIPTION
Add date input placeholders with required format (YYYY and YYYY-MM)

Add meaningful hover title with required format for date inputs

Add default since-until dates: 1952-01 for master games\2012-01 for lichess games for since, current year and month for until. I found that first games on lichess date from 2012-12, so 2012-01 should be a reasonable default value and a bit more suitable than 1952.

![Untitled](https://user-images.githubusercontent.com/24920435/147608644-8e80f8c5-c889-4747-a32a-5ccb3d880318.png)

Couldn't find any reference to default Jan 2010 since date that was mentioned by @maxrosenb, or any default date at all. These fields are stored in LocalStorage, probably it was set to 2010 manually once and after that it automatically populates inputs with stored values.

Since now inputs have default values and empty fields have placeholders, adjusting styles to make it look more editable doesn't look necessary.

Fix #10218