### PR TITLE
Make simul host's online status consistent

### DIFF
--- a/modules/simul/src/main/Env.scala
+++ b/modules/simul/src/main/Env.scala
@@ -29,7 +29,8 @@ final class Env(
     onGameStart: lila.round.OnStart,
     cacheApi: lila.memo.CacheApi,
     remoteSocketApi: lila.socket.RemoteSocket,
-    proxyRepo: lila.round.GameProxyRepo
+    proxyRepo: lila.round.GameProxyRepo,
+    isOnline: lila.socket.IsOnline
 )(implicit
     ec: scala.concurrent.ExecutionContext,
     system: ActorSystem,

--- a/modules/simul/src/main/JsonView.scala
+++ b/modules/simul/src/main/JsonView.scala
@@ -110,7 +110,7 @@ final class JsonView(
         .add("title" -> light.map(_.title))
         .add("provisional" -> ~player.provisional)
         .add("patron" -> light.??(_.isPatron))
-        .add("online" -> true)
+        .add("online" -> isOnline(player.user))
     }
 
   private def applicantJson(app: SimulApplicant): Fu[JsObject] =

--- a/modules/simul/src/main/JsonView.scala
+++ b/modules/simul/src/main/JsonView.scala
@@ -10,7 +10,8 @@ import lila.user.User
 final class JsonView(
     gameRepo: GameRepo,
     getLightUser: LightUser.Getter,
-    proxyRepo: lila.round.GameProxyRepo
+    proxyRepo: lila.round.GameProxyRepo,
+    isOnline: lila.socket.IsOnline
 )(implicit ec: scala.concurrent.ExecutionContext) {
 
   implicit private val simulTeamWriter = Json.writes[SimulTeam]
@@ -80,6 +81,7 @@ final class JsonView(
           .add("gameId" -> simul.hostGameId.ifTrue(simul.isRunning))
           .add("title" -> host.title)
           .add("patron" -> host.isPatron)
+          .add("online" -> isOnline(host.id))
       },
       "name"       -> simul.name,
       "fullName"   -> simul.fullName,
@@ -108,6 +110,7 @@ final class JsonView(
         .add("title" -> light.map(_.title))
         .add("provisional" -> ~player.provisional)
         .add("patron" -> light.??(_.isPatron))
+        .add("online" -> true)
     }
 
   private def applicantJson(app: SimulApplicant): Fu[JsObject] =

--- a/ui/simul/src/interfaces.ts
+++ b/ui/simul/src/interfaces.ts
@@ -47,12 +47,12 @@ export interface Team {
   isIn: boolean;
 }
 
-export interface Player extends LightUser {
+export interface Player extends LightUserOnline {
   rating: number;
   provisional?: boolean;
 }
 
-export interface Host extends LightUser {
+export interface Host extends LightUserOnline {
   rating: number;
   gameId?: string;
 }

--- a/ui/simul/src/view/util.ts
+++ b/ui/simul/src/view/util.ts
@@ -4,7 +4,7 @@ import SimulCtrl from '../ctrl';
 
 export function player(p: Player, ctrl: SimulCtrl) {
   return h(
-    'a.ulpt.user-link.' + p.online ? 'online' : 'offline',
+    'a.ulpt.user-link.' + (p.online ? 'online' : 'offline'),
     {
       attrs: { href: '/@/' + p.name },
       hook: {

--- a/ui/simul/src/view/util.ts
+++ b/ui/simul/src/view/util.ts
@@ -4,7 +4,7 @@ import SimulCtrl from '../ctrl';
 
 export function player(p: Player, ctrl: SimulCtrl) {
   return h(
-    'a.ulpt.user-link.online',
+    'a.ulpt.user-link.' + p.online ? 'online' : 'offline',
     {
       attrs: { href: '/@/' + p.name },
       hook: {


### PR DESCRIPTION
Only queries the host's online status to reduce server load, for other players there's no change in behaviour. Fixes #10272
Looks like it works without issues, but requires testing to make sure nothing is broken.