### PR TITLE
Fix simul results in partecipant's profile

### DIFF
--- a/app/views/activity.scala
+++ b/app/views/activity.scala
@@ -252,7 +252,8 @@ object activity {
                     " simul by ",
                     userIdLink(s.hostId.some)
                   ),
-                  scoreFrag(Score(s.wins, s.losses, s.draws, none))
+                  if (isHost) scoreFrag(Score(s.wins, s.losses, s.draws, none))
+                  else scoreFrag(Score(s.wins(u.id), s.losses(u.id), s.draws(u.id), none))
                 )
               }
             )

--- a/modules/simul/src/main/Simul.scala
+++ b/modules/simul/src/main/Simul.scala
@@ -138,6 +138,10 @@ case class Simul(
   def draws   = pairings.count(p => p.finished && p.wins.isEmpty)
   def losses  = pairings.count(p => p.finished && p.wins.has(true))
   def ongoing = pairings.count(_.ongoing)
+
+  def wins(userId: String)   = pairings.filter(_ is userId).count(p => p.finished && p.wins.has(true))
+  def draws(userId: String)  = pairings.filter(_ is userId).count(p => p.finished && p.wins.isEmpty)
+  def losses(userId: String) = pairings.filter(_ is userId).count(p => p.finished && p.wins.has(false))
 }
 
 object Simul {


### PR DESCRIPTION
If the player is the host the behaviour is the same as before, otherwise the page shows player's result in the given simul.

Fixes #5066