### PR TITLE
Fix replayed clocks in /api/stream/game/:id

### DIFF
--- a/modules/round/src/main/ApiMoveStream.scala
+++ b/modules/round/src/main/ApiMoveStream.scala
@@ -37,16 +37,17 @@ final class ApiMoveStream(gameRepo: GameRepo, gameJsonView: lila.game.JsonView)(
               }
             }
             .mapMaterializedValue { queue =>
-              val clocks = ~(for {
-                clk   <- game.clock
-                times <- game.bothClockStates
-              } yield Vector(clk.config.initTime, clk.config.initTime) ++ times)
+              val clocks = for {
+                clk        <- game.clock
+                clkHistory <- game.clockHistory
+              } yield (Vector(clk.config.initTime) ++ clkHistory.white, Vector(clk.config.initTime) ++ clkHistory.black)
               val clockOffset = game.startColor.fold(0, 1)
               Replay.situations(game.pgnMoves, initialFen, game.variant) foreach {
                 _.zipWithIndex foreach { case (s, index) =>
                   val clk = for {
-                    white <- clocks.lift(index + 1 - clockOffset)
-                    black <- clocks.lift(index - clockOffset)
+                    (clkWhite, clkBlack) <- clocks
+                    white <- clkWhite.lift((index + 1 - clockOffset) >> 1)
+                    black <- clkBlack.lift((index + clockOffset) >> 1)
                   } yield (white, black)
                   queue offer toJson(
                     Forsyth exportBoard s.board,


### PR DESCRIPTION
Currently returns the clocks from the wrong players (it swaps back and forth each turn).