### PR TITLE
Change Note form button from "Send" to "Save"

### DIFF
--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -253,7 +253,7 @@ object header {
       ),
       if (isGranted(_.ModNote))
         div(cls := "mod-note")(
-          submitButton(cls := "button")(trans.send()),
+          submitButton(cls := "button")(trans.save()),
           div(
             div(form3.cmnToggle("note-mod", "mod", checked = true)),
             label(`for` := "note-mod")("For moderators only")
@@ -266,7 +266,7 @@ object header {
       else
         frag(
           input(tpe := "hidden", name := "mod", value := "false"),
-          submitButton(cls := "button")(trans.send())
+          submitButton(cls := "button")(trans.save())
         )
     ),
     notes.isEmpty option div("No note yet"),


### PR DESCRIPTION
When writing a private note about a user, I think Save is better action.

It uses "Send" right now which was a little confusing because it's supposed to be a private note.

![image](https://user-images.githubusercontent.com/271432/148659865-ae344a4d-c5da-4e3a-bc8b-3494713aeb4f.png)
