### PR TITLE
Correct pgn comment for insufficient material flag-draws

### DIFF
--- a/modules/game/src/main/StatusText.scala
+++ b/modules/game/src/main/StatusText.scala
@@ -16,9 +16,13 @@ object StatusText {
       case Stalemate                => "Draw by stalemate."
       case Timeout if win.isDefined => s"${loser(win)} left the game."
       case Timeout | Draw           => "The game is a draw."
-      case Outoftime                => s"${winner(win)} wins on time."
-      case NoStart                  => s"${loser(win)} wins by forfeit."
-      case Cheat                    => "Cheat detected."
+      case Outoftime =>
+        win match {
+          case Some(value) => s"${value} wins on time."
+          case None        => "Draw by insufficient material"
+        }
+      case NoStart => s"${loser(win)} wins by forfeit."
+      case Cheat   => "Cheat detected."
       case VariantEnd =>
         variant match {
           case chess.variant.KingOfTheHill => s"${winner(win)} brings the king in the center."

--- a/modules/game/src/main/StatusText.scala
+++ b/modules/game/src/main/StatusText.scala
@@ -19,7 +19,7 @@ object StatusText {
       case Outoftime =>
         win match {
           case Some(value) => s"${value} wins on time."
-          case None        => "Draw by insufficient material"
+          case None        => "Draw by time and insufficient material."
         }
       case NoStart => s"${loser(win)} wins by forfeit."
       case Cheat   => "Cheat detected."


### PR DESCRIPTION
Close #10339 

In case `OutOfTime` I assume that there is only way to draw is `insufficient material`.