### PR TITLE
Change /api/user/:name/perf/:perfKey to match /@/:username/perf/:perfKey

### DIFF
--- a/modules/perfStat/src/main/JsonView.scala
+++ b/modules/perfStat/src/main/JsonView.scala
@@ -46,7 +46,7 @@ final class JsonView(getLightUser: LightUser.GetterSync) {
 
 object JsonView {
 
-  private def round(v: Double, depth: Int = 2) = lila.common.Maths.roundAt(v, depth)
+  private def round(v: Double, depth: Int = 2) = lila.common.Maths.roundDownAt(v, depth)
 
   private val isoFormatter = ISODateTimeFormat.dateTime
   implicit private val dateWriter: Writes[DateTime] = Writes { d =>


### PR DESCRIPTION
The API now uses roundDownAt like app/views/user/perfStat.scala.
See #9605 and #9635 for reference.
Closes #10183.